### PR TITLE
Add txn result formatters for ``type`` and ``chainId``

### DIFF
--- a/newsfragments/2491.feature.rst
+++ b/newsfragments/2491.feature.rst
@@ -1,0 +1,1 @@
+Add transaction result formatters for `type` and `chainId` to convert values to ``int`` if ``hexadecimal`` if the field is not null

--- a/tests/core/utilities/test_valid_transaction_params.py
+++ b/tests/core/utilities/test_valid_transaction_params.py
@@ -55,7 +55,6 @@ def test_assert_valid_transaction_params_invalid_param():
 
 
 FULL_TXN_DICT = {
-    'chainId': 1,
     'type': '0x2',
     'from': '0x0',
     'to': '0x1',

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -169,6 +169,8 @@ TRANSACTION_RESULT_FORMATTERS = {
     'hash': to_hexbytes(32),
     'v': apply_formatter_if(is_not_null, to_integer_if_hex),
     'standardV': apply_formatter_if(is_not_null, to_integer_if_hex),
+    'type': apply_formatter_if(is_not_null, to_integer_if_hex),
+    'chainId': apply_formatter_if(is_not_null, to_integer_if_hex),
 }
 
 


### PR DESCRIPTION
### What was wrong?

closes #2491

### How was it fixed?

- Add transaction result formatters for `type` and `chainId` to convert values to ``int`` if ``hexadecimal`` if the field is not null

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fedge.alluremedia.com.au%2Fm%2Fg%2F2017%2F07%2Ftasmanian-devil.jpg&f=1&nofb=1)
