### PR TITLE
Fix bug with ``async_lock`` implementation

### DIFF
--- a/newsfragments/2695.bugfix.rst
+++ b/newsfragments/2695.bugfix.rst
@@ -1,0 +1,1 @@
+Properly release ``async_lock`` for session requests if an exception is raised during a task.

--- a/tests/core/utilities/test_request.py
+++ b/tests/core/utilities/test_request.py
@@ -29,6 +29,8 @@ from web3._utils.caching import (
 )
 from web3._utils.request import (
     SessionCache,
+    _async_session_cache_lock,
+    async_lock,
     cache_and_return_async_session,
     cache_and_return_session,
 )
@@ -323,3 +325,23 @@ async def test_async_unique_cache_keys_created_per_thread_with_same_uri():
 
     # clear cache
     request._async_session_cache.clear()
+
+
+@pytest.mark.asyncio
+async def test_async_lock_releases_if_a_task_is_cancelled():
+    # inspired by issue #2693
+    # Note: this test will raise a `TimeoutError` if `request.async_lock` is not
+    # applied correctly
+
+    async def _utilize_async_lock():
+        async with async_lock(_async_session_cache_lock):
+            await asyncio.sleep(0.2)
+
+    asyncio.create_task(_utilize_async_lock())
+
+    inner = asyncio.create_task(_utilize_async_lock())
+    await asyncio.sleep(0.1)
+    inner.cancel()
+
+    outer = asyncio.wait_for(_utilize_async_lock(), 2)
+    await outer

--- a/web3/_utils/request.py
+++ b/web3/_utils/request.py
@@ -196,8 +196,8 @@ async def cache_and_return_async_session(
 @contextlib.asynccontextmanager
 async def async_lock(lock: threading.Lock) -> AsyncGenerator[None, None]:
     loop = asyncio.get_event_loop()
-    await loop.run_in_executor(_pool, lock.acquire)
     try:
+        await loop.run_in_executor(_pool, lock.acquire)
         yield
     finally:
         lock.release()


### PR DESCRIPTION
### What was wrong?

closes #2693 

### How was it fixed?

- Properly close ``async_lock`` if something goes wrong during a task.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20221026_111149](https://user-images.githubusercontent.com/3532824/198104021-05c233c8-3fe9-4268-906b-583e5c3f13a3.jpg)

