### PR TITLE
(v6) Upgrade `jsonschema` to version range `>=4.0.0<5`

### DIFF
--- a/newsfragments/2361.feature.rst
+++ b/newsfragments/2361.feature.rst
@@ -1,0 +1,1 @@
+Upgrade ``jsonschema`` version to ``>=4.0.0<5``

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         "eth-utils>=1.9.5,<2.0.0",
         "hexbytes>=0.1.0,<1.0.0",
         "ipfshttpclient==0.8.0a2",
-        "jsonschema>=3.2.0,<4.0.0",
+        "jsonschema>=4.0.0,<5",
         "lru-dict>=1.1.6,<2.0.0",
         "protobuf>=3.10.0,<4",
         "pywin32>=223;platform_system=='Windows'",


### PR DESCRIPTION
### What was wrong?

Related to Issue #2358, #2360

### How was it fixed?

- Upgrade ``jsonschema`` to version range ``>=4.0.0<5``

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fi.pinimg.com%2Foriginals%2F4c%2F9d%2F62%2F4c9d62d7c6f5bb9e74f3d34e95db03fb.jpg&f=1&nofb=1)
