### PR TITLE
Pin protobuf to ``3.19.4`` for now:

### DIFF
--- a/newsfragments/2659.bugfix.rst
+++ b/newsfragments/2659.bugfix.rst
@@ -1,0 +1,1 @@
+Protobuf dependency breaks at version ``3.20.2`` and above; pin to ``3.19.4`` for now since that is the last non-breaking version for python 3.6.

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
         "ipfshttpclient==0.8.0a2",
         "jsonschema>=3.2.0,<5",
         "lru-dict>=1.1.6,<2.0.0",
-        "protobuf>=3.10.0,<4",
+        "protobuf==3.19.4",
         "pywin32>=223;platform_system=='Windows'",
         "requests>=2.16.0,<3.0.0",
         # remove typing_extensions after python_requires>=3.8, see web3._utils.compat


### PR DESCRIPTION
### What was wrong?

Closes #2654
`v5` backport of #2657 with the exception that ``protobuf`` version ``3.19.4`` was the last non-breaking supported 3.x version for python ``3.6`` which ``web3.py`` ``v5`` still supports.

### How was it fixed?

See: #2657 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20220918_174958](https://user-images.githubusercontent.com/3532824/191812733-705287c6-d22a-4113-b5f7-395bc7c4a151.jpg)


