### PR TITLE
Async session cache improvements

### DIFF
--- a/newsfragments/2713.feature.rst
+++ b/newsfragments/2713.feature.rst
@@ -1,0 +1,1 @@
+If the loop for a cached async session is closed, or the session itself was closed, create a new session at that cache key and properly close and evict the stale session.


### PR DESCRIPTION
### What was wrong?

I believe this closes #2597. That issue is a bit stale so we'll see if it gets re-opened after these changes are in.

### How was it fixed?

- If the loop for a cached async session is closed, or the session itself was closed, create a new session at that cache key and properly close and evict the stale session.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20221102_222308](https://user-images.githubusercontent.com/3532824/200931964-cdcb2fea-18dc-4cfa-9d85-aea237d011cd.jpg)

