### PR TITLE
Add news fragment for updating to flaky version >=3.7.0,<4

### DIFF
--- a/newsfragments/2028.misc.rst
+++ b/newsfragments/2028.misc.rst
@@ -1,0 +1,1 @@
+Update to flaky version >=3.7.0,<4


### PR DESCRIPTION
### What was wrong?
There was no news fragment for recent change to flaky version!

Related to PR #2027

### How was it fixed?
There is now a news fragment 😅 

### Todo:
- [X] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![16](https://user-images.githubusercontent.com/3532824/121718596-b332e500-ca9f-11eb-8477-bb0f6dd2adc9.jpg)

