### PR TITLE
Bugfix failing tests

### DIFF
--- a/newsfragments/2057.bugfix.rst
+++ b/newsfragments/2057.bugfix.rst
@@ -1,0 +1,1 @@
+Turned some tests back on and reduced cross-test noise that was causing some tests to fail.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,30 +15,6 @@ from web3._utils.module_testing.revert_contract import (
 )
 
 
-def pytest_collection_modifyitems(items):
-    """
-    Certain tests have issues running after most of our test suite has run. If we run
-    these tests in the beginning, we can ensure that the client isn't overloaded with
-    context from our other tests and therefore reduce the noise for these more sensitive
-    tests. We can somewhat control when tests are run by overriding this pytest hook and
-    customizing the test order. You may find it helpful to move a conflicting test to
-    the beginning of the test suite or configure the test order in some other way here.
-    """
-    test_names_to_append_to_start = [
-        'test_eth_get_logs_with_logs',
-        'test_eth_call_old_contract_state',
-    ]
-    for index, item in enumerate(items):
-        # We run two versions of some tests that end with [<lambda>] or [address_conversion_func1].
-        # This step cleans up the name depending on whether or not they exist as two separate
-        # tests or just one without the bracketed "[]" suffix.
-        test_name = item.name if "[" not in item.name else item.name[:item.name.find("[")]
-
-        if test_name in test_names_to_append_to_start:
-            test_item = items.pop(index)
-            items.insert(0, test_item)
-
-
 @pytest.fixture(scope="module")
 def math_contract_factory(web3):
     contract_factory = web3.eth.contract(abi=MATH_ABI, bytecode=MATH_BYTECODE)

--- a/tests/integration/go_ethereum/common.py
+++ b/tests/integration/go_ethereum/common.py
@@ -17,17 +17,6 @@ class GoEthereumTest(Web3ModuleTest):
 
 
 class GoEthereumEthModuleTest(EthModuleTest):
-    @pytest.mark.xfail(
-        strict=False,
-        reason='Sometimes a TimeoutError is hit when waiting for the txn to be mined',
-    )
-    def test_eth_replace_transaction_already_mined(self, web3, unlocked_account_dual_type):
-        try:
-            web3.geth.miner.start()
-            super().test_eth_replace_transaction_already_mined(web3, unlocked_account_dual_type)
-        finally:
-            web3.geth.miner.stop()
-
     @pytest.mark.xfail(reason='eth_signTypedData has not been released in geth')
     def test_eth_sign_typed_data(self, web3, unlocked_account_dual_type):
         super().test_eth_sign_typed_data(web3, unlocked_account_dual_type)


### PR DESCRIPTION
### What was wrong?
- Some of our tests have been having some issues due to transactions hanging in the tx pool and inconsistent mining of the pending block for other tests

### How was it fixed?
- I traced most of the issues to low `gasPrice` values for some of the `send_transaction` / `replace_transaction` tests and raised these numbers so the txns didn't hang in the tx pool.
- I added a method to mine a block before a test if that is desired as well. This helped ensure that `get_transaction_count` returns a correct number for a nonce for tests explicitly passing in the `nonce` value.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![bckgrnd](https://user-images.githubusercontent.com/3532824/124190172-156b7e00-da7f-11eb-9fc3-e3770a426234.jpeg)
