### PR TITLE
Pin protobuf to ``3.20.1``

### DIFF
--- a/newsfragments/2657.bugfix.rst
+++ b/newsfragments/2657.bugfix.rst
@@ -1,0 +1,1 @@
+Protobuf dependency breaks at version ``3.20.2`` and above; pin to ``3.20.1`` for now.

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         "ipfshttpclient==0.8.0a2",
         "jsonschema>=4.0.0,<5",
         "lru-dict>=1.1.6,<2.0.0",
-        "protobuf>=3.10.0,<4",
+        "protobuf==3.20.1",
         "pywin32>=223;platform_system=='Windows'",
         "requests>=2.16.0,<3.0.0",
         # remove typing_extensions after python_requires>=3.8, see web3._utils.compat


### PR DESCRIPTION
### What was wrong?

Relate to issue #2654 

- see: https://github.com/protocolbuffers/protobuf/issues/10051

### How was it fixed?

Pin `protobuf` to `3.20.1` for now

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20220918_174958](https://user-images.githubusercontent.com/3532824/191809650-07947916-7d83-45f7-9675-9e36c43955d1.jpg)
