### PR TITLE
Add formatting to eth-tester middleware for eth_getTransactionCount

### DIFF
--- a/newsfragments/1801.bugfix.rst
+++ b/newsfragments/1801.bugfix.rst
@@ -1,0 +1,1 @@
+Properly format ``block_number`` for ``eth_getTransactionCount`` when using ``EthereumTesterProvider``

--- a/tests/core/middleware/test_eth_tester_middleware.py
+++ b/tests/core/middleware/test_eth_tester_middleware.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.mark.parametrize("block_number", {0, "0x0", "earliest"})
+def test_get_transaction_count_formatters(w3, block_number):
+    tx_counts = w3.eth.get_transaction_count(w3.eth.accounts[-1], block_number)
+    assert tx_counts == 0

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -66,9 +66,7 @@ def is_hexstr(value: Any) -> bool:
 
 
 to_integer_if_hex = apply_formatter_if(is_hexstr, hex_to_integer)
-
 is_not_named_block = complement(is_named_block)
-
 
 # --- Request Mapping --- #
 
@@ -197,6 +195,10 @@ request_formatters = {
     ),
     RPCEndpoint("eth_getFilterChanges"): apply_formatters_to_args(hex_to_integer),
     RPCEndpoint("eth_getFilterLogs"): apply_formatters_to_args(hex_to_integer),
+    RPCEndpoint("eth_getTransactionCount"): apply_formatters_to_args(
+        identity,
+        apply_formatter_if(is_not_named_block, to_integer_if_hex),
+    ),
     RPCEndpoint("eth_getBlockTransactionCountByNumber"): apply_formatters_to_args(
         apply_formatter_if(is_not_named_block, to_integer_if_hex),
     ),


### PR DESCRIPTION
### What was wrong?

closes #1801

### How was it fixed?

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![lazymoog](https://user-images.githubusercontent.com/3532824/177856581-65d133c8-b835-4816-93fe-74fd30cc9e5a.jpg)

