### PR TITLE
Better messaging for wrong arguments to tuple types

### DIFF
--- a/newsfragments/2556.breaking-change.rst
+++ b/newsfragments/2556.breaking-change.rst
@@ -1,0 +1,1 @@
+Provide better messaging to wrong arguments for contract functions, especially for ``tuple`` argument types.

--- a/newsfragments/README.md
+++ b/newsfragments/README.md
@@ -12,6 +12,8 @@ relevant to people working on the code itself.)
 * `bugfix`
 * `doc`
 * `misc`
+* `breaking-change`
+* `deprecation`
 
 So for example: `123.feature.rst`, `456.bugfix.rst`
 

--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -672,13 +672,15 @@ def test_function_multiple_error_diagnoses(w3, arg1, arg2, diagnosis):
 
 
 @pytest.mark.parametrize(
-    "address", (
+    "address",
+    (
         "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",  # checksummed
-        b'\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee',  # noqa: E501
-    )
+        b"\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee",  # noqa: E501
+    ),
 )
 def test_function_wrong_args_for_tuple_collapses_args_in_message(
-    address, tuple_contract,
+    address,
+    tuple_contract,
 ):
     with pytest.raises(ValidationError) as e:
         tuple_contract.functions.method(
@@ -687,18 +689,23 @@ def test_function_wrong_args_for_tuple_collapses_args_in_message(
 
     # assert the user arguments are formatted as expected:
     # (int,(int,int),((int,(bool,(bool)),(address))))
-    e.match("\\(int,\\(int,int\\),\\(\\(int,\\(bool,\\(bool\\)\\),\\(address\\)\\)\\)\\)")  # noqa: E501
+    e.match(
+        "\\(int,\\(int,int\\),\\(\\(int,\\(bool,\\(bool\\)\\),\\(address\\)\\)\\)\\)"
+    )
 
     # assert the found method signature is formatted as expected:
     # ['method((uint256,uint256[],(int256,bool[2],address[])[]))']
-    e.match("\\['method\\(\\(uint256,uint256\\[\\],\\(int256,bool\\[2\\],address\\[\\]\\)\\[\\]\\)\\)'\\]")  # noqa: E501
+    e.match(
+        "\\['method\\(\\(uint256,uint256\\[\\],\\(int256,bool\\[2\\],address\\[\\]\\)\\[\\]\\)\\)'\\]"  # noqa: E501
+    )
 
 
 @pytest.mark.parametrize(
-    "address", (
+    "address",
+    (
         "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",  # checksummed
-        b'\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee',  # noqa: E501
-    )
+        b"\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee\xee",  # noqa: E501
+    ),
 )
 def test_function_wrong_args_for_tuple_collapses_kwargs_in_message(
     address, tuple_contract
@@ -710,11 +717,15 @@ def test_function_wrong_args_for_tuple_collapses_kwargs_in_message(
 
     # assert the user keyword arguments are formatted as expected:
     # {'a': '(int,(int,int),((int,(bool,(bool)),(address))))'}
-    e.match("{'a': '\\(int,\\(int,int\\),\\(\\(int,\\(bool,\\(bool\\)\\),\\(address\\)\\)\\)\\)'}")  # noqa: E501
+    e.match(
+        "{'a': '\\(int,\\(int,int\\),\\(\\(int,\\(bool,\\(bool\\)\\),\\(address\\)\\)\\)\\)'}"  # noqa: E501
+    )
 
     # assert the found method signature is formatted as expected:
     # ['method((uint256,uint256[],(int256,bool[2],address[])[]))']
-    e.match("\\['method\\(\\(uint256,uint256\\[\\],\\(int256,bool\\[2\\],address\\[\\]\\)\\[\\]\\)\\)'\\]")  # noqa: E501
+    e.match(
+        "\\['method\\(\\(uint256,uint256\\[\\],\\(int256,bool\\[2\\],address\\[\\]\\)\\[\\]\\)\\)'\\]"  # noqa: E501
+    )
 
 
 def test_function_no_abi(w3):
@@ -1471,7 +1482,7 @@ async def test_async_accepts_block_hash_as_identifier(async_w3, async_math_contr
     )
     new = await async_math_contract.functions.counter().call(
         block_identifier=more_blocks["result"][2]
-    )  # noqa: E501
+    )
 
     assert old == 0
     assert new == 1

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -724,7 +724,8 @@ def abi_to_signature(abi: Union[ABIFunction, ABIEvent]) -> str:
     function_signature = "{fn_name}({fn_input_types})".format(
         fn_name=abi["name"],
         fn_input_types=",".join(
-            [arg["type"] for arg in normalize_event_input_types(abi.get("inputs", []))]
+            collapse_if_tuple(dict(arg))
+            for arg in normalize_event_input_types(abi.get("inputs", []))
         ),
     )
     return function_signature


### PR DESCRIPTION
### What was wrong?

Contract function signatures in our error messages were only ever read as `<class 'tuple'>` for `tuple` / `struct` argument types. This makes it very difficult to compare user-provided arguments to the function signature.

### How was it fixed?

- Collapse `tuple` argument types in the identified function signature(s)
- Collapse user-provided argument types to better compare directly to the identified function signature(s)

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![moog_camping](https://user-images.githubusercontent.com/3532824/177386852-c2bd17eb-5097-4035-a28d-8a98c9354608.jpg)

