### PR TITLE
Add account to async Eth (backport of #2582)

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -411,6 +411,7 @@ Supported Methods
 
 Eth
 ***
+- :class:`web3.eth.account <eth_account.account.Account>`
 - :meth:`web3.eth.accounts <web3.eth.Eth.accounts>`
 - :meth:`web3.eth.block_number <web3.eth.Eth.block_number>`
 - :meth:`web3.eth.chain_id <web3.eth.Eth.chain_id>`

--- a/newsfragments/2590.feature.rst
+++ b/newsfragments/2590.feature.rst
@@ -1,0 +1,1 @@
+Support for ``Account`` class access in ``AsyncEth`` via ``async_w3.eth.account``

--- a/tests/core/eth-module/test_accounts.py
+++ b/tests/core/eth-module/test_accounts.py
@@ -1,11 +1,18 @@
 # coding=utf-8
 
 import pytest
+from unittest.mock import (
+    patch,
+)
 
 from eth_account.messages import (
     encode_defunct,
 )
+from eth_account.signers.local import (
+    LocalAccount,
+)
 from eth_utils import (
+    is_bytes,
     is_checksum_address,
     to_bytes,
     to_hex,
@@ -21,8 +28,15 @@ from web3 import (
     Account,
     Web3,
 )
+from web3.eth import (
+    AsyncEth,
+    BaseEth,
+)
 from web3.providers.eth_tester import (
     EthereumTesterProvider,
+)
+from web3.providers.eth_tester.main import (
+    AsyncEthereumTesterProvider,
 )
 
 # from https://github.com/ethereum/tests/blob/3930ca3a9a377107d5792b3e7202f79c688f1a67/BasicTests/txtest.json # noqa: 501
@@ -77,7 +91,7 @@ def web3js_password():
 @pytest.fixture(params=['instance', 'class'])
 def acct(request, web3):
     if request.param == 'instance':
-        return web3.eth.account
+        return BaseEth(web3).account
     elif request.param == 'class':
         return Account
     raise Exception('Unreachable!')
@@ -494,3 +508,26 @@ def test_eth_account_sign_and_send_EIP155_transaction_to_eth_tester(
     assert actual_txn.r == r
     assert actual_txn.s == s
     assert actual_txn.v == v
+
+
+# -- async -- #
+
+
+@pytest.fixture()
+def async_w3():
+    return Web3(AsyncEthereumTesterProvider(), modules={"eth": [AsyncEth]})
+
+
+@patch("web3.eth.BaseEth.account", "wired via BaseEth")
+def test_account_is_wired_via_base_eth_for_sync_and_async(w3, async_w3):
+    # this gives us some comfort that all the `w3` tests would apply for `async_w3` as
+    # well, since `Account` is static and not actually awaited
+    assert w3.eth.account == "wired via BaseEth"
+    assert async_w3.eth.account == "wired via BaseEth"
+
+
+def test_async_eth_account_creates_account(async_w3):
+    account = async_w3.eth.account.create()
+    assert isinstance(account, LocalAccount)
+    assert is_checksum_address(account.address)
+    assert is_bytes(account.key)

--- a/web3/eth.py
+++ b/web3/eth.py
@@ -112,6 +112,7 @@ from web3.types import (
 
 
 class BaseEth(Module):
+    account = Account()
     _default_account: Union[ChecksumAddress, Empty] = empty
     _default_block: BlockIdentifier = "latest"
     gasPriceStrategy = None
@@ -552,7 +553,6 @@ class AsyncEth(BaseEth):
 
 
 class Eth(BaseEth):
-    account = Account()
     defaultContractFactory: Type[Union[Contract, ConciseContract, ContractCaller]] = Contract  # noqa: E704,E501
     iban = Iban
 


### PR DESCRIPTION
### What was wrong?

backport of #2582

### How was it fixed?

- Move ``account`` into ``BaseEth``

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse3.mm.bing.net%2Fth%3Fid%3DOIP.v03npXrQrtIxAHDOoTjrvgHaE7%26pid%3DApi&f=1)
