### PR TITLE
[v5] Allow hex for ``value`` when validating via ``validate_payable()``

### DIFF
--- a/newsfragments/2609.bugfix.rst
+++ b/newsfragments/2609.bugfix.rst
@@ -1,0 +1,1 @@
+Allow hex for ``value`` field when validating via ``validate_payable()`` contracts method

--- a/tests/core/contracts/test_contract_util_functions.py
+++ b/tests/core/contracts/test_contract_util_functions.py
@@ -1,3 +1,8 @@
+import pytest
+
+from web3._utils.contracts import (
+    validate_payable,
+)
 from web3.contract import (
     parse_block_identifier_int,
 )
@@ -11,3 +16,10 @@ from web3.contract import (
 def test_parse_block_identifier_int(web3):
     last_num = web3.eth.get_block('latest').number
     assert 0 == parse_block_identifier_int(web3, -1 - last_num)
+
+
+@pytest.mark.parametrize("value", (0, "0x0", "0x00"))
+def test_validate_payable(value):
+    tx = {"value": value}
+    abi = {"payable": False}
+    validate_payable(tx, abi)

--- a/web3/_utils/contracts.py
+++ b/web3/_utils/contracts.py
@@ -53,6 +53,9 @@ from web3._utils.function_identifiers import (
     FallbackFn,
     ReceiveFn,
 )
+from web3._utils.method_formatters import (
+    to_integer_if_hex,
+)
 from web3._utils.normalizers import (
     abi_address_to_hex,
     abi_bytes_to_bytes,
@@ -313,10 +316,10 @@ def get_function_info(
 
 def validate_payable(transaction: TxParams, abi: ABIFunction) -> None:
     """Raise ValidationError if non-zero ether
-    is sent to a non payable function.
+    is sent to a non-payable function.
     """
     if 'value' in transaction:
-        if transaction['value'] != 0:
+        if to_integer_if_hex(transaction['value']) != 0:
             if "payable" in abi and not abi["payable"]:
                 raise ValidationError(
                     "Sending non-zero ether to a contract function "


### PR DESCRIPTION
### What was wrong?

`v5` port of `v6` PR #2602 

### How was it fixed?

- Use `to_integer_if_hex()` to appropriately convert hex values before comparison

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20220810_110429](https://user-images.githubusercontent.com/3532824/184405349-5cb62b0b-d6e8-4d4b-b396-571f9513b562.jpg)

