### PR TITLE
Rethink `eth_chainId` calls

### DIFF
--- a/web3/__init__.py
+++ b/web3/__init__.py
@@ -45,7 +45,6 @@ __all__ = [
     "HTTPProvider",
     "IPCProvider",
     "WebsocketProvider",
-    "TestRPCProvider",
     "EthereumTesterProvider",
     "Account",
     "AsyncHTTPProvider",

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -64,7 +64,7 @@ TRANSACTION_DEFAULTS = {
         web3.eth.max_priority_fee + (2 * web3.eth.get_block('latest')['baseFeePerGas'])
     ),
     'maxPriorityFeePerGas': lambda web3, tx: web3.eth.max_priority_fee,
-    'chainId': lambda web3, tx: web3.eth.chain_id,
+    'chainId': lambda web3, tx: web3.provider.internal_chain_id,
 }
 
 if TYPE_CHECKING:

--- a/web3/middleware/validation.py
+++ b/web3/middleware/validation.py
@@ -51,7 +51,7 @@ to_integer_if_hex = apply_formatter_if(is_string, hex_to_integer)
 
 @curry
 def validate_chain_id(web3: "Web3", chain_id: int) -> int:
-    if to_integer_if_hex(chain_id) == web3.eth.chain_id:
+    if to_integer_if_hex(chain_id) == web3.provider.internal_chain_id:
         return chain_id
     else:
         raise ValidationError(
@@ -88,7 +88,7 @@ def transaction_param_validator(web3: "Web3") -> Callable[..., Any]:
     transactions_params_validators = {
         "chainId": apply_formatter_if(
             # Bypass `validate_chain_id` if chainId can't be determined
-            lambda _: is_not_null(web3.eth.chain_id),
+            lambda _: is_not_null(web3.provider.internal_chain_id),
             validate_chain_id(web3),
         ),
     }


### PR DESCRIPTION
### What was wrong?

- We can often end up making multiple calls to `eth_chainId` to validate the `chainId` param in a transaction, or to add the default value to each transaction making use of default values (i.e. `contract.buildTransaction()`).

Related to Issue #2207 

### How was it fixed?

- One possible solution is setting an internal chain id value on provider instantiation

- Another solution would be to cache the call to `eth_chainId`
   - Downside to this is default caching happens once per instance so each call for `w3.eth.chain_id`, on its own, would return the cached value and would not be an earnest call.