### PR TITLE
`ContractFunctions.__getitem__` type hint bugfix

### DIFF
--- a/web3/contract.py
+++ b/web3/contract.py
@@ -198,7 +198,7 @@ class ContractFunctions:
         else:
             return super().__getattribute__(function_name)
 
-    def __getitem__(self, function_name: str) -> ABIFunction:
+    def __getitem__(self, function_name: str) -> "ContractFunction":
         return getattr(self, function_name)
 
     def __hasattr__(self, event_name: str) -> bool:


### PR DESCRIPTION
The item is defined by `setattr` at Line 166, which is a `ContractFunction`.