### PR TITLE
Unique cache keys

### DIFF
--- a/newsfragments/2690.bugfix.rst
+++ b/newsfragments/2690.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug to generate unique cache keys when multi-threading & with unique event loops for async.

--- a/newsfragments/2690.misc.rst
+++ b/newsfragments/2690.misc.rst
@@ -1,0 +1,1 @@
+Increase request session cache size from ``20`` to ``100``.

--- a/web3/_utils/request.py
+++ b/web3/_utils/request.py
@@ -74,7 +74,7 @@ def get_default_http_endpoint() -> URI:
     return URI(os.environ.get("WEB3_HTTP_PROVIDER_URI", "http://localhost:8545"))
 
 
-_session_cache = SessionCache(size=20)
+_session_cache = SessionCache(size=100)
 _session_cache_lock = threading.Lock()
 
 
@@ -145,7 +145,7 @@ def _close_evicted_sessions(evicted_sessions: List[requests.Session]) -> None:
 # --- async --- #
 
 
-_async_session_cache = SessionCache(size=20)
+_async_session_cache = SessionCache(size=100)
 _async_session_cache_lock = threading.Lock()
 _pool = ThreadPoolExecutor(max_workers=1)
 

--- a/web3/_utils/request.py
+++ b/web3/_utils/request.py
@@ -81,7 +81,8 @@ _session_cache_lock = threading.Lock()
 def cache_and_return_session(
     endpoint_uri: URI, session: requests.Session = None
 ) -> requests.Session:
-    cache_key = generate_cache_key(endpoint_uri)
+    # cache key should have a unique thread identifier
+    cache_key = generate_cache_key(f"{threading.get_ident()}:{endpoint_uri}")
 
     evicted_items = None
     with _session_cache_lock:
@@ -153,7 +154,8 @@ async def cache_and_return_async_session(
     endpoint_uri: URI,
     session: Optional[ClientSession] = None,
 ) -> ClientSession:
-    cache_key = generate_cache_key(endpoint_uri)
+    # cache key should have a unique thread identifier
+    cache_key = generate_cache_key(f"{threading.get_ident()}:{endpoint_uri}")
 
     evicted_items = None
     async with async_lock(_async_session_cache_lock):


### PR DESCRIPTION
### What was wrong?

closes #2680

### How was it fixed?

- Use unique cache keys per thread, utilizing the thread id, in both sync and async versions of ``cache_and_return_session`` in ``requests.py``

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20221021_094338](https://user-images.githubusercontent.com/3532824/197294723-c71b1853-4fc5-4784-ae64-5ed3ee53c0b4.jpg)

