### PR TITLE
Add support for ``async_simple_cache_middleware``

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -484,5 +484,6 @@ Supported Middleware
 - :meth:`Gas Price Strategy <web3.middleware.gas_price_strategy_middleware>`
 - :meth:`Buffered Gas Estimate Middleware <web3.middleware.buffered_gas_estimate_middleware>`
 - :meth:`Stalecheck Middleware <web3.middleware.make_stalecheck_middleware>`
-- :meth:`Validation middleware <web3.middleware.validation>`
+- :meth:`Validation Middleware <web3.middleware.validation>`
 - :ref:`Geth POA Middleware <geth-poa>`
+- :meth:`Simple Cache Middleware <web3.middleware.simple_cache_middleware>`

--- a/docs/web3.utils.rst
+++ b/docs/web3.utils.rst
@@ -3,30 +3,40 @@ Utils
 
 .. py:module:: web3.utils
 
-The ``utils`` module houses public utility and helper functions.
+The ``utils`` module houses public utility functions and classes.
 
 ABI
 ---
 
-.. py:method:: Utils.get_abi_input_names(abi)
+.. py:method:: utils.get_abi_input_names(abi)
 
     Return the ``input`` names for an ABI function or event.
 
 
-.. py:method:: Utils.get_abi_output_names(abi)
+.. py:method:: utils.get_abi_output_names(abi)
 
     Return the ``output`` names an ABI function or event.
+
+
+Caching
+-------
+
+.. py:class:: utils.SimpleCache
+
+    The main cache class being used internally by web3.py. In some cases, it may prove
+    useful to set your own cache size and pass in your own instance of this class where
+    supported.
 
 
 Exception Handling
 ------------------
 
-.. py:method:: Utils.handle_offchain_lookup(offchain_lookup_payload, transaction)
+.. py:method:: utils.handle_offchain_lookup(offchain_lookup_payload, transaction)
 
     Handle ``OffchainLookup`` reverts on contract function calls manually. For an example, see :ref:`ccip-read-example`
     within the examples section.
 
 
-.. py:method:: Utils.async_handle_offchain_lookup(offchain_lookup_payload, transaction)
+.. py:method:: utils.async_handle_offchain_lookup(offchain_lookup_payload, transaction)
 
     The async version of the ``handle_offchain_lookup()`` utility method described above.

--- a/newsfragments/2579.breaking.rst
+++ b/newsfragments/2579.breaking.rst
@@ -1,0 +1,1 @@
+Remove support for dictionary-based caches, for simple-cache-middleware, in favor of the internal ``SimpleCache`` class.

--- a/newsfragments/2579.feature.rst
+++ b/newsfragments/2579.feature.rst
@@ -1,1 +1,1 @@
-Async support for caching certain methods via ``async_simple_cache_middleware`` as well as constructing custom async caching middleware via ``async_construct_simple_cache_middleware``.
+Async support for caching certain methods via ``async_simple_cache_middleware`` as well as constructing custom async caching middleware via ``async_construct_simple_cache_middleware``. ``SimpleCache`` class was also added to the public ``utils`` module.

--- a/newsfragments/2579.feature.rst
+++ b/newsfragments/2579.feature.rst
@@ -1,0 +1,1 @@
+Async support for caching certain methods via ``async_simple_cache_middleware`` as well as constructing custom async caching middleware via ``async_construct_simple_cache_middleware``.

--- a/tests/core/utilities/test_caching_utils.py
+++ b/tests/core/utilities/test_caching_utils.py
@@ -1,0 +1,35 @@
+import asyncio
+from concurrent.futures import (
+    ThreadPoolExecutor,
+)
+import pytest
+import threading
+
+from web3._utils.async_caching import (
+    async_lock,
+)
+
+# --- async -- #
+
+
+@pytest.mark.asyncio
+async def test_async_lock_releases_if_a_task_is_cancelled():
+    # inspired by issue #2693
+    # Note: this test will raise a `TimeoutError` if `request.async_lock` is not
+    # applied correctly
+
+    _thread_pool = ThreadPoolExecutor(max_workers=1)
+    _lock = threading.Lock()
+
+    async def _utilize_async_lock():
+        async with async_lock(_thread_pool, _lock):
+            await asyncio.sleep(0.2)
+
+    asyncio.create_task(_utilize_async_lock())
+
+    inner = asyncio.create_task(_utilize_async_lock())
+    await asyncio.sleep(0.1)
+    inner.cancel()
+
+    outer = asyncio.wait_for(_utilize_async_lock(), 2)
+    await outer

--- a/tests/core/utilities/test_request.py
+++ b/tests/core/utilities/test_request.py
@@ -25,12 +25,14 @@ from web3._utils import (
     request,
 )
 from web3._utils.caching import (
-    SimpleCache,
     generate_cache_key,
 )
 from web3._utils.request import (
     cache_and_return_async_session,
     cache_and_return_session,
+)
+from web3.utils.caching import (
+    SimpleCache,
 )
 
 
@@ -149,10 +151,9 @@ def test_cache_session_class():
     assert "1" not in cache
     assert "1" in evicted_items
 
-    with pytest.raises(KeyError):
-        # This should throw a KeyError since the cache size was 2 and 3 were inserted
-        # the first inserted cached item was removed and returned in evicted items
-        cache.get_cache_entry("1")
+    # Cache size is `3`. We should have "2" and "3" in the cache and "1" should have
+    # been evicted.
+    assert cache.get_cache_entry("1") is None
 
     # clear cache
     request._session_cache.clear()

--- a/web3/_utils/async_caching.py
+++ b/web3/_utils/async_caching.py
@@ -1,0 +1,21 @@
+import asyncio
+from concurrent.futures import (
+    ThreadPoolExecutor,
+)
+import contextlib
+import threading
+from typing import (
+    AsyncGenerator,
+)
+
+
+@contextlib.asynccontextmanager
+async def async_lock(
+    thread_pool: ThreadPoolExecutor, lock: threading.Lock
+) -> AsyncGenerator[None, None]:
+    loop = asyncio.get_event_loop()
+    try:
+        await loop.run_in_executor(thread_pool, lock.acquire)
+        yield
+    finally:
+        lock.release()

--- a/web3/_utils/caching.py
+++ b/web3/_utils/caching.py
@@ -1,12 +1,7 @@
 import collections
-from collections import (
-    OrderedDict,
-)
 import hashlib
 from typing import (
     Any,
-    Dict,
-    Union,
 )
 
 from eth_utils import (
@@ -39,66 +34,3 @@ def generate_cache_key(value: Any) -> str:
         raise TypeError(
             f"Cannot generate cache key for value {value} of type {type(value)}"
         )
-
-
-class SimpleCache:
-    def __init__(self, size: int = 100):
-        self._size = size
-        self._data: OrderedDict[str, Any] = OrderedDict()
-
-    def cache(self, key: str, value: Any) -> Dict[str, Any]:
-        evicted_items = None
-        # If the key is already in the OrderedDict just update it
-        # and don't evict any values. Ideally, we could still check to see
-        # if there are too many items in the OrderedDict but that may rearrange
-        # the order it should be unlikely that the size could grow over the limit
-        if key not in self._data:
-            while len(self._data) >= self._size:
-                if evicted_items is None:
-                    evicted_items = {}
-                k, v = self._data.popitem(last=False)
-                evicted_items[k] = v
-        self._data[key] = value
-        return evicted_items
-
-    def get_cache_entry(self, key: str) -> Any:
-        return self._data[key]
-
-    def clear(self) -> None:
-        self._data.clear()
-
-    def items(self) -> Dict[str, Any]:
-        return self._data
-
-    def __contains__(self, item: str) -> bool:
-        return item in self._data
-
-    def __len__(self) -> int:
-        return len(self._data)
-
-
-def type_aware_cache_entry(
-    cache: Union[Dict[str, Any], SimpleCache], cache_key: str, value: Any
-) -> None:
-    """
-    Commit an entry to a dictionary-based cache or to a `SimpleCache` class.
-    """
-    if isinstance(cache, SimpleCache):
-        cache.cache(cache_key, value)
-    else:
-        cache[cache_key] = value
-
-
-def type_aware_get_cache_entry(
-    cache: Union[Dict[str, Any], SimpleCache],
-    cache_key: str,
-) -> Any:
-    """
-    Get a cache entry, with `cache_key`, from a dictionary-based cache or a
-    `SimpleCache` class.
-    """
-    if isinstance(cache, SimpleCache) and cache_key in cache.items():
-        return cache.get_cache_entry(cache_key)
-    elif isinstance(cache, dict) and cache_key in cache:
-        return cache[cache_key]
-    return None

--- a/web3/_utils/request.py
+++ b/web3/_utils/request.py
@@ -27,8 +27,10 @@ from web3._utils.async_caching import (
     async_lock,
 )
 from web3._utils.caching import (
-    SimpleCache,
     generate_cache_key,
+)
+from web3.utils.caching import (
+    SimpleCache,
 )
 
 logger = logging.getLogger(__name__)
@@ -40,7 +42,7 @@ def get_default_http_endpoint() -> URI:
     return URI(os.environ.get("WEB3_HTTP_PROVIDER_URI", "http://localhost:8545"))
 
 
-_session_cache = SimpleCache(size=100)
+_session_cache = SimpleCache()
 _session_cache_lock = threading.Lock()
 
 
@@ -111,7 +113,7 @@ def _close_evicted_sessions(evicted_sessions: List[requests.Session]) -> None:
 # --- async --- #
 
 
-_async_session_cache = SimpleCache(size=100)
+_async_session_cache = SimpleCache()
 _async_session_cache_lock = threading.Lock()
 _async_session_pool = ThreadPoolExecutor(max_workers=1)
 

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -14,6 +14,9 @@ from web3.types import (
 from .abi import (  # noqa: F401
     abi_middleware,
 )
+from web3.middleware.async_cache import (  # noqa: F401
+    _async_simple_cache_middleware as async_simple_cache_middleware,
+)
 from .attrdict import (  # noqa: F401
     attrdict_middleware,
 )

--- a/web3/middleware/async_cache.py
+++ b/web3/middleware/async_cache.py
@@ -1,0 +1,93 @@
+from concurrent.futures import (
+    ThreadPoolExecutor,
+)
+import functools
+import threading
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Collection,
+    Dict,
+    Type,
+    Union,
+    cast,
+)
+
+from web3._utils.async_caching import (
+    async_lock,
+)
+from web3._utils.caching import (
+    SimpleCache,
+    generate_cache_key,
+    type_aware_cache_entry,
+    type_aware_get_cache_entry,
+)
+from web3.middleware.cache import (
+    SIMPLE_CACHE_RPC_WHITELIST,
+    _should_cache_response,
+)
+from web3.types import (
+    AsyncMiddleware,
+    Middleware,
+    RPCEndpoint,
+    RPCResponse,
+)
+
+if TYPE_CHECKING:
+    from web3 import Web3  # noqa: F401
+
+_async_request_thread_pool = ThreadPoolExecutor()
+
+
+async def async_construct_simple_cache_middleware(
+    cache_class: Union[Type[Dict[str, Any]], Type[SimpleCache]],
+    rpc_whitelist: Collection[RPCEndpoint] = SIMPLE_CACHE_RPC_WHITELIST,
+    should_cache_fn: Callable[
+        [RPCEndpoint, Any, RPCResponse], bool
+    ] = _should_cache_response,
+) -> Middleware:
+    """
+    Constructs a middleware which caches responses based on the request
+    ``method`` and ``params``
+
+    :param cache_class: A ``SimpleCache`` class or any dictionary-like object.
+    :param rpc_whitelist: A set of RPC methods which may have their responses cached.
+    :param should_cache_fn: A callable which accepts ``method`` ``params`` and
+        ``response`` and returns a boolean as to whether the response should be
+        cached.
+    """
+
+    async def async_simple_cache_middleware(
+        make_request: Callable[[RPCEndpoint, Any], Any], _async_w3: "Web3"
+    ) -> AsyncMiddleware:
+        cache = cache_class()
+        lock = threading.Lock()
+
+        async def middleware(method: RPCEndpoint, params: Any) -> RPCResponse:
+            if method in rpc_whitelist:
+                async with async_lock(_async_request_thread_pool, lock):
+                    cache_key = generate_cache_key(
+                        f"{threading.get_ident()}:{(method, params)}"
+                    )
+                    if not type_aware_get_cache_entry(cache, cache_key):
+                        response = await make_request(method, params)
+                        if should_cache_fn(method, params, response):
+                            type_aware_cache_entry(cache, cache_key, response)
+                        return response
+                    return type_aware_get_cache_entry(cache, cache_key)
+            else:
+                return await make_request(method, params)
+
+        return middleware
+
+    return async_simple_cache_middleware
+
+
+async def _async_simple_cache_middleware(
+    make_request: Callable[[RPCEndpoint, Any], Any], async_w3: "Web3"
+) -> Middleware:
+    middleware = await async_construct_simple_cache_middleware(
+        cache_class=cast(Type[SimpleCache], functools.partial(SimpleCache, 256)),
+    )
+    return await middleware(make_request, async_w3)

--- a/web3/utils/__init__.py
+++ b/web3/utils/__init__.py
@@ -9,6 +9,9 @@ from .abi import (  # NOQA
 from .async_exception_handling import (  # NOQA
     async_handle_offchain_lookup,
 )
+from .caching import (  # NOQA
+    SimpleCache,
+)
 from .exception_handling import (  # NOQA
     handle_offchain_lookup,
 )

--- a/web3/utils/caching.py
+++ b/web3/utils/caching.py
@@ -1,0 +1,44 @@
+from collections import (
+    OrderedDict,
+)
+from typing import (
+    Any,
+    Dict,
+    Optional,
+)
+
+
+class SimpleCache:
+    def __init__(self, size: int = 100):
+        self._size = size
+        self._data: OrderedDict[str, Any] = OrderedDict()
+
+    def cache(self, key: str, value: Any) -> Dict[str, Any]:
+        evicted_items = None
+        # If the key is already in the OrderedDict just update it
+        # and don't evict any values. Ideally, we could still check to see
+        # if there are too many items in the OrderedDict but that may rearrange
+        # the order it should be unlikely that the size could grow over the limit
+        if key not in self._data:
+            while len(self._data) >= self._size:
+                if evicted_items is None:
+                    evicted_items = {}
+                k, v = self._data.popitem(last=False)
+                evicted_items[k] = v
+        self._data[key] = value
+        return evicted_items
+
+    def get_cache_entry(self, key: str) -> Optional[Any]:
+        return self._data[key] if key in self._data else None
+
+    def clear(self) -> None:
+        self._data.clear()
+
+    def items(self) -> Dict[str, Any]:
+        return self._data
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._data
+
+    def __len__(self) -> int:
+        return len(self._data)


### PR DESCRIPTION
### What was wrong?

Related to Issue #2578

Hard-coding an internal `chain_id` was considered at some point but ultimately we landed on adding `eth_chainId` to the list of whitelisted endpoints for `simple_cache_middleware`. The `chain_id` setter had made its way into the library already and some users had gotten around the multiple `eth_chainId` checks by using this setter, especially with `AsyncEth`.

Rather than introduce this setter back, this PR adds support to cache `eth_chainId` calls using the `async_simple_cache_middleware` with `AsyncEth`.

### How was it fixed?

- Async request caching support via `async_simple_cache_middleware`
- Supports creating custom simple caching middleware via `async_construct_simple_cache_middleware`
- Refactor ``SessionCache`` to a more generic ``SimpleCache`` within the caching `_utils` and use this cache class in the simple cache middleware as the default cache (for sync and async). Leave support for a simple dictionary cache as well.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fwww.wallpaperflare.com%2Fstatic%2F615%2F441%2F129%2Ftitle-macro-photo-ladybug-wallpaper.jpg&f=1&nofb=1)
