### PR TITLE
[WIP] Unpin ``protobuf``. The bug has been fixed on their end.

### DIFF
--- a/newsfragments/2664.misc.rst
+++ b/newsfragments/2664.misc.rst
@@ -1,0 +1,1 @@
+Unpin ``protobuf``. The bug has been fixed on their end.

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         "ipfshttpclient==0.8.0a2",
         "jsonschema>=4.0.0,<5",
         "lru-dict>=1.1.6,<2.0.0",
-        "protobuf==3.20.1",
+        "protobuf>=3.20.2<4",
         "pywin32>=223;platform_system=='Windows'",
         "requests>=2.16.0,<3.0.0",
         # remove typing_extensions after python_requires>=3.8, see web3._utils.compat


### PR DESCRIPTION
### What was wrong?

Related to Issue #

### How was it fixed?

Unpin ``protobuf`` dependency since they fixed the bug on their end.

- Start from version ``3.20.2`` since a security vulnerability was fixed there: https://github.com/advisories/GHSA-8gq9-2x98-w8hf
- Discussion here: https://github.com/protocolbuffers/protobuf/issues/10571

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
