### PR TITLE
Include web3 middleware in ENS.fromWeb3()

### DIFF
--- a/docs/ens_overview.rst
+++ b/docs/ens_overview.rst
@@ -34,6 +34,7 @@ Create an :class:`~ens.main.ENS` object (named ``ns`` below) in one of three way
 
 
     # or, with a w3 instance
+    # Note: This inherits the w3 middlewares from the w3 instance and adds a stalecheck middleware to the middleware onion
     from ens import ENS
 
     w3 = Web3(...)

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -165,7 +165,7 @@ below for the API.
 
 When specifying middlewares in a list, or retrieving the list of middlewares, they will
 be returned in the order of outermost layer first and innermost layer last. In the above
-example, that means that ``list(w3.middleware_onion)`` would return the middlewares in
+example, that means that ``w3.middleware_onion.middlewares`` would return the middlewares in
 the order of: ``[2, 1, 0]``.
 
 See "Internals: :ref:`internals__middlewares`" for a deeper dive to how middlewares work.
@@ -247,6 +247,24 @@ To add or remove items in different layers, use the following API:
         >>> w3 = Web3(...)
         >>> w3.middleware_onion.clear()
         >>> assert len(w3.middleware_onion) == 0
+
+.. py:attribute:: Web3.middleware_onion.middlewares
+
+    Return all the current middlewares for the ``Web3`` instance in the appropriate order for importing into a new
+    ``Web3`` instance.
+
+    .. code-block:: python
+
+        >>> w3_1 = Web3(...)
+        # add uniquely named middleware:
+        >>> w3_1.middleware_onion.add(web3.middleware.pythonic_middleware, 'test_middleware')
+        # export middlewares from first w3 instance
+        >>> middlewares = w3_1.middleware_onion.middlewares
+
+        # import into second instance
+        >>> w3_2 = Web3(..., middlewares=middlewares)
+        >>> assert w3_1.middleware_onion.middlewares == w3_2.middleware_onion.middlewares
+        >>> assert w3_2.middleware_onion.get('test_middleware')
 
 
 Optional Middleware

--- a/ens/utils.py
+++ b/ens/utils.py
@@ -7,6 +7,8 @@ from typing import (
     Callable,
     Collection,
     Optional,
+    Sequence,
+    Tuple,
     Type,
     TypeVar,
     Union,
@@ -49,6 +51,9 @@ if TYPE_CHECKING:
     from web3.providers import (  # noqa: F401
         BaseProvider,
     )
+    from web3.types import (  # noqa: F401
+        Middleware,
+    )
 
 
 def Web3() -> Type['_Web3']:
@@ -68,13 +73,16 @@ def dict_copy(func: TFunc) -> TFunc:
     return cast(TFunc, wrapper)
 
 
-def init_web3(provider: 'BaseProvider' = cast('BaseProvider', default)) -> '_Web3':
+def init_web3(
+    provider: 'BaseProvider' = cast('BaseProvider', default),
+    middlewares: Optional[Sequence[Tuple['Middleware', str]]] = None,
+) -> '_Web3':
     from web3 import Web3 as Web3Main
 
     if provider is default:
         w3 = Web3Main(ens=None)
     else:
-        w3 = Web3Main(provider, ens=None)
+        w3 = Web3Main(provider, middlewares, ens=None)
 
     return customize_web3(w3)
 
@@ -82,11 +90,15 @@ def init_web3(provider: 'BaseProvider' = cast('BaseProvider', default)) -> '_Web
 def customize_web3(w3: '_Web3') -> '_Web3':
     from web3.middleware import make_stalecheck_middleware
 
-    w3.middleware_onion.remove('name_to_address')
-    w3.middleware_onion.add(
-        make_stalecheck_middleware(ACCEPTABLE_STALE_HOURS * 3600),
-        name='stalecheck',
-    )
+    if w3.middleware_onion.get('name_to_address'):
+        w3.middleware_onion.remove('name_to_address')
+
+    if not w3.middleware_onion.get('stalecheck'):
+        w3.middleware_onion.add(
+            make_stalecheck_middleware(ACCEPTABLE_STALE_HOURS * 3600),
+            name='stalecheck'
+        )
+
     return w3
 
 

--- a/newsfragments/2239.bugfix.rst
+++ b/newsfragments/2239.bugfix.rst
@@ -1,0 +1,1 @@
+Inherit ``Web3`` instance middlewares when instantiating ``ENS`` with ``ENS.fromWeb3()`` method

--- a/newsfragments/2239.feature.rst
+++ b/newsfragments/2239.feature.rst
@@ -1,0 +1,1 @@
+Add ``middlewares`` property to ``NamedElementOnion`` / ``web3.middleware_onion``. Returns current middlewares in proper order for importing into a new ``Web3`` instance

--- a/tests/core/manager/test_middleware_onion_api.py
+++ b/tests/core/manager/test_middleware_onion_api.py
@@ -66,7 +66,7 @@ def test_add_named_duplicate_middleware(middleware_factory):
 def test_add_duplicate_middleware(middleware_factory):
     mw = middleware_factory()
     with pytest.raises(ValueError):
-        manager = RequestManager(None, BaseProvider(), middlewares=[mw, mw])
+        RequestManager(None, BaseProvider(), middlewares=[mw, mw])
 
     manager = RequestManager(None, BaseProvider(), middlewares=[])
     manager.middleware_onion.add(mw)
@@ -168,3 +168,13 @@ def test_remove_middleware(middleware_factory):
     manager.middleware_onion.remove(mw2)
 
     assert tuple(manager.middleware_onion) == (mw1, mw3)
+
+
+def test_export_middlewares(middleware_factory):
+    mw1 = middleware_factory()
+    mw2 = middleware_factory()
+    manager = RequestManager(None, BaseProvider(), middlewares=[(mw1, 'name1'), (mw2, 'name2')])
+    assert tuple(manager.middleware_onion) == (mw1, mw2)
+
+    middlewares = manager.middleware_onion.middlewares
+    assert middlewares == [(mw1, 'name1'), (mw2, 'name2')]

--- a/tests/ens/test_ens.py
+++ b/tests/ens/test_ens.py
@@ -1,0 +1,12 @@
+from ens import ENS
+from web3.middleware import (
+    pythonic_middleware,
+)
+
+
+def test_fromWeb3_inherits_web3_middlewares(web3):
+    test_middleware = pythonic_middleware
+    web3.middleware_onion.add(test_middleware, 'test_middleware')
+
+    ns = ENS.fromWeb3(web3)
+    assert ns.web3.middleware_onion.get('test_middleware') == test_middleware

--- a/web3/datastructures.py
+++ b/web3/datastructures.py
@@ -196,6 +196,14 @@ class NamedElementOnion(Mapping[TKey, TValue]):
             raise ValueError("You can only remove something that has been added")
         del self._queue[old]
 
+    @property
+    def middlewares(self) -> Sequence[Any]:
+        """
+        Returns middlewares in the appropriate order to be imported into a new Web3 instance
+        (reversed _queue order) as a list of (middleware, name) tuples.
+        """
+        return [(val, key) for key, val in reversed(self._queue.items())]
+
     def _replace_with_new_name(self, old: TKey, new: TKey) -> None:
         self._queue[new] = new
         found_old = False


### PR DESCRIPTION
### What was wrong?

From recent comments on issue #425:
- ``ENS.fromWeb3()`` does not make use of existing middlewares present in the ``Web3`` instance that is passed in to the method. This led to issues using ``geth_poa_middleware``.

Closes #1657 

### How was it fixed?

- Inherit the ``Web3`` instance's middlewares when instantiating the ``ENS`` instance from a ``Web3`` instance.
- Adds a ``middlewares`` property to the ``NamedElementOnion`` data structure / ``web3.middleware_onion`` that returns a list of all current middlewares in appropriate order to be passed in to a new ``Web3`` instance.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20211206_151027](https://user-images.githubusercontent.com/3532824/145085688-568fd499-66fc-43c5-a180-d101d1ba2b23.jpg)