### PR TITLE
Flaky update to >=3.7.0,<4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ extras_require = {
     ],
     'dev': [
         "bumpversion",
-        "flaky>=3.3.0",
+        "flaky>=3.7.0,<4",
         "hypothesis>=3.31.2,<6",
         "pytest>=4.4.0,<5.0.0",
         "pytest-asyncio>=0.10.0,<0.11",


### PR DESCRIPTION
### What was wrong?
Running targeted tests using pytest and py39 with earlier versions of flaky would error out.

Related to Issue # N/A

### How was it fixed?
Flaky was updated to >=3.7.0,<4

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20210216_122910](https://user-images.githubusercontent.com/3532824/121712444-fc336b00-ca98-11eb-8da1-81d99cb24f85.jpg)


