### PR TITLE
Issue1588

### DIFF
--- a/docs/contracts.rst
+++ b/docs/contracts.rst
@@ -240,7 +240,7 @@ Each Contract Factory exposes the following methods.
         >>> txn_receipt['contractAddress']
         '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318'
 
-.. py:classmethod:: Contract.constructor(*args, **kwargs).estimateGas(transaction=None)
+.. py:classmethod:: Contract.constructor(*args, **kwargs).estimateGas(transaction=None, block_identifier=None)
 
     Estimate gas for constructing and deploying the contract.
 
@@ -248,6 +248,9 @@ Each Contract Factory exposes the following methods.
     :py:meth:`Contract.constructor(*args, **kwargs).transact` method,
     with transaction details being passed into the end portion of the
     function call, and function arguments being passed into the first portion.
+
+    The ``block_identifier`` parameter is passed directly to the call at the end portion 
+    of the function call.
 
     Returns the amount of gas consumed which can be used as a gas estimate for
     executing this transaction publicly.

--- a/newsfragments/1588.feature.rst
+++ b/newsfragments/1588.feature.rst
@@ -1,0 +1,1 @@
+Added block_identifier parameter to `ContractConstructor.estimateGas` method.

--- a/tests/core/contracts/test_contract_constructor.py
+++ b/tests/core/contracts/test_contract_constructor.py
@@ -25,6 +25,16 @@ def test_contract_constructor_gas_estimate_no_constructor(web3, MathContract):
     assert abs(gas_estimate - gas_used) < 21000
 
 
+def test_contract_constructor_gas_estimate_with_block_id(web3, MathContract):
+    block_identifier = None
+    gas_estimate = MathContract.constructor().estimateGas(block_identifier=None)
+    deploy_txn = MathContract.constructor().transact()
+    txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
+    gas_used = txn_receipt.get('gasUsed')
+
+    assert abs(gas_estimate - gas_used) < 21000
+
+
 def test_contract_constructor_gas_estimate_with_constructor_without_arguments(
         web3,
         SimpleConstructorContract):

--- a/tests/core/contracts/test_contract_constructor.py
+++ b/tests/core/contracts/test_contract_constructor.py
@@ -27,7 +27,7 @@ def test_contract_constructor_gas_estimate_no_constructor(web3, MathContract):
 
 def test_contract_constructor_gas_estimate_with_block_id(web3, MathContract):
     block_identifier = None
-    gas_estimate = MathContract.constructor().estimateGas(block_identifier=None)
+    gas_estimate = MathContract.constructor().estimateGas(block_identifier=block_identifier)
     deploy_txn = MathContract.constructor().transact()
     txn_receipt = web3.eth.waitForTransactionReceipt(deploy_txn)
     gas_used = txn_receipt.get('gasUsed')

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -586,7 +586,7 @@ class ContractConstructor:
         return data
 
     @combomethod
-    def estimateGas(self, transaction: TxParams=None) -> int:
+    def estimateGas(self, transaction: TxParams=None, block_identifier: BlockIdentifier=None) -> int:
         if transaction is None:
             estimate_gas_transaction: TxParams = {}
         else:
@@ -600,7 +600,7 @@ class ContractConstructor:
 
         estimate_gas_transaction['data'] = self.data_in_transaction
 
-        return self.web3.eth.estimateGas(estimate_gas_transaction)
+        return self.web3.eth.estimateGas(estimate_gas_transaction, block_identifier=block_identifier)
 
     @combomethod
     def transact(self, transaction: TxParams=None) -> HexBytes:

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -586,7 +586,9 @@ class ContractConstructor:
         return data
 
     @combomethod
-    def estimateGas(self, transaction: TxParams=None, block_identifier: BlockIdentifier=None) -> int:
+    def estimateGas(
+        self, transaction: TxParams=None, block_identifier: BlockIdentifier=None
+    ) -> int:
         if transaction is None:
             estimate_gas_transaction: TxParams = {}
         else:
@@ -600,7 +602,9 @@ class ContractConstructor:
 
         estimate_gas_transaction['data'] = self.data_in_transaction
 
-        return self.web3.eth.estimateGas(estimate_gas_transaction, block_identifier=block_identifier)
+        return self.web3.eth.estimateGas(
+            estimate_gas_transaction, block_identifier=block_identifier
+        )
 
     @combomethod
     def transact(self, transaction: TxParams=None) -> HexBytes:


### PR DESCRIPTION
### What was wrong?
There was no block_identifier parameter in the web3.Contract object's estimateGas method.

Related to Issue #1588 

### How was it fixed?
Added the parameter to the method itself and the call to the web3.eth.estimateGas method at the end of the function.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://mymodernmet.com/wp/wp-content/uploads/2017/01/animal-selfies-5.jpg)
