### PR TITLE
Abi  _utils to utils

### DIFF
--- a/docs/web3.utils.rst
+++ b/docs/web3.utils.rst
@@ -5,6 +5,21 @@ Utils
 
 The ``utils`` module houses public utility and helper functions.
 
+ABI
+---
+
+.. py:method:: Utils.get_abi_input_names(abi)
+
+    Return the ``input`` names for an ABI function or event.
+
+
+.. py:method:: Utils.get_abi_output_names(abi)
+
+    Return the ``output`` names an ABI function or event.
+
+
+Exception Handling
+------------------
 
 .. py:method:: Utils.handle_offchain_lookup(offchain_lookup_payload, transaction)
 

--- a/newsfragments/2596.feature.rst
+++ b/newsfragments/2596.feature.rst
@@ -1,0 +1,1 @@
+Expose public abi utility methods: ``get_abi_output_names()`` and ``get_abi_input_names()``

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -83,6 +83,9 @@ from web3.types import (
     ABIFunction,
     ABIFunctionParams,
 )
+from web3.utils import (  # public utils module
+    get_abi_input_names,
+)
 
 
 def filter_by_type(_type: str, contract_abi: ABI) -> List[Union[ABIFunction, ABIEvent]]:
@@ -107,25 +110,11 @@ def get_abi_input_types(abi: ABIFunction) -> List[str]:
         return [collapse_if_tuple(cast(Dict[str, Any], arg)) for arg in abi["inputs"]]
 
 
-def get_abi_input_names(abi: Union[ABIFunction, ABIEvent]) -> List[str]:
-    if "inputs" not in abi and abi["type"] == "fallback":
-        return []
-    else:
-        return [arg["name"] for arg in abi["inputs"]]
-
-
 def get_abi_output_types(abi: ABIFunction) -> List[str]:
     if abi["type"] == "fallback":
         return []
     else:
         return [collapse_if_tuple(cast(Dict[str, Any], arg)) for arg in abi["outputs"]]
-
-
-def get_abi_output_names(abi: Union[ABIFunction, ABIEvent]) -> List[str]:
-    if "outputs" not in abi and abi["type"] == "fallback":
-        return []
-    else:
-        return [arg["name"] for arg in abi["outputs"]]
 
 
 def get_receive_func_abi(contract_abi: ABI) -> ABIFunction:

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -107,6 +107,13 @@ def get_abi_input_types(abi: ABIFunction) -> List[str]:
         return [collapse_if_tuple(cast(Dict[str, Any], arg)) for arg in abi["inputs"]]
 
 
+def get_abi_input_names(abi: Union[ABIFunction, ABIEvent]) -> List[str]:
+    if "inputs" not in abi and abi["type"] == "fallback":
+        return []
+    else:
+        return [arg["name"] for arg in abi["inputs"]]
+
+
 def get_abi_output_types(abi: ABIFunction) -> List[str]:
     if abi["type"] == "fallback":
         return []
@@ -114,11 +121,11 @@ def get_abi_output_types(abi: ABIFunction) -> List[str]:
         return [collapse_if_tuple(cast(Dict[str, Any], arg)) for arg in abi["outputs"]]
 
 
-def get_abi_input_names(abi: Union[ABIFunction, ABIEvent]) -> List[str]:
-    if "inputs" not in abi and abi["type"] == "fallback":
+def get_abi_output_names(abi: Union[ABIFunction, ABIEvent]) -> List[str]:
+    if "outputs" not in abi and abi["type"] == "fallback":
         return []
     else:
-        return [arg["name"] for arg in abi["inputs"]]
+        return [arg["name"] for arg in abi["outputs"]]
 
 
 def get_receive_func_abi(contract_abi: ABI) -> ABIFunction:

--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -53,7 +53,6 @@ from eth_utils.toolz import (
 import web3
 from web3._utils.abi import (
     exclude_indexed_event_inputs,
-    get_abi_input_names,
     get_indexed_event_inputs,
     get_normalized_abi_arg_type,
     map_abi_data,
@@ -81,6 +80,9 @@ from web3.types import (
     EventData,
     FilterParams,
     LogReceipt,
+)
+from web3.utils import (
+    get_abi_input_names,
 )
 
 if TYPE_CHECKING:

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -53,7 +53,6 @@ from web3._utils.abi import (
     check_if_arguments_can_be_encoded,
     fallback_func_abi_exists,
     filter_by_type,
-    get_abi_input_names,
     get_abi_input_types,
     get_abi_output_types,
     get_constructor_abi,
@@ -145,6 +144,9 @@ from web3.types import (  # noqa: F401
     LogReceipt,
     TxParams,
     TxReceipt,
+)
+from web3.utils import (
+    get_abi_input_names,
 )
 
 if TYPE_CHECKING:

--- a/web3/utils/__init__.py
+++ b/web3/utils/__init__.py
@@ -1,3 +1,11 @@
+"""
+NOTE: This is a public utility module. Any changes to these utility methods would
+classify as breaking changes.
+"""
+from .abi import (  # NOQA
+    get_abi_input_names,
+    get_abi_output_names,
+)
 from .async_exception_handling import (  # NOQA
     async_handle_offchain_lookup,
 )

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -1,0 +1,21 @@
+from typing import (
+    List,
+    Union,
+)
+
+from web3.types import (
+    ABIEvent,
+    ABIFunction,
+)
+
+
+def get_abi_input_names(abi: Union[ABIFunction, ABIEvent]) -> List[str]:
+    if "inputs" not in abi and abi["type"] == "fallback":
+        return []
+    return [arg["name"] for arg in abi["inputs"]]
+
+
+def get_abi_output_names(abi: Union[ABIFunction]) -> List[str]:
+    if "outputs" not in abi and abi["type"] == "fallback":
+        return []
+    return [arg["name"] for arg in abi["outputs"]]


### PR DESCRIPTION
### What was wrong?

Cherry picked from PR #2496. Couldn't push to that branch and that PR went stale, so opened up a new one.

### How was it fixed?

- Moved the requested internal API utility methods over to the public utility API module. This can serve as a starting point for other useful ABI utility methods to be moved over eventually as well.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

baby stingrays
![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fi.redd.it%2F30yo73awdci11.jpg&f=1&nofb=1)
