### PR TITLE
Fix TypeError in ContractFunction.call when args and kwargs properties are None

### DIFF
--- a/web3/contract.py
+++ b/web3/contract.py
@@ -1219,8 +1219,8 @@ class ContractFunction(BaseContractFunction):
             self.abi,
             state_override,
             ccip_read_enabled,
-            *self.args,
-            **self.kwargs,
+            *(self.args or []),
+            **(self.kwargs or {}),
         )
 
     def transact(self, transaction: Optional[TxParams] = None) -> HexBytes:


### PR DESCRIPTION
Fix #2541.

I confirmed that the example code in #2541 passes with this change.

If you want me to add related tests in the same PR, as I am new to this project, I would appreciate if you could give some hints, e.g., similar existing tests, where to put tests (a new file or existing file?), etc.

#### Cute Animal Picture
My cats 😺

![Put a link to a cute animal picture inside the parenthesis-->](https://pbs.twimg.com/media/FEKWwYsakAA-OMl?format=jpg&name=4096x4096)
