### PR TITLE
Poa doc update v5 backport

### DIFF
--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -361,10 +361,19 @@ All of the caching middlewares accept these common arguments.
 
 .. _geth-poa:
 
-Geth-style Proof of Authority
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Proof of authority
+~~~~~~~~~~~~~~~~~~
 
 This middleware is required to connect to ``geth --dev`` or the Rinkeby public network.
+It maybe also needed for other EVM compatible blockchains like Polygon or BNB Chain (Binance Smart Chain).
+
+If the middleware is not installed you may get errors like the example below when interacting
+with your EVM node.
+
+.. code-block::
+
+     web3.exceptions.ExtraDataLengthError: The field extraData is 97 bytes, but should be 32. It is quite likely that you are connected to a POA chain. Refer to http://web3py.readthedocs.io/en/stable/middleware.html#geth-style-proof-of-authority for more details. The full extraData is: HexBytes('...')
+
 
 The easiest way to connect to a default ``geth --dev`` instance which loads the middleware is:
 
@@ -379,7 +388,6 @@ The easiest way to connect to a default ``geth --dev`` instance which loads the 
 
 This example connects to a local ``geth --dev`` instance on Linux with a
 unique IPC location and loads the middleware:
-
 
 .. code-block:: python
 

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -361,18 +361,24 @@ All of the caching middlewares accept these common arguments.
 
 .. _geth-poa:
 
-Proof of authority
+Proof of Authority
 ~~~~~~~~~~~~~~~~~~
 
-This middleware is required to connect to ``geth --dev`` or the Rinkeby public network.
-It maybe also needed for other EVM compatible blockchains like Polygon or BNB Chain (Binance Smart Chain).
+.. note::
+    It's important to inject the middleware at the 0th layer of the middleware onion:
+    `w3.middleware_onion.inject(geth_poa_middleware, layer=0)`
 
-If the middleware is not installed you may get errors like the example below when interacting
-with your EVM node.
+The ``geth_poa_middleware`` is required to connect to ``geth --dev`` or the Rinkeby
+public network. It may also be needed for other EVM compatible blockchains like Polygon
+or BNB Chain (Binance Smart Chain).
 
-.. code-block::
+If the middleware is not injected at the 0th layer of the middleware onion, you may get
+errors like the example below when interacting with your EVM node.
 
-     web3.exceptions.ExtraDataLengthError: The field extraData is 97 bytes, but should be 32. It is quite likely that you are connected to a POA chain. Refer to http://web3py.readthedocs.io/en/stable/middleware.html#geth-style-proof-of-authority for more details. The full extraData is: HexBytes('...')
+```web3.exceptions.ExtraDataLengthError: The field extraData is 97 bytes, but should be
+32. It is quite likely that you are connected to a POA chain. Refer to
+http://web3py.readthedocs.io/en/stable/middleware.html#proof-of-authority
+for more details. The full extraData is: HexBytes('...')```
 
 
 The easiest way to connect to a default ``geth --dev`` instance which loads the middleware is:
@@ -398,7 +404,7 @@ unique IPC location and loads the middleware:
 
     >>> from web3.middleware import geth_poa_middleware
 
-    # inject the poa compatibility middleware to the innermost layer
+    # inject the poa compatibility middleware to the innermost layer (0th layer)
     >>> w3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
     # confirm that the connection succeeded

--- a/newsfragments/2589.doc.rst
+++ b/newsfragments/2589.doc.rst
@@ -1,0 +1,1 @@
+Update Proof of Authority middleware (`geth_poa_middleware`) documentation for better clarity.


### PR DESCRIPTION
### What was wrong?

`v5` back port of #2538

Note: Needs [these changes](https://github.com/ethereum/web3.py/pull/2587/commits/9acc3a08896c689c6e6088dbf7b4435d5221b20e#r930443269) from #2587 before merging.

### How was it fixed?

Cherry picked commits directly from `master` with no conflicts.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%3Fid%3DOIP.-fC6INoqoXPeny9nDhXcJAHaFj%26pid%3DApi&f=1)
