### PR TITLE
AsyncHTTPProvider extra dependencies

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -369,6 +369,14 @@ AsyncHTTPProvider
 .. warning:: This provider is unstable and there are still gaps in
     functionality. However, it is being actively developed.
 
+.. NOTE:: To install the needed dependencies to use ``AsyncHTTPProvider``, you can install the
+    pip extras package that has the correct interoperable version of the ``aiohttp``
+    library needed for asynchronous HTTP client.
+
+    .. code-block:: shell
+
+      $ pip install web3[async]
+
 .. py:class:: web3.providers.async_rpc.AsyncHTTPProvider(endpoint_uri[, request_kwargs])
 
     This provider handles interactions with an HTTP or HTTPS based JSON-RPC server asynchronously.

--- a/newsfragments/2136.misc.rst
+++ b/newsfragments/2136.misc.rst
@@ -1,0 +1,1 @@
+Use ``web3[async]`` extra keyword to install ``AsyncHTTPProvider`` dependencies.

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ extras_require['dev'] = (
     + extras_require['linter']
     + extras_require['docs']
     + extras_require['dev']
+    + extras_require['async']
 )
 
 with open('./README.md') as readme:

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,9 @@ from setuptools import (
 )
 
 extras_require = {
+    'async': [
+        "aiohttp>=3.7.4.post0,<4"
+    ],
     'tester': [
         "eth-tester[py-evm]==v0.5.0-beta.4",
         "py-geth>=3.5.0,<4",
@@ -72,7 +75,6 @@ setup(
     url='https://github.com/ethereum/web3.py',
     include_package_data=True,
     install_requires=[
-        "aiohttp>=3.7.4.post0,<4",
         "eth-abi>=2.0.0b6,<3.0.0",
         "eth-account>=0.5.5,<0.6.0",
         "eth-hash[pycryptodome]>=0.2.0,<1.0.0",


### PR DESCRIPTION
### What was wrong?

Installation of `web.py` python package by default required `aiohttp` in dependencies.

Async HTTP provider is not required until you specifically write async code(which is not a general case).

Thus it would be rational to move this dependency to extras.

### How was it fixed?

Moved `aiohttp` to extra requirements.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![photo-1605206731460-0bbdfadf9808](https://user-images.githubusercontent.com/892861/132453902-214bdc84-fe2d-44ac-961d-582622bb6732.jpeg)
