### PR TITLE
Use build for build commands.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ ethpm_steps: &ethpm_steps
         key: ethpm-cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 orbs:
-  win: circleci/windows@2.2.0
+  win: circleci/windows@5.0.0
 
 windows_steps: &windows_steps
   executor:
@@ -199,7 +199,7 @@ windows_steps: &windows_steps
         command: pip install --user tox
     - run:
         name: run tox
-        command: 'C:/Users/circleci/AppData/Roaming/Python/Python37/Scripts/tox.exe -r'
+        command: 'C:/Users/circleci.PACKER-633B1A5A/AppData/Roaming/Python/Python310/Scripts/tox.exe -r'
     - save_cache:
         paths:
           - .tox
@@ -311,11 +311,6 @@ jobs:
       - image: cimg/python:3.7
     environment:
       TOXENV: py37-wheel-cli
-
-  py37-wheel-cli-windows:
-    <<: *windows_steps
-    environment:
-      TOXENV: py37-wheel-cli-windows
 
   #
   # Python 3.8
@@ -629,6 +624,11 @@ jobs:
         environment:
           TOXENV: py310-wheel-cli
 
+  py310-wheel-cli-windows:
+    <<: *windows_steps
+    environment:
+      TOXENV: py310-wheel-cli-windows
+
   #
   # Python 3.11
   #
@@ -764,7 +764,6 @@ workflows:
       - py37-integration-goethereum-ws_flaky
       - py37-integration-ethtester-pyevm
       - py37-wheel-cli
-      - py37-wheel-cli-windows
       - py38-lint
       - py38-ens
       - py38-ethpm
@@ -801,6 +800,7 @@ workflows:
       - py310-integration-goethereum-ws_flaky
       - py310-integration-ethtester-pyevm
       - py310-wheel-cli
+      - py310-wheel-cli-windows
       - py311-lint
       - py311-ens
       - py311-ethpm

--- a/Makefile
+++ b/Makefile
@@ -72,14 +72,14 @@ release: clean
 	git config commit.gpgSign true
 	bumpversion $(bump)
 	git push upstream && git push upstream --tags
-	python setup.py sdist bdist_wheel
+	python -m build
 	twine upload dist/*
 	git config commit.gpgSign "$(CURRENT_SIGN_SETTING)"
 
 dist: clean
-	python setup.py sdist bdist_wheel
+	python -m build
 	ls -l dist
 
 package: clean
-	python setup.py sdist bdist_wheel
+	python -m build
 	python web3/scripts/release/test_package.py

--- a/newsfragments/2714.internal.rst
+++ b/newsfragments/2714.internal.rst
@@ -1,0 +1,1 @@
+Do not invoke ``setup.py`` directly; use ``python -m build`` where appropriate.

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ extras_require = {
         "twine>=1.13",
         "pluggy==0.13.1",
         "when-changed>=0.3.0",
+        "build>=0.9.0",
     ],
     "ipfs": [
         "ipfshttpclient==0.8.0a2",

--- a/tox.ini
+++ b/tox.ini
@@ -72,60 +72,30 @@ commands=
     python {toxinidir}/web3/tools/benchmark/main.py --num-calls 50
     python {toxinidir}/web3/tools/benchmark/main.py --num-calls 100
 
-[common-wheel-cli]
-deps=wheel
+[testenv:py{37,38,39,310,311}-wheel-cli]
+deps=
+    wheel
+    build
 allowlist_externals=
     /bin/rm
     /bin/bash
 commands=
     pip install --upgrade pip
     /bin/rm -rf build dist
-    python setup.py sdist bdist_wheel
+    python -m build
     /bin/bash -c 'pip install --upgrade "$(ls dist/web3-*-py3-none-any.whl)" --progress-bar off'
     python -c "from web3 import Web3"
-
-[testenv:py37-wheel-cli]
-deps={[common-wheel-cli]deps}
-allowlist_externals={[common-wheel-cli]allowlist_externals}
-commands={[common-wheel-cli]commands}
 skip_install=true
 
-[testenv:py38-wheel-cli]
-deps={[common-wheel-cli]deps}
-allowlist_externals={[common-wheel-cli]allowlist_externals}
-commands={[common-wheel-cli]commands}
-skip_install=true
-
-[testenv:py39-wheel-cli]
-deps={[common-wheel-cli]deps}
-allowlist_externals={[common-wheel-cli]allowlist_externals}
-commands={[common-wheel-cli]commands}
-skip_install=true
-
-[testenv:py310-wheel-cli]
-deps={[common-wheel-cli]deps}
-allowlist_externals={[common-wheel-cli]allowlist_externals}
-commands={[common-wheel-cli]commands}
-skip_install=true
-
-[testenv:py311-wheel-cli]
-deps={[common-wheel-cli]deps}
-allowlist_externals={[common-wheel-cli]allowlist_externals}
-commands={[common-wheel-cli]commands}
-skip_install=true
-
-[common-wheel-cli-windows]
-deps=wheel
+[testenv:py310-wheel-cli-windows]
+deps=
+    wheel
+    build[virtualenv]
 allowlist_externals=
     bash.exe
 commands=
     bash.exe -c "rm -rf build dist"
-    python setup.py sdist bdist_wheel
+    python -m build
     bash.exe -c 'pip install --upgrade "$(ls dist/web3-*-py3-none-any.whl)" --progress-bar off'
     python -c "from web3 import Web3"
-
-[testenv:py37-wheel-cli-windows]
-deps={[common-wheel-cli]deps}
-allowlist_externals={[common-wheel-cli-windows]allowlist_externals}
-commands={[common-wheel-cli-windows]commands}
 skip_install=true


### PR DESCRIPTION
### What was wrong?

Remove direct invocations of ``setup.py``

### How was it fixed?

- Removed direct invocations of ``setup.py`` and replaced with ``python -m build``
- Use circleci orb `windows@5.0.0` which uses `py310` + change tox path to reflect this new path in `config.yml`
- Consolidate `tox.ini` testenvs

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.rainforest-alliance.org/wp-content/uploads/2021/06/three-toed-sloth-teaser-1.jpg.optimal.jpg)
