### PR TITLE
Clean up old eth abi references

### DIFF
--- a/newsfragments/2668.internal.rst
+++ b/newsfragments/2668.internal.rst
@@ -1,0 +1,1 @@
+Clean up remaining uses of deprecated ``eth_abi`` methods.

--- a/newsfragments/README.md
+++ b/newsfragments/README.md
@@ -5,15 +5,17 @@ release notes. This should be a description of aspects of the change
 commit message and PR description, which are a description of the change as
 relevant to people working on the code itself.)
 
- Each file should be named like `<ISSUE>.<TYPE>.rst`, where
+Each file should be named like `<ISSUE>.<TYPE>.rst`, where
 `<ISSUE>` is an issue number, and `<TYPE>` is one of:
 
 * `feature`
 * `bugfix`
+* `performance`
 * `doc`
+* `internal`
+* `removal`
 * `misc`
-* `breaking-change`
-* `deprecation`
+* `breaking`
 
 So for example: `123.feature.rst`, `456.bugfix.rst`
 
@@ -22,5 +24,5 @@ then open up the PR first and use the PR number for the newsfragment.
 
 Note that the `towncrier` tool will automatically
 reflow your text, so don't try to do any fancy formatting. Run
-`towncrier --draft` to get a preview of what the release notes entry
+`towncrier build --draft` to get a preview of what the release notes entry
 will look like in the final release notes.

--- a/newsfragments/validate_files.py
+++ b/newsfragments/validate_files.py
@@ -7,12 +7,14 @@ import pathlib
 import sys
 
 ALLOWED_EXTENSIONS = {
+    '.breaking.rst',
     '.bugfix.rst',
     '.doc.rst',
     '.feature.rst',
+    '.internal.rst',
     '.misc.rst',
-    '.breaking-change.rst',
-    '.deprecation.rst',
+    '.performance.rst',
+    '.removal.rst',
 }
 
 ALLOWED_FILES = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,34 +7,44 @@
     title_format = "v{version} ({project_date})"
 
 [[tool.towncrier.type]]
-directory = "breaking-change"
-name="Breaking Changes"
-showcontent=true
-
-[[tool.towncrier.type]]
-directory = "deprecation"
-name = "Deprecations"
+directory = "feature"
+name = "Features"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "bugfix"
-name="Bugfixes"
-showcontent=true
+name = "Bugfixes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "performance"
+name = "Performance improvements"
+showcontent = true
 
 [[tool.towncrier.type]]
 directory = "doc"
-name="Documentation Updates"
-showcontent=true
+name = "Improved Documentation"
+showcontent = true
 
 [[tool.towncrier.type]]
-directory = "feature"
-name="Features"
-showcontent=true
+directory = "removal"
+name = "Deprecations and Removals"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "internal"
+name = "Internal Changes - for web3.py Contributors"
+showcontent = true
 
 [[tool.towncrier.type]]
 directory = "misc"
-name="Misc"
-showcontent=false
+name = "Miscellaneous changes"
+showcontent = false
+
+[[tool.towncrier.type]]
+directory = "breaking"
+name = "Breaking changes"
+showcontent = true
 
 [tool.isort]
 profile="black"

--- a/tests/core/contracts/test_offchain_lookup.py
+++ b/tests/core/contracts/test_offchain_lookup.py
@@ -1,7 +1,7 @@
 import pytest
 
 from eth_abi import (
-    decode,
+    abi,
 )
 
 from web3._utils.module_testing.module_testing_utils import (
@@ -74,7 +74,7 @@ def test_offchain_lookup_functionality(
     response = offchain_lookup_contract.caller.testOffchainLookup(
         OFFCHAIN_LOOKUP_TEST_DATA
     )
-    assert decode(["string"], response)[0] == "web3py"
+    assert abi.decode(["string"], response)[0] == "web3py"
 
 
 def test_eth_call_offchain_lookup_raises_when_ccip_read_is_disabled(
@@ -123,7 +123,7 @@ def test_offchain_lookup_call_flag_overrides_provider_flag(
     response = offchain_lookup_contract.functions.testOffchainLookup(
         OFFCHAIN_LOOKUP_TEST_DATA
     ).call(ccip_read_enabled=True)
-    assert decode(["string"], response)[0] == "web3py"
+    assert abi.decode(["string"], response)[0] == "web3py"
 
     w3.provider.global_ccip_read_enabled = True
 
@@ -176,7 +176,7 @@ def test_eth_call_offchain_lookup_tries_next_url_for_non_4xx_error_status_and_te
     response = offchain_lookup_contract.caller.testOffchainLookup(
         OFFCHAIN_LOOKUP_TEST_DATA
     )
-    assert decode(["string"], response)[0] == "web3py"
+    assert abi.decode(["string"], response)[0] == "web3py"
 
 
 @pytest.mark.parametrize("status_code_4xx_error", [400, 410, 450, 499])

--- a/web3/_utils/async_transactions.py
+++ b/web3/_utils/async_transactions.py
@@ -8,7 +8,7 @@ from typing import (
 )
 
 from eth_abi import (
-    encode,
+    abi,
 )
 from eth_typing import (
     URI,
@@ -199,7 +199,7 @@ async def async_handle_offchain_lookup(
                 # 4-byte callback function selector
                 to_bytes_if_hex(offchain_lookup_payload["callbackFunction"]),
                 # encode the `data` from the result and the `extraData` as bytes
-                encode(
+                abi.encode(
                     ["bytes", "bytes"],
                     [
                         to_bytes_if_hex(result["data"]),

--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -127,7 +127,7 @@ def construct_event_topic_set(
         [
             None
             if option is None
-            else encode_hex(abi_codec.encode_single(arg["type"], option))
+            else encode_hex(abi_codec.encode([arg["type"]], [option]))
             for option in arg_options
         ]
         for arg, arg_options in zipped_abi_and_args
@@ -169,7 +169,7 @@ def construct_event_data_set(
         [
             None
             if option is None
-            else encode_hex(abi_codec.encode_single(arg["type"], option))
+            else encode_hex(abi_codec.encode([arg["type"]], [option]))
             for option in arg_options
         ]
         for arg, arg_options in zipped_abi_and_args
@@ -252,7 +252,7 @@ def get_event_data(
     )
 
     decoded_topic_data = [
-        abi_codec.decode_single(topic_type, topic_data)
+        abi_codec.decode([topic_type], topic_data)[0]
         for topic_type, topic_data in zip(log_topic_types, log_topics)
     ]
     normalized_topic_data = map_abi_data(
@@ -517,7 +517,7 @@ class TopicArgumentFilter(BaseArgumentFilter):
         if is_dynamic_sized_type(self.arg_type):
             return to_hex(keccak(encode_single_packed(self.arg_type, value)))
         else:
-            return to_hex(self.abi_codec.encode_single(self.arg_type, value))
+            return to_hex(self.abi_codec.encode([self.arg_type], [value]))
 
 
 class EventLogErrorFlags(Enum):

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -13,7 +13,7 @@ from typing import (
 )
 
 from eth_abi import (
-    decode,
+    abi,
 )
 from eth_typing import (
     HexStr,
@@ -623,7 +623,9 @@ def raise_solidity_error_on_revert(response: RPCResponse) -> RPCResponse:
     # OffchainLookup(address,string[],bytes,bytes4,bytes)
     if data[:10] == "0x556f1830":
         parsed_data_as_bytes = to_bytes(hexstr=data[10:])
-        abi_decoded_data = decode(OFFCHAIN_LOOKUP_FIELDS.values(), parsed_data_as_bytes)
+        abi_decoded_data = abi.decode(
+            OFFCHAIN_LOOKUP_FIELDS.values(), parsed_data_as_bytes
+        )
         offchain_lookup_payload = dict(
             zip(OFFCHAIN_LOOKUP_FIELDS.keys(), abi_decoded_data)
         )

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -747,7 +747,7 @@ class AsyncEthModuleTest:
         )
         call_result = await async_w3.eth.call(txn_params)  # type: ignore
         assert is_string(call_result)
-        result = async_w3.codec.decode_single("uint256", call_result)
+        (result,) = async_w3.codec.decode(["uint256"], call_result)
         assert result == 18
 
     @pytest.mark.asyncio
@@ -760,7 +760,7 @@ class AsyncEthModuleTest:
             transaction={"from": coinbase, "to": revert_contract.address},
         )
         call_result = await async_w3.eth.call(txn_params)  # type: ignore
-        result = async_w3.codec.decode_single("bool", call_result)
+        (result,) = async_w3.codec.decode(["bool"], call_result)
         assert result is True
 
         # override runtime bytecode: `normalFunction` returns `false`
@@ -770,7 +770,7 @@ class AsyncEthModuleTest:
         call_result = await async_w3.eth.call(  # type: ignore
             txn_params, "latest", {revert_contract.address: {"code": override_code}}
         )
-        result = async_w3.codec.decode_single("bool", call_result)
+        (result,) = async_w3.codec.decode(["bool"], call_result)
         assert result is False
 
     @pytest.mark.asyncio
@@ -785,7 +785,7 @@ class AsyncEthModuleTest:
         )
         call_result = await async_w3.eth.call(txn_params)  # type: ignore
         assert is_string(call_result)
-        result = async_w3.codec.decode_single("uint256", call_result)
+        (result,) = async_w3.codec.decode(["uint256"], call_result)
         assert result == 0
 
     @pytest.mark.asyncio
@@ -2569,7 +2569,7 @@ class EthModuleTest:
         )
         call_result = w3.eth.call(txn_params)
         assert is_string(call_result)
-        result = w3.codec.decode_single("uint256", call_result)
+        (result,) = w3.codec.decode(["uint256"], call_result)
         assert result == 18
 
     def test_eth_call_with_override(
@@ -2581,7 +2581,7 @@ class EthModuleTest:
             transaction={"from": coinbase, "to": revert_contract.address},
         )
         call_result = w3.eth.call(txn_params)
-        result = w3.codec.decode_single("bool", call_result)
+        (result,) = w3.codec.decode(["bool"], call_result)
         assert result is True
 
         # override runtime bytecode: `normalFunction` returns `false`
@@ -2591,7 +2591,7 @@ class EthModuleTest:
         call_result = w3.eth.call(
             txn_params, "latest", {revert_contract.address: {"code": override_code}}
         )
-        result = w3.codec.decode_single("bool", call_result)
+        (result,) = w3.codec.decode(["bool"], call_result)
         assert result is False
 
     def test_eth_call_with_0_result(
@@ -2605,7 +2605,7 @@ class EthModuleTest:
         )
         call_result = w3.eth.call(txn_params)
         assert is_string(call_result)
-        result = w3.codec.decode_single("uint256", call_result)
+        (result,) = w3.codec.decode(["uint256"], call_result)
         assert result == 0
 
     def test_eth_call_revert_with_msg(

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -13,8 +13,8 @@ from typing import (
     Type,
 )
 
-from eth_abi.abi import (
-    decode,
+from eth_abi import (
+    abi,
 )
 from eth_tester.exceptions import (
     BlockNotFound,
@@ -89,7 +89,7 @@ def call_eth_tester(
             data_payload = parsed_data_as_bytes[
                 4:
             ]  # everything but the function selector
-            abi_decoded_data = decode(OFFCHAIN_LOOKUP_FIELDS.values(), data_payload)
+            abi_decoded_data = abi.decode(OFFCHAIN_LOOKUP_FIELDS.values(), data_payload)
             offchain_lookup_payload = dict(
                 zip(OFFCHAIN_LOOKUP_FIELDS.keys(), abi_decoded_data)
             )

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -8,7 +8,7 @@ from typing import (
 )
 
 from eth_abi import (
-    decode_single,
+    abi,
 )
 from eth_abi.exceptions import (
     InsufficientDataBytes,
@@ -76,7 +76,7 @@ class AsyncEthereumTesterProvider(AsyncBaseProvider):
             )
         except TransactionFailed as e:
             try:
-                reason = decode_single("(string)", e.args[0].args[0][4:])[0]
+                reason = abi.decode(["(string)"], e.args[0].args[0][4:])[0]
             except (InsufficientDataBytes, AttributeError):
                 reason = e.args[0]
             raise TransactionFailed(f"execution reverted: {reason}")
@@ -148,7 +148,7 @@ class EthereumTesterProvider(BaseProvider):
             )
         except TransactionFailed as e:
             try:
-                reason = decode_single("(string)", e.args[0].args[0][4:])[0]
+                reason = abi.decode(["(string)"], e.args[0].args[0][4:])[0]
             except (InsufficientDataBytes, AttributeError):
                 reason = e.args[0]
             raise TransactionFailed(f"execution reverted: {reason}")

--- a/web3/utils/async_exception_handling.py
+++ b/web3/utils/async_exception_handling.py
@@ -4,7 +4,7 @@ from typing import (
 )
 
 from eth_abi import (
-    encode,
+    abi,
 )
 from eth_typing import (
     URI,
@@ -81,7 +81,7 @@ async def async_handle_offchain_lookup(
                 # 4-byte callback function selector
                 to_bytes_if_hex(offchain_lookup_payload["callbackFunction"]),
                 # encode the `data` from the result and the `extraData` as bytes
-                encode(
+                abi.encode(
                     ["bytes", "bytes"],
                     [
                         to_bytes_if_hex(result["data"]),

--- a/web3/utils/exception_handling.py
+++ b/web3/utils/exception_handling.py
@@ -4,7 +4,7 @@ from typing import (
 )
 
 from eth_abi import (
-    encode,
+    abi,
 )
 from eth_typing import (
     URI,
@@ -83,7 +83,7 @@ def handle_offchain_lookup(
                 # 4-byte callback function selector
                 to_bytes_if_hex(offchain_lookup_payload["callbackFunction"]),
                 # encode the `data` from the result and the `extraData` as bytes
-                encode(
+                abi.encode(
                     ["bytes", "bytes"],
                     [
                         to_bytes_if_hex(result["data"]),


### PR DESCRIPTION
### What was wrong?

Related to Issue ethereum/eth-abi#161

### How was it fixed?

- Use ``abi.decode()`` over the deprecated ``abi.decode_single()``
- Since "encode" and "decode" are common across many libraries, import ``abi`` and use ``abi.encode()`` and ``abi.decode()`` so a reader can have more context when reading the code.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20221006_210324](https://user-images.githubusercontent.com/3532824/194668953-c3aab983-0413-429b-8a45-ad890aaf4295.jpg)

