### PR TITLE
Contract: Handle TypeError

### DIFF
--- a/web3/contract.py
+++ b/web3/contract.py
@@ -964,8 +964,8 @@ class ContractFunction:
             self.contract_abi,
             self.abi,
             state_override,
-            *self.args,
-            **self.kwargs
+            *self.args is self.args else [],
+            **self.kwargs if self.kwargs else {}
         )
 
     def transact(self, transaction: Optional[TxParams] = None) -> HexBytes:
@@ -1001,8 +1001,8 @@ class ContractFunction:
             transact_transaction,
             self.contract_abi,
             self.abi,
-            *self.args,
-            **self.kwargs
+            *self.args is self.args else [],
+            **self.kwargs if self.kwargs else {}
         )
 
     def estimateGas(
@@ -1044,8 +1044,8 @@ class ContractFunction:
             self.contract_abi,
             self.abi,
             block_identifier,
-            *self.args,
-            **self.kwargs
+            *self.args is self.args else [],
+            **self.kwargs if self.kwargs else {}
         )
 
     def buildTransaction(self, transaction: Optional[TxParams] = None) -> TxParams:
@@ -1083,8 +1083,8 @@ class ContractFunction:
             built_transaction,
             self.contract_abi,
             self.abi,
-            *self.args,
-            **self.kwargs
+            *self.args is self.args else [],
+            **self.kwargs if self.kwargs else {}
         )
 
     @combomethod


### PR DESCRIPTION
Handles TypeError in methods when either self.args or self.kwargs is None

### What was wrong?

I was interacting with avalanche testnet, and one of the contract function threw these errors;

```
TypeError: call_contract_function() argument after * must be an iterable, not NoneType
```

```
TypeError: call_contract_function() argument after*** must be a mapping, not NoneType
```

Looking at the code I realized that it is because of None values getting unpacked.



### How was it fixed?

I added a conditional assignment to handle None values. I'm not sure if this is the right way to do it though because I didn't find this issue encountered by anyone else on the repository issues. It might be that I'm doing something wrong during initialization. 

However from the type definition of `ContractFunction` it seems that args and kwargs are initialized to None, so unless there's a logic that'll always make sure that neither of this are None when `*`, and `**` are used, the chances of these errors will be there.

Let me know if my analysis is correct 😅 


### Todo:

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://d33wubrfki0l68.cloudfront.net/f45b8c090ff9bab60aaee84ed4327d27c9150057/34009/static/5dea0acbc8484c42006d7bbed32fa019/23573/doge-computer.png)
