### PR TITLE
Handle Revert() strings

### DIFF
--- a/newsfragments/2535.bugfix.rst
+++ b/newsfragments/2535.bugfix.rst
@@ -1,0 +1,1 @@
+Handle json-rpc response errors in the format Revert(0x...)

--- a/tests/core/utilities/test_method_formatters.py
+++ b/tests/core/utilities/test_method_formatters.py
@@ -31,6 +31,19 @@ REVERT_WITH_MSG = RPCResponse({
     'id': 2987,
 })
 
+ANOTHER_REVERT_WITH_MSG = RPCResponse({
+    'jsonrpc': '2.0',
+    'error': (
+        'Revert('
+        '0x08c379a'
+        '00000000000000000000000000000000000000000000000000000000000000020'
+        '000000000000000000000000000000000000000000000000000000000000000c'
+        '4f7574206f662072616e67650000000000000000000000000000000000000000'
+        ')'
+    ),
+    'id': 20,
+})
+
 REVERT_WITHOUT_MSG = RPCResponse({
     'jsonrpc': '2.0',
     'error': {
@@ -86,12 +99,14 @@ GANACHE_RESPONSE = RPCResponse({
         (REVERT_WITHOUT_MSG, 'execution reverted'),
         (GETH_RESPONSE, 'execution reverted: Function has been reverted.'),
         (GANACHE_RESPONSE, 'execution reverted: VM Exception while processing transaction: revert Custom revert message'),  # noqa: 501
+        (ANOTHER_REVERT_WITH_MSG, 'execution reverted: Out of range'),
     ),
     ids=[
         'test-get-revert-reason-with-msg',
         'test-get-revert-reason-without-msg',
         'test-get-geth-revert-reason',
         'test_get-ganache-revert-reason',
+        'test-get-another-revert-reason-with-msg',
     ])
 def test_get_revert_reason(response, expected) -> None:
     with pytest.raises(ContractLogicError, match=expected):

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -631,7 +631,7 @@ def raise_solidity_error_on_revert(response: RPCResponse) -> RPCResponse:
         )
         raise OffchainLookup(offchain_lookup_payload)
 
-    if isinstance(data, dict):
+    if isinstance(response["error"], dict):
         # Geth case:
         if "message" in response["error"] and response["error"].get("code", "") == 3:
             raise ContractLogicError(response["error"]["message"])

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -631,13 +631,14 @@ def raise_solidity_error_on_revert(response: RPCResponse) -> RPCResponse:
         )
         raise OffchainLookup(offchain_lookup_payload)
 
-    # Geth case:
-    if "message" in response["error"] and response["error"].get("code", "") == 3:
-        raise ContractLogicError(response["error"]["message"])
+    if isinstance(data, dict):
+        # Geth case:
+        if "message" in response["error"] and response["error"].get("code", "") == 3:
+            raise ContractLogicError(response["error"]["message"])
 
-    # Geth Revert without error message case:
-    if "execution reverted" in response["error"].get("message"):
-        raise ContractLogicError("execution reverted")
+        # Geth Revert without error message case:
+        if "execution reverted" in response["error"].get("message"):
+            raise ContractLogicError("execution reverted")
 
     return response
 


### PR DESCRIPTION
### What was wrong?

Related to Issue #2535 

### How was it fixed?

Handle response errors that start with `Revert(`.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.newscientist.com/wp-content/uploads/2020/02/26183019/f0at2n_web.jpg)
