### PR TITLE
Update ``mypy`` file exclusion to use regex search

### DIFF
--- a/newsfragments/2734.internal.rst
+++ b/newsfragments/2734.internal.rst
@@ -1,0 +1,1 @@
+Use regex pattern for ``mypy`` command for ``tox`` / ``make lint`` linting commands.

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,7 @@ commands=
     flake8 {toxinidir}/web3 {toxinidir}/ens {toxinidir}/ethpm {toxinidir}/tests --exclude {toxinidir}/ethpm/ethpm-spec,{toxinidir}/**/*_pb2.py
     black {toxinidir}/ens {toxinidir}/ethpm {toxinidir}/web3 {toxinidir}/tests {toxinidir}/setup.py --exclude /ethpm/ethpm-spec/|/ethpm/_utils/protobuf/ipfs_file_pb2\.py --check
     isort --recursive --skip {toxinidir}/ethpm/_utils/protobuf/ipfs_file_pb2.py --skip {toxinidir}/ethpm/ethpm-spec --check-only --diff {toxinidir}/web3/ {toxinidir}/ens/ {toxinidir}/ethpm/ {toxinidir}/tests/
-    mypy -p web3 -p ethpm -p ens --exclude {toxinidir}/ethpm/_utils/protobuf/ipfs_file_pb2.py --config-file {toxinidir}/mypy.ini
+    mypy -p web3 -p ethpm -p ens --exclude ethpm/_utils/protobuf/ipfs_file_pb2\.py --config-file {toxinidir}/mypy.ini
 
 [testenv:benchmark]
 basepython=python


### PR DESCRIPTION
### What was wrong?

- Due to similar issues as was happening in #2727, ``mypy`` looks for regular expressions which led to issues running ``make lint`` locally with some versions of `tox`.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![278611_10150693933715613_722865612_19422754_4741222_o](https://user-images.githubusercontent.com/3532824/203434391-dee31633-86b6-45f1-8d76-ccba9a10436a.jpg)

