### PR TITLE
(v5) Upgrade jsonschema to >=3.2.0<4

### DIFF
--- a/newsfragments/2360.feature.rst
+++ b/newsfragments/2360.feature.rst
@@ -1,0 +1,1 @@
+Upgrade ``jsonschema`` version range to >=3.2.0<5

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         "eth-utils>=1.9.5,<2.0.0",
         "hexbytes>=0.1.0,<1.0.0",
         "ipfshttpclient==0.8.0a2",
-        "jsonschema>=3.2.0,<4.0.0",
+        "jsonschema>=3.2.0,<5",
         "lru-dict>=1.1.6,<2.0.0",
         "protobuf>=3.10.0,<4",
         "pywin32>=223;platform_system=='Windows'",


### PR DESCRIPTION
### What was wrong?

closes #2358

### How was it fixed?

- Upgrade `jsonschema` version range to allow for versions between `4.0.0` and `5.0.0`

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
- [x] Add cute animal picture

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F4c%2F9d%2F62%2F4c9d62d7c6f5bb9e74f3d34e95db03fb.jpg&f=1&nofb=1)
