### PR TITLE
Make ``ipfshhtpclient`` an optional library / backend for ethpm

### DIFF
--- a/docs/ethpm.rst
+++ b/docs/ethpm.rst
@@ -169,7 +169,16 @@ BaseURIBackend
 IPFS
 ~~~~
 
-``Py-EthPM`` has multiple backends available to fetch/pin files to IPFS. The desired backend can be set via the environment variable: ``ETHPM_IPFS_BACKEND_CLASS``.
+``Py-EthPM`` has multiple backends available to fetch/pin files to IPFS.
+The IPFS backends rely on the now-unmaintained ``ipfshttpclient`` library. Because of
+this, they are opt-in and may be installed via the ``ipfs`` web3 install extra.
+
+.. code-block:: bash
+
+    $ pip install "web3[ipfs]"
+
+
+The desired backend can be set via the environment variable: ``ETHPM_IPFS_BACKEND_CLASS``.
 
 - ``InfuraIPFSBackend`` (default)
     - `https://ipfs.infura.io`

--- a/newsfragments/2730.breaking.rst
+++ b/newsfragments/2730.breaking.rst
@@ -1,0 +1,1 @@
+Make the ``ipfshttpclient`` library opt-in via a web3 install extra. This only affects the ``ethpm`` ``ipfs`` backends, which rely on the library.

--- a/setup.py
+++ b/setup.py
@@ -51,12 +51,16 @@ extras_require = {
         "pluggy==0.13.1",
         "when-changed>=0.3.0",
     ],
+    "ipfs": [
+        "ipfshttpclient==0.8.0a2",
+    ],
 }
 
 extras_require["dev"] = (
     extras_require["tester"]
     + extras_require["linter"]
     + extras_require["docs"]
+    + extras_require["ipfs"]
     + extras_require["dev"]
 )
 
@@ -82,7 +86,6 @@ setup(
         "eth-typing>=3.0.0",
         "eth-utils>=2.0.0",
         "hexbytes>=0.1.0",
-        "ipfshttpclient==0.8.0a2",
         "jsonschema>=4.0.0",
         "lru-dict>=1.1.6",
         "protobuf>=4.21.6",


### PR DESCRIPTION
### What was wrong?

- Related to Issue #1416
- closes #2629 

### How was it fixed?

- Make ``ipfshttpclient`` optional as a web3 install extra.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![2672_71140428065_621963065_2212139_181618_n](https://user-images.githubusercontent.com/3532824/203420947-c24010b5-b962-46f3-9f71-1e90092b2ec3.jpg)
