### PR TITLE
Update ``black`` command to use regex pattern

### DIFF
--- a/newsfragments/2727.internal.rst
+++ b/newsfragments/2727.internal.rst
@@ -1,0 +1,1 @@
+Use regex pattern for ``black`` command for ``tox`` / ``make lint`` linting commands.

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ basepython=python
 extras=linter
 commands=
     flake8 {toxinidir}/web3 {toxinidir}/ens {toxinidir}/ethpm {toxinidir}/tests --exclude {toxinidir}/ethpm/ethpm-spec,{toxinidir}/**/*_pb2.py
-    black {toxinidir}/ens {toxinidir}/ethpm {toxinidir}/web3 {toxinidir}/tests {toxinidir}/setup.py --exclude {toxinidir}/ethpm/ethpm-spec --extend-exclude {toxinidir}/ethpm/_utils/protobuf/ipfs_file_pb2.py --check
+    black {toxinidir}/ens {toxinidir}/ethpm {toxinidir}/web3 {toxinidir}/tests {toxinidir}/setup.py --exclude /ethpm/ethpm-spec/|/ethpm/_utils/protobuf/ipfs_file_pb2\.py --check
     isort --recursive --skip {toxinidir}/ethpm/_utils/protobuf/ipfs_file_pb2.py --skip {toxinidir}/ethpm/ethpm-spec --check-only --diff {toxinidir}/web3/ {toxinidir}/ens/ {toxinidir}/ethpm/ {toxinidir}/tests/
     mypy -p web3 -p ethpm -p ens --exclude {toxinidir}/ethpm/_utils/protobuf/ipfs_file_pb2.py --config-file {toxinidir}/mypy.ini
 


### PR DESCRIPTION
### What was wrong?

- Running `black` locally via `tox` or `make lint` has never really worked for me. This regex way to set up the `black` command via `tox` seems to work a bit better locally and regex seems to be the recommended way to run the command. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20221116_090946](https://user-images.githubusercontent.com/3532824/203187119-d0601b6f-e9b1-4aa7-a90e-6e09350c2365.jpg)
