### PR TITLE
keep pluggy version updated to avoid pytest errors on python 3.9.1

### DIFF
--- a/newsfragments/2080.misc.rst
+++ b/newsfragments/2080.misc.rst
@@ -1,0 +1,1 @@
+Pluggy version updated to avoid pytest errors with certain python versions

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ extras_require = {
         "tox>=1.8.0",
         "tqdm>4.32,<5",
         "twine>=1.13,<2",
+        "pluggy==0.13.1",
         "when-changed>=0.3.0,<0.4"
     ]
 }


### PR DESCRIPTION
### What was wrong?

- Running `pytest` on python 3.9.1 threw `pluggy` error related to older version of `pluggy`

### How was it fixed?

- Keeping `pluggy` up-to-date with latest version and above

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![4981144592_46f2dfd9fe_z](https://user-images.githubusercontent.com/3532824/126529571-e4876f1c-69b0-456a-8ef6-4060d4203c31.jpg)
