### PR TITLE
Replace eth-abi deprecated method usage with supported methods

### DIFF
--- a/newsfragments/2726.internal.rst
+++ b/newsfragments/2726.internal.rst
@@ -1,0 +1,1 @@
+Remove references to deprecated ``eth-abi`` methods and replace with supported methods.

--- a/newsfragments/README.md
+++ b/newsfragments/README.md
@@ -5,13 +5,17 @@ release notes. This should be a description of aspects of the change
 commit message and PR description, which are a description of the change as
 relevant to people working on the code itself.)
 
- Each file should be named like `<ISSUE>.<TYPE>.rst`, where
+Each file should be named like `<ISSUE>.<TYPE>.rst`, where
 `<ISSUE>` is an issue number, and `<TYPE>` is one of:
 
 * `feature`
 * `bugfix`
+* `performance`
 * `doc`
+* `internal`
+* `removal`
 * `misc`
+* `breaking`
 
 So for example: `123.feature.rst`, `456.bugfix.rst`
 
@@ -21,4 +25,4 @@ then open up the PR first and use the PR number for the newsfragment.
 Note that the `towncrier` tool will automatically
 reflow your text, so don't try to do any fancy formatting. Run
 `towncrier --draft` to get a preview of what the release notes entry
-will look like in the final release notes.
+ will look like in the final release notes.

--- a/newsfragments/validate_files.py
+++ b/newsfragments/validate_files.py
@@ -7,10 +7,13 @@ import pathlib
 import sys
 
 ALLOWED_EXTENSIONS = {
+    '.breaking.rst',
     '.bugfix.rst',
     '.doc.rst',
     '.feature.rst',
+    '.internal.rst',
     '.misc.rst',
+    '.performance.rst',
     '.removal.rst',
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,43 @@
     underlines = ["-", "~", "^"]
     issue_format = "`#{issue} <https://github.com/ethereum/web3.py/issues/{issue}>`__"
     title_format = "v{version} ({project_date})"
+
+[[tool.towncrier.type]]
+directory = "feature"
+name = "Features"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "bugfix"
+name = "Bugfixes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "performance"
+name = "Performance improvements"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "doc"
+name = "Improved Documentation"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "removal"
+name = "Deprecations and Removals"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "internal"
+name = "Internal Changes - for web3.py Contributors"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "misc"
+name = "Miscellaneous changes"
+showcontent = false
+
+[[tool.towncrier.type]]
+directory = "breaking"
+name = "Breaking changes"
+showcontent = true

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import (
 
 extras_require = {
     "tester": [
-        "eth-tester[py-evm]==v0.6.0-beta.6",
+        "eth-tester[py-evm]==v0.6.0-beta.7",
         "py-geth>=3.9.1,<4",
     ],
     "linter": [

--- a/tests/core/contracts/test_contract_constructor_encoding.py
+++ b/tests/core/contracts/test_contract_constructor_encoding.py
@@ -56,7 +56,7 @@ def test_error_if_invalid_arguments_supplied(WithConstructorArgumentsContract, a
 def test_contract_constructor_encoding_encoding(web3, WithConstructorArgumentsContract, bytes_arg):
     deploy_data = WithConstructorArgumentsContract._encode_constructor_data([1234, bytes_arg])
     encoded_args = '0x00000000000000000000000000000000000000000000000000000000000004d26162636400000000000000000000000000000000000000000000000000000000'  # noqa: E501
-    expected_ending = encode_hex(web3.codec.encode_abi(['uint256', 'bytes32'], [1234, b'abcd']))
+    expected_ending = encode_hex(web3.codec.encode(['uint256', 'bytes32'], [1234, b'abcd']))
     assert expected_ending == encoded_args
     assert deploy_data.endswith(remove_0x_prefix(expected_ending))
 
@@ -70,7 +70,7 @@ def test_contract_constructor_encoding_encoding_warning(web3, WithConstructorArg
         encoded_args = '0x00000000000000000000000000000000000000000000000000000000000004d26162636400000000000000000000000000000000000000000000000000000000'  # noqa: E501
 
         expected_ending = encode_hex(
-            web3.codec.encode_abi(['uint256', 'bytes32'], [1234, b'abcd'])
+            web3.codec.encode(['uint256', 'bytes32'], [1234, b'abcd'])
         )
         assert expected_ending == encoded_args
         assert deploy_data.endswith(remove_0x_prefix(expected_ending))
@@ -92,7 +92,7 @@ def test_contract_constructor_encoding_encoding_strict(
     deploy_data = WithConstructorArgumentsContractStrict._encode_constructor_data([1234, bytes_arg])
 
     expected_ending = encode_hex(
-        w3_strict_abi.codec.encode_abi(['uint256', 'bytes32'], [1234, bytes_arg])
+        w3_strict_abi.codec.encode(['uint256', 'bytes32'], [1234, bytes_arg])
     )
     assert expected_ending == encoded_args
     assert deploy_data.endswith(remove_0x_prefix(expected_ending))

--- a/tests/core/contracts/test_extracting_event_data.py
+++ b/tests/core/contracts/test_extracting_event_data.py
@@ -342,7 +342,7 @@ def test_argument_extraction_strict_bytes_types(w3_strict_abi,
     event_topic = emitter_log_topics.LogListArgs
     assert event_topic in log_entry['topics']
 
-    encoded_arg_0 = w3_strict_abi.codec.encode_abi(['bytes2'], arg_0)
+    encoded_arg_0 = w3_strict_abi.codec.encode(['bytes2'], arg_0)
     padded_arg_0 = encoded_arg_0.ljust(32, b'\x00')
     arg_0_topic = w3_strict_abi.keccak(padded_arg_0)
     assert arg_0_topic in log_entry['topics']

--- a/tests/core/filtering/test_utils_functions.py
+++ b/tests/core/filtering/test_utils_functions.py
@@ -130,7 +130,7 @@ from web3._utils.filters import (
 )
 def test_match_fn_with_various_data_types(web3, data, expected, match_data_and_abi):
     abi_types, match_data = zip(*match_data_and_abi)
-    encoded_data = web3.codec.encode_abi(abi_types, data)
+    encoded_data = web3.codec.encode(abi_types, data)
     assert match_fn(web3.codec, match_data_and_abi, encoded_data) == expected
 
 
@@ -205,7 +205,7 @@ def test_match_fn_with_various_data_types_strict(w3_strict_abi,
                                                  expected,
                                                  match_data_and_abi):
     abi_types, match_data = zip(*match_data_and_abi)
-    encoded_data = w3_strict_abi.codec.encode_abi(abi_types, data)
+    encoded_data = w3_strict_abi.codec.encode(abi_types, data)
     assert match_fn(w3_strict_abi.codec, match_data_and_abi, encoded_data) == expected
 
 
@@ -221,7 +221,7 @@ def test_encode_abi_with_wrong_types_strict(w3_strict_abi,
                                             data,
                                             abi_type):
     with pytest.raises(ValueOutOfBounds):
-        w3_strict_abi.codec.encode_abi(abi_type, data)
+        w3_strict_abi.codec.encode(abi_type, data)
 
 
 def test_wrong_type_match_data(web3):
@@ -231,6 +231,6 @@ def test_wrong_type_match_data(web3):
         ("string", (50505050,)),
     )
     abi_types, match_data = zip(*match_data_and_abi)
-    encoded_data = web3.codec.encode_abi(abi_types, data)
+    encoded_data = web3.codec.encode(abi_types, data)
     with pytest.raises(ValueError):
         match_fn(web3.codec, match_data_and_abi, encoded_data)

--- a/web3/_utils/contracts.py
+++ b/web3/_utils/contracts.py
@@ -190,7 +190,7 @@ def encode_abi(
         argument_types,
         arguments,
     )
-    encoded_arguments = web3.codec.encode_abi(
+    encoded_arguments = web3.codec.encode(
         argument_types,
         normalized_arguments,
     )

--- a/web3/_utils/filters.py
+++ b/web3/_utils/filters.py
@@ -253,7 +253,7 @@ def match_fn(codec: ABICodec, match_values_and_abi: Collection[Tuple[str, Any]],
     """
     abi_types, all_match_values = zip(*match_values_and_abi)
 
-    decoded_values = codec.decode_abi(abi_types, HexBytes(data))
+    decoded_values = codec.decode(abi_types, HexBytes(data))
     for data_value, match_values, abi_type in zip(decoded_values, all_match_values, abi_types):
         if match_values is None:
             continue

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -691,7 +691,7 @@ class AsyncEthModuleTest:
         )
         call_result = await async_w3.eth.call(txn_params)  # type: ignore
         assert is_string(call_result)
-        result = async_w3.codec.decode_single('uint256', call_result)
+        (result, ) = async_w3.codec.decode(['uint256'], call_result)
         assert result == 18
 
     @pytest.mark.asyncio
@@ -704,7 +704,7 @@ class AsyncEthModuleTest:
             transaction={'from': coinbase, 'to': revert_contract.address},
         )
         call_result = await async_w3.eth.call(txn_params)  # type: ignore
-        result = async_w3.codec.decode_single('bool', call_result)
+        (result, ) = async_w3.codec.decode(['bool'], call_result)
         assert result is True
 
         # override runtime bytecode: `normalFunction` returns `false`
@@ -714,7 +714,7 @@ class AsyncEthModuleTest:
             'latest',
             {revert_contract.address: {'code': override_code}}
         )
-        result = async_w3.codec.decode_single('bool', call_result)
+        (result, ) = async_w3.codec.decode(['bool'], call_result)
         assert result is False
 
     @pytest.mark.asyncio
@@ -729,7 +729,7 @@ class AsyncEthModuleTest:
         )
         call_result = await async_w3.eth.call(txn_params)  # type: ignore
         assert is_string(call_result)
-        result = async_w3.codec.decode_single('uint256', call_result)
+        (result, ) = async_w3.codec.decode(['uint256'], call_result)
         assert result == 0
 
     @pytest.mark.asyncio
@@ -2505,7 +2505,7 @@ class EthModuleTest:
         )
         call_result = web3.eth.call(txn_params)
         assert is_string(call_result)
-        result = web3.codec.decode_single('uint256', call_result)
+        (result, ) = web3.codec.decode(['uint256'], call_result)
         assert result == 18
 
     def test_eth_call_with_override(
@@ -2517,7 +2517,7 @@ class EthModuleTest:
             transaction={'from': coinbase, 'to': revert_contract.address},
         )
         call_result = web3.eth.call(txn_params)
-        result = web3.codec.decode_single('bool', call_result)
+        (result, ) = web3.codec.decode(['bool'], call_result)
         assert result is True
 
         # override runtime bytecode: `normalFunction` returns `false`
@@ -2527,7 +2527,7 @@ class EthModuleTest:
             'latest',
             {revert_contract.address: {'code': override_code}}
         )
-        result = web3.codec.decode_single('bool', call_result)
+        (result, ) = web3.codec.decode(['bool'], call_result)
         assert result is False
 
     def test_eth_call_with_0_result(
@@ -2541,7 +2541,7 @@ class EthModuleTest:
         )
         call_result = web3.eth.call(txn_params)
         assert is_string(call_result)
-        result = web3.codec.decode_single('uint256', call_result)
+        (result, ) = web3.codec.decode(['uint256'], call_result)
         assert result == 0
 
     def test_eth_call_revert_with_msg(

--- a/web3/contract.py
+++ b/web3/contract.py
@@ -468,7 +468,7 @@ class Contract:
         names = get_abi_input_names(func.abi)
         types = get_abi_input_types(func.abi)
 
-        decoded = self.web3.codec.decode_abi(types, cast(HexBytes, params))
+        decoded = self.web3.codec.decode(types, cast(HexBytes, params))
         normalized = map_abi_data(BASE_RETURN_NORMALIZERS, types, decoded)
 
         return func, dict(zip(names, normalized))
@@ -1534,7 +1534,7 @@ def call_contract_function(
     output_types = get_abi_output_types(fn_abi)
 
     try:
-        output_data = web3.codec.decode_abi(output_types, return_data)
+        output_data = web3.codec.decode(output_types, return_data)
     except DecodingError as e:
         # Provide a more helpful error message than the one provided by
         # eth-abi-utils

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -8,7 +8,7 @@ from typing import (
 )
 
 from eth_abi import (
-    decode_single,
+    abi,
 )
 from eth_abi.exceptions import (
     InsufficientDataBytes,
@@ -107,7 +107,7 @@ class EthereumTesterProvider(BaseProvider):
             )
         except TransactionFailed as e:
             try:
-                reason = decode_single('(string)', e.args[0].args[0][4:])[0]
+                reason = abi.decode(["string"], e.args[0].args[0][4:])[0]
             except (InsufficientDataBytes, AttributeError):
                 reason = e.args[0]
             raise TransactionFailed(f'execution reverted: {reason}')


### PR DESCRIPTION
### What was wrong?

closes #2725 

- These changes have been made in web3.py `v6` but need to be updated in `v5`.

### How was it fixed?

- Replace deprecated `eth-abi` methods internally with supported methods to silence warnings.
- Had to do the same with `eth-tester` for non-breaking changes there since I saw the `eth-tester` tests with `py-evm` backend were still giving these warnings in one or two places. Cherry picked an earlier `eth-tester` branch, released `v0.6.0-beta.7`, and pulled that in here so now the messages should not be there even through `eth-tester` with `py-evm` backend tests.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![SSPX0407](https://user-images.githubusercontent.com/3532824/203141062-d152c91c-638d-4278-a6c6-ff40b822f6f7.jpg)

