### PR TITLE
Classes inheriting from ``Web3`` did not attach modules appropriately

### DIFF
--- a/newsfragments/2587.bugfix.rst
+++ b/newsfragments/2587.bugfix.rst
@@ -1,0 +1,1 @@
+Allow classes to inherit from the ``Web3`` class by attaching modules appropriately.

--- a/tests/core/contracts/test_implicit_contract.py
+++ b/tests/core/contracts/test_implicit_contract.py
@@ -70,13 +70,13 @@ def test_implicitcontract_transact_default(web3, math_contract, get_transaction_
     assert is_integer(start_count)  # Verify correct type
     # When a function is called that defaults to transact
     blocknum, starting_txns = get_transaction_count("pending")
-    with pytest.warns(DeprecationWarning,
-                      match='deprecated in favor of classic contract syntax') as warnings:
+    with pytest.warns(
+        DeprecationWarning,
+        match='deprecated in favor of classic contract syntax'
+    ):
         math_contract.increment(transact={})
         # Check that a transaction was made and not a call
         assert math_contract.counter() - start_count == 1
-        # Check that the correct number of warnings are raised
-        assert len(warnings) == 2
     # (Auto-mining is enabled, so query by block number)
     assert get_transaction_count(blocknum) == starting_txns + 1
     # Check that only one block was mined
@@ -102,12 +102,13 @@ def test_implicitcontract_transact_override(math_contract, get_transaction_count
     assert is_integer(start_count)  # Verify correct type
     # When a function is called with call override that defaults to transact
     blocknum, starting_txns = get_transaction_count("pending")
-    with pytest.warns(DeprecationWarning,
-                      match='deprecated in favor of classic contract syntax') as warnings:
+    with pytest.warns(
+        DeprecationWarning,
+        match='deprecated in favor of classic contract syntax'
+    ):
         math_contract.increment(call={})
         # Check that a call was made and not a transact
         assert math_contract.counter() - start_count == 0
-        assert len(warnings) == 2
     # (Auto-mining is enabled, so query by block number)
     assert get_transaction_count(blocknum) == starting_txns
     # Check that no blocks were mined

--- a/tests/core/web3-module/test_web3_inheritance.py
+++ b/tests/core/web3-module/test_web3_inheritance.py
@@ -1,0 +1,12 @@
+from web3 import (
+    EthereumTesterProvider,
+    Web3,
+)
+
+
+def test_classes_may_inherit_from_web3():
+    class InheritsFromWeb3(Web3):
+        pass
+
+    inherited_w3 = InheritsFromWeb3(EthereumTesterProvider())
+    assert inherited_w3.eth.chain_id == 61

--- a/tests/ens/test_v6_warnings.py
+++ b/tests/ens/test_v6_warnings.py
@@ -25,7 +25,8 @@ def test_resolver_future_warning_when_name_is_missing(ens):
 
     # assert no warning when `name` is passed in as a kwarg
     with warnings.catch_warnings():
-        warnings.simplefilter("error")  # turn all warnings to errors
+        # turn all `FutureWarning` warnings to errors:
+        warnings.simplefilter("error", category=FutureWarning)
         assert ens.resolver(name="EtH")
 
     # assert TypeError if both arguments passed in

--- a/web3/_utils/module.py
+++ b/web3/_utils/module.py
@@ -55,9 +55,13 @@ def attach_modules(
                 "already has an attribute with that name"
             )
 
-        # The parent module is the ``Web3`` instance on first run of the loop
-        if type(parent_module).__name__ == 'Web3':
-            w3 = parent_module
+        # The parent module is the ``Web3`` instance on first run of the loop and w3 is
+        # None. Thus, set w3 to the parent_module. The import needs to happen locally
+        # due to circular import issues.
+        if w3 is None:
+            from web3 import Web3
+            if isinstance(parent_module, Web3):
+                w3 = parent_module
 
         module_init_params = _validate_init_params_and_return_if_found(module_class)
         if len(module_init_params) == 1:


### PR DESCRIPTION
### What was wrong?

closes #2586 

### How was it fixed?

* Import ``Web3`` locally in order to avoid circular import. This allows us to make the check we wanted to in the first place which is to check that the ``parent_module`` is an instance of the ``Web3`` class (or inherits from it) when ``w3`` is ``None``.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%3Fid%3DOIP.CIVu81YEeL36lX3XZ3xL0AHaFj%26pid%3DApi&f=1)
