### PR TITLE
Performance updates to ``SimpleCache``, session cache, cache middlewares

### DIFF
--- a/newsfragments/2719.feature.rst
+++ b/newsfragments/2719.feature.rst
@@ -1,0 +1,1 @@
+Some minor performance improvements to the ``SimpleCache`` class and simple cache middlewares (sync and async).

--- a/web3/_utils/module_testing/module_testing_utils.py
+++ b/web3/_utils/module_testing/module_testing_utils.py
@@ -26,7 +26,7 @@ from web3._utils.compat import (
     Literal,
 )
 from web3._utils.request import (
-    cache_and_return_async_session,
+    async_cache_and_return_session,
     cache_and_return_session,
 )
 from web3.types import (
@@ -153,7 +153,7 @@ def async_mock_offchain_lookup_request_response(
             return AsyncMockedResponse()
 
         # else, make a normal request (no mocking)
-        session = await cache_and_return_async_session(url_from_args)
+        session = await async_cache_and_return_session(url_from_args)
         return await session.request(
             method=http_method.upper(), url=url_from_args, **kwargs
         )

--- a/web3/providers/async_rpc.py
+++ b/web3/providers/async_rpc.py
@@ -22,8 +22,8 @@ from web3._utils.http import (
     construct_user_agent,
 )
 from web3._utils.request import (
+    async_cache_and_return_session as _async_cache_and_return_session,
     async_make_post_request,
-    cache_and_return_async_session as _cache_and_return_async_session,
     get_default_http_endpoint,
 )
 from web3.types import (
@@ -56,7 +56,7 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
         super().__init__()
 
     async def cache_async_session(self, session: ClientSession) -> ClientSession:
-        return await _cache_and_return_async_session(self.endpoint_uri, session)
+        return await _async_cache_and_return_session(self.endpoint_uri, session)
 
     def __str__(self) -> str:
         return f"RPC connection {self.endpoint_uri}"

--- a/web3/utils/caching.py
+++ b/web3/utils/caching.py
@@ -5,6 +5,7 @@ from typing import (
     Any,
     Dict,
     Optional,
+    Tuple,
 )
 
 
@@ -13,7 +14,7 @@ class SimpleCache:
         self._size = size
         self._data: OrderedDict[str, Any] = OrderedDict()
 
-    def cache(self, key: str, value: Any) -> Dict[str, Any]:
+    def cache(self, key: str, value: Any) -> Tuple[Any, Dict[str, Any]]:
         evicted_items = None
         # If the key is already in the OrderedDict just update it
         # and don't evict any values. Ideally, we could still check to see
@@ -26,7 +27,10 @@ class SimpleCache:
                 k, v = self._data.popitem(last=False)
                 evicted_items[k] = v
         self._data[key] = value
-        return evicted_items
+
+        # Return the cached value along with the evicted items at the same time. No
+        # need to reach back into the cache to grab the value.
+        return value, evicted_items
 
     def get_cache_entry(self, key: str) -> Optional[Any]:
         return self._data[key] if key in self._data else None


### PR DESCRIPTION
### What was wrong?

Some performance considerations for when to lock the cache.

- Return the cached `value` at the same time as the `evicted_items` rather than reaching back into the cache for it. There's no reason to reach back into the cache for it.
- Only lock the cache when necessary. I think we were locking the cache a bit too early in almost all cases here. One exception is the async session cache since a session that is cached can be considered stale. That case was left alone as it should be under lock the whole time.

### How was it fixed?

- Lock cache only when necessary.
- Return the cached value from `SimpleCache` at the same time as the evicted items.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

My beloved former pigmy goat, Bootsy, as a kid:

![5](https://user-images.githubusercontent.com/3532824/202551027-4090b786-0129-4dcf-ba92-a1103bec6ffa.jpg)
