### PR TITLE
 Classes inheriting from Web3 did not attach modules appropriately

### DIFF
--- a/newsfragments/2592.bugfix.rst
+++ b/newsfragments/2592.bugfix.rst
@@ -1,0 +1,1 @@
+Allow classes to inherit from the ``Web3`` class by attaching modules appropriately.

--- a/tests/core/web3-module/test_web3_inheritance.py
+++ b/tests/core/web3-module/test_web3_inheritance.py
@@ -1,0 +1,12 @@
+from web3 import (
+    EthereumTesterProvider,
+    Web3,
+)
+
+
+def test_classes_may_inherit_from_web3():
+    class InheritsFromWeb3(Web3):
+        pass
+
+    inherited_w3 = InheritsFromWeb3(EthereumTesterProvider())
+    assert inherited_w3.eth.chain_id == 131277322940537

--- a/web3/_utils/module.py
+++ b/web3/_utils/module.py
@@ -55,9 +55,14 @@ def attach_modules(
                 " The web3 object already has an attribute with that name"
             )
 
-        # The parent module is the ``Web3`` instance on first run of the loop
-        if type(parent_module).__name__ == "Web3":
-            w3 = parent_module
+        # The parent module is the ``Web3`` instance on first run of the loop and w3 is
+        # None. Thus, set w3 to the parent_module. The import needs to happen locally
+        # due to circular import issues.
+        if w3 is None:
+            from web3 import Web3
+
+            if isinstance(parent_module, Web3):
+                w3 = parent_module
 
         module_init_params = _validate_init_params_and_return_if_found(module_class)
         if len(module_init_params) == 1:


### PR DESCRIPTION
### What was wrong?

`v6` version of PR #2587

### How was it fixed?

* Bug fix: On the first run of ``attach_modules()``, ``w3`` should be ``None`` and the ``parent_module`` is the ``Web3`` class. We should look for this condition and set ``w3 = parent_module``. We couldn't use a simple ``isinstance()`` due to a circular import, but we can import it locally if ``w3`` is ``None``. This allows classes to inherit from ``Web3`` without needing to validate that the class name is ``Web3``. This also allows modules to not need to set a ``w3`` if they don't need one, as the older code was intended to do.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

<img width="1660" alt="Screen Shot 2022-08-01 at 09 39 43" src="https://user-images.githubusercontent.com/3532824/182187596-4f10f49f-f319-49c0-b3dc-140ac5d6c536.png">

