### PR TITLE
Clean up ``AsyncHTTPProvider`` instantiation

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -282,18 +282,10 @@ AsyncHTTPProvider
         >>> from web3.net import AsyncNet
         >>> from web3.geth import Geth, AsyncGethTxPool
 
-        >>> w3 = Web3(
-        ...     AsyncHTTPProvider(endpoint_uri),
-        ...     modules={'eth': (AsyncEth,),
-        ...         'net': (AsyncNet,),
-        ...         'geth': (Geth,
-        ...             {'txpool': (AsyncGethTxPool,),
-        ...              'personal': (AsyncGethPersonal,),
-        ...              'admin' : (AsyncGethAdmin,)})
-        ...         },
-        ...     middlewares=[]   # See supported middleware section below for middleware options
-        ...     )
-        >>> custom_session = ClientSession()  # If you want to pass in your own session
+        >>> w3 = Web3(AsyncHTTPProvider(endpoint_uri))
+
+        >>> # If you want to pass in your own session:
+        >>> custom_session = ClientSession()
         >>> await w3.provider.cache_async_session(custom_session) # This method is an async method so it needs to be handled accordingly
 
     Under the hood, the ``AsyncHTTPProvider`` uses the python

--- a/newsfragments/2736.feature.rst
+++ b/newsfragments/2736.feature.rst
@@ -1,0 +1,1 @@
+Load the ``AsyncHTTPProvider`` with default async middleware and default async modules, just as the ``HTTPProvider``.

--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -29,6 +29,7 @@ from web3.exceptions import (
     FallbackNotFound,
     InvalidAddress,
     MismatchedABI,
+    NameNotFound,
     NoABIFound,
     NoABIFunctionsFound,
     ValidationError,
@@ -490,9 +491,9 @@ def test_call_address_reflector_name_array(address_reflector_contract, call):
     assert addresses == result
 
 
-def test_call_reject_invalid_ens_name(address_reflector_contract, call):
+def test_call_rejects_invalid_ens_name(address_reflector_contract, call):
     with contract_ens_addresses(address_reflector_contract, []):
-        with pytest.raises(ValueError):
+        with pytest.raises(NameNotFound):
             call(
                 contract=address_reflector_contract,
                 contract_function="reflect",
@@ -1363,11 +1364,11 @@ async def test_async_call_address_reflector_name_array(
 
 @pytest.mark.xfail
 @pytest.mark.asyncio
-async def test_async_call_reject_invalid_ens_name(
+async def test_async_call_rejects_invalid_ens_name(
     async_address_reflector_contract, async_call
 ):
     with contract_ens_addresses(async_address_reflector_contract, []):
-        with pytest.raises(ValueError):
+        with pytest.raises(NameNotFound):
             await async_call(
                 contract=async_address_reflector_contract,
                 contract_function="reflect",

--- a/tests/core/providers/test_async_http_provider.py
+++ b/tests/core/providers/test_async_http_provider.py
@@ -51,8 +51,8 @@ def test_web3_with_async_http_provider_has_default_middlewares_and_modules() -> 
     # assert default modules
 
     assert isinstance(async_w3.eth, AsyncEth)
-    assert isinstance(async_w3.geth, Geth)
     assert isinstance(async_w3.net, AsyncNet)
+    assert isinstance(async_w3.geth, Geth)
     assert isinstance(async_w3.geth.admin, AsyncGethAdmin)
     assert isinstance(async_w3.geth.personal, AsyncGethPersonal)
     assert isinstance(async_w3.geth.txpool, AsyncGethTxPool)

--- a/tests/core/providers/test_async_http_provider.py
+++ b/tests/core/providers/test_async_http_provider.py
@@ -4,18 +4,80 @@ from aiohttp import (
     ClientSession,
 )
 
+from web3 import Web3
 from web3._utils import (
     request,
+)
+from web3.eth import (
+    AsyncEth,
+)
+from web3.geth import (
+    AsyncGethAdmin,
+    AsyncGethPersonal,
+    AsyncGethTxPool,
+    Geth,
+)
+from web3.middleware import (
+    async_buffered_gas_estimate_middleware,
+    async_gas_price_strategy_middleware,
+    async_validation_middleware,
+)
+from web3.net import (
+    AsyncNet,
 )
 from web3.providers.async_rpc import (
     AsyncHTTPProvider,
 )
 
+URI = "http://mynode.local:8545"
+
+
+def test_no_args():
+    provider = AsyncHTTPProvider()
+    w3 = Web3(provider)
+    assert w3.manager.provider == provider
+    assert w3.manager.provider.is_async
+
+
+def test_init_kwargs():
+    provider = AsyncHTTPProvider(endpoint_uri=URI, request_kwargs={"timeout": 60})
+    w3 = Web3(provider)
+    assert w3.manager.provider == provider
+
+
+def test_web3_with_async_http_provider_has_default_middlewares_and_modules() -> None:
+    async_w3 = Web3(AsyncHTTPProvider(endpoint_uri="http://mynode.local:8545"))
+
+    # assert default modules
+
+    assert isinstance(async_w3.eth, AsyncEth)
+    assert isinstance(async_w3.geth, Geth)
+    assert isinstance(async_w3.async_net, AsyncNet)
+    assert isinstance(async_w3.geth.admin, AsyncGethAdmin)
+    assert isinstance(async_w3.geth.personal, AsyncGethPersonal)
+    assert isinstance(async_w3.geth.txpool, AsyncGethTxPool)
+
+    # assert default middleware
+
+    # the following length check should fail and will need to be added to once more
+    # async middlewares are added to the defaults
+    assert len(async_w3.middleware_onion.middlewares) == 3
+
+    assert (
+        async_w3.middleware_onion.get("gas_price_strategy")
+        == async_gas_price_strategy_middleware
+    )
+    assert async_w3.middleware_onion.get("validation") == async_validation_middleware
+    assert (
+        async_w3.middleware_onion.get("gas_estimate")
+        == async_buffered_gas_estimate_middleware
+    )
+
 
 @pytest.mark.asyncio
 async def test_user_provided_session() -> None:
     session = ClientSession()
-    provider = AsyncHTTPProvider(endpoint_uri="http://mynode.local:8545")
+    provider = AsyncHTTPProvider(endpoint_uri=URI)
     cached_session = await provider.cache_async_session(session)
     assert len(request._async_session_cache) == 1
     assert cached_session == session

--- a/tests/core/providers/test_async_http_provider.py
+++ b/tests/core/providers/test_async_http_provider.py
@@ -46,7 +46,7 @@ def test_init_kwargs():
 
 
 def test_web3_with_async_http_provider_has_default_middlewares_and_modules() -> None:
-    async_w3 = Web3(AsyncHTTPProvider(endpoint_uri="http://mynode.local:8545"))
+    async_w3 = Web3(AsyncHTTPProvider(endpoint_uri=URI))
 
     # assert default modules
 

--- a/tests/core/providers/test_async_http_provider.py
+++ b/tests/core/providers/test_async_http_provider.py
@@ -52,7 +52,7 @@ def test_web3_with_async_http_provider_has_default_middlewares_and_modules() -> 
 
     assert isinstance(async_w3.eth, AsyncEth)
     assert isinstance(async_w3.geth, Geth)
-    assert isinstance(async_w3.async_net, AsyncNet)
+    assert isinstance(async_w3.net, AsyncNet)
     assert isinstance(async_w3.geth.admin, AsyncGethAdmin)
     assert isinstance(async_w3.geth.personal, AsyncGethPersonal)
     assert isinstance(async_w3.geth.txpool, AsyncGethTxPool)

--- a/tests/core/providers/test_http_provider.py
+++ b/tests/core/providers/test_http_provider.py
@@ -20,6 +20,7 @@ def test_no_args():
     provider = HTTPProvider()
     w3 = Web3(provider)
     assert w3.manager.provider == provider
+    assert not w3.manager.provider.is_async
 
 
 def test_init_kwargs():

--- a/tests/integration/go_ethereum/test_goethereum_http.py
+++ b/tests/integration/go_ethereum/test_goethereum_http.py
@@ -12,23 +12,6 @@ from web3._utils.module_testing.go_ethereum_admin_module import (
 from web3._utils.module_testing.go_ethereum_personal_module import (
     GoEthereumAsyncPersonalModuleTest,
 )
-from web3.eth import (
-    AsyncEth,
-)
-from web3.geth import (
-    AsyncGethAdmin,
-    AsyncGethPersonal,
-    AsyncGethTxPool,
-    Geth,
-)
-from web3.middleware import (
-    async_buffered_gas_estimate_middleware,
-    async_gas_price_strategy_middleware,
-    async_validation_middleware,
-)
-from web3.net import (
-    AsyncNet,
-)
 from web3.providers.async_rpc import (
     AsyncHTTPProvider,
 )
@@ -137,26 +120,7 @@ class TestGoEthereumTxPoolModuleTest(GoEthereumTxPoolModuleTest):
 @pytest_asyncio.fixture(scope="module")
 async def async_w3(geth_process, endpoint_uri):
     await wait_for_aiohttp(endpoint_uri)
-    _w3 = Web3(
-        AsyncHTTPProvider(endpoint_uri),
-        middlewares=[
-            async_buffered_gas_estimate_middleware,
-            async_gas_price_strategy_middleware,
-            async_validation_middleware,
-        ],
-        modules={
-            "eth": AsyncEth,
-            "async_net": AsyncNet,
-            "geth": (
-                Geth,
-                {
-                    "txpool": (AsyncGethTxPool,),
-                    "personal": (AsyncGethPersonal,),
-                    "admin": (AsyncGethAdmin,),
-                },
-            ),
-        },
-    )
+    _w3 = Web3(AsyncHTTPProvider(endpoint_uri))
     return _w3
 
 

--- a/tests/integration/go_ethereum/test_goethereum_http.py
+++ b/tests/integration/go_ethereum/test_goethereum_http.py
@@ -129,22 +129,22 @@ class TestGoEthereumAsyncAdminModuleTest(GoEthereumAsyncAdminModuleTest):
     @pytest.mark.xfail(
         reason="running geth with the --nodiscover flag doesn't allow peer addition"
     )
-    async def test_admin_peers(self, w3: "Web3") -> None:
-        await super().test_admin_peers(w3)
+    async def test_admin_peers(self, async_w3: "Web3") -> None:
+        await super().test_admin_peers(async_w3)
 
     @pytest.mark.asyncio
-    async def test_admin_start_stop_http(self, w3: "Web3") -> None:
+    async def test_admin_start_stop_http(self, async_w3: "Web3") -> None:
         # This test causes all tests after it to fail on CI if it's allowed to run
         pytest.xfail(
             reason="Only one HTTP endpoint is allowed to be active at any time"
         )
-        await super().test_admin_start_stop_http(w3)
+        await super().test_admin_start_stop_http(async_w3)
 
     @pytest.mark.asyncio
-    async def test_admin_start_stop_ws(self, w3: "Web3") -> None:
+    async def test_admin_start_stop_ws(self, async_w3: "Web3") -> None:
         # This test causes all tests after it to fail on CI if it's allowed to run
         pytest.xfail(reason="Only one WS endpoint is allowed to be active at any time")
-        await super().test_admin_start_stop_ws(w3)
+        await super().test_admin_start_stop_ws(async_w3)
 
 
 class TestGoEthereumAsyncNetModuleTest(GoEthereumAsyncNetModuleTest):

--- a/web3/_utils/contracts.py
+++ b/web3/_utils/contracts.py
@@ -208,11 +208,13 @@ def encode_abi(
         )
 
     normalizers = [
-        abi_ens_resolver(w3),
         abi_address_to_hex,
         abi_bytes_to_bytes,
         abi_string_to_text,
     ]
+    if not w3.eth.is_async:
+        normalizers.append(abi_ens_resolver(w3))
+
     normalized_arguments = map_abi_data(
         normalizers,
         argument_types,

--- a/web3/_utils/module_testing/net_module.py
+++ b/web3/_utils/module_testing/net_module.py
@@ -1,6 +1,7 @@
 import pytest
 from typing import (
     TYPE_CHECKING,
+    cast,
 )
 
 from eth_utils import (
@@ -15,7 +16,7 @@ if TYPE_CHECKING:
 
 class NetModuleTest:
     def test_net_version(self, w3: "Web3") -> None:
-        version = w3.net.version
+        version = cast(str, w3.net.version)
 
         assert is_string(version)
         assert version.isdigit()
@@ -34,19 +35,19 @@ class NetModuleTest:
 class AsyncNetModuleTest:
     @pytest.mark.asyncio
     async def test_net_version(self, async_w3: "Web3") -> None:
-        version = await async_w3.async_net.version
+        version = await async_w3.net.version  # type: ignore
 
         assert is_string(version)
         assert version.isdigit()
 
     @pytest.mark.asyncio
     async def test_net_listening(self, async_w3: "Web3") -> None:
-        listening = await async_w3.async_net.listening
+        listening = await async_w3.net.listening  # type: ignore
 
         assert is_boolean(listening)
 
     @pytest.mark.asyncio
     async def test_net_peer_count(self, async_w3: "Web3") -> None:
-        peer_count = await async_w3.async_net.peer_count
+        peer_count = await async_w3.net.peer_count  # type: ignore
 
         assert is_integer(peer_count)

--- a/web3/_utils/module_testing/net_module.py
+++ b/web3/_utils/module_testing/net_module.py
@@ -1,7 +1,6 @@
 import pytest
 from typing import (
     TYPE_CHECKING,
-    cast,
 )
 
 from eth_utils import (
@@ -16,7 +15,7 @@ if TYPE_CHECKING:
 
 class NetModuleTest:
     def test_net_version(self, w3: "Web3") -> None:
-        version = cast(str, w3.net.version)
+        version = w3.net.version
 
         assert is_string(version)
         assert version.isdigit()

--- a/web3/_utils/normalizers.py
+++ b/web3/_utils/normalizers.py
@@ -205,7 +205,11 @@ def abi_address_to_hex(
 
 
 @curry
-def abi_ens_resolver(w3: "Web3", type_str: TypeStr, val: Any) -> Tuple[TypeStr, Any]:
+def abi_ens_resolver(
+    w3: "Web3",
+    type_str: TypeStr,
+    val: Any,
+) -> Tuple[TypeStr, Any]:
     if type_str == "address" and is_ens_name(val):
         if w3 is None:
             raise InvalidAddress(
@@ -214,11 +218,12 @@ def abi_ens_resolver(w3: "Web3", type_str: TypeStr, val: Any) -> Tuple[TypeStr, 
             )
 
         _ens = cast(ENS, w3.ens)
+        net_version = int(cast(str, w3.net.version)) if hasattr(w3, "net") else None
         if _ens is None:
             raise InvalidAddress(
                 f"Could not look up name {val!r} because ENS is" " set to None"
             )
-        elif int(w3.net.version) != 1 and not isinstance(_ens, StaticENS):
+        elif net_version != 1 and not isinstance(_ens, StaticENS):
             raise InvalidAddress(
                 f"Could not look up name {val!r} because web3 is"
                 " not connected to mainnet"

--- a/web3/_utils/normalizers.py
+++ b/web3/_utils/normalizers.py
@@ -218,7 +218,7 @@ def abi_ens_resolver(
             )
 
         _ens = cast(ENS, w3.ens)
-        net_version = int(cast(str, w3.net.version)) if hasattr(w3, "net") else None
+        net_version = int(w3.net.version) if hasattr(w3, "net") else None
         if _ens is None:
             raise InvalidAddress(
                 f"Could not look up name {val!r} because ENS is" " set to None"

--- a/web3/main.py
+++ b/web3/main.py
@@ -74,9 +74,13 @@ from web3._utils.normalizers import (
     abi_ens_resolver,
 )
 from web3.eth import (
+    AsyncEth,
     Eth,
 )
 from web3.geth import (
+    AsyncGethAdmin,
+    AsyncGethPersonal,
+    AsyncGethTxPool,
     Geth,
     GethAdmin,
     GethMiner,
@@ -124,6 +128,21 @@ from web3.types import (  # noqa: F401
 if TYPE_CHECKING:
     from web3.pm import PM  # noqa: F401
     from web3._utils.empty import Empty  # noqa: F401
+
+
+def get_async_default_modules() -> Dict[str, Union[Type[Module], Sequence[Any]]]:
+    return {
+        "eth": AsyncEth,
+        "async_net": AsyncNet,
+        "geth": (
+            Geth,
+            {
+                "admin": AsyncGethAdmin,
+                "personal": AsyncGethPersonal,
+                "txpool": AsyncGethTxPool,
+            },
+        ),
+    }
 
 
 def get_default_modules() -> Dict[str, Union[Type[Module], Sequence[Any]]]:
@@ -237,7 +256,10 @@ class Web3:
         self.codec = ABICodec(build_default_registry())
 
         if modules is None:
-            modules = get_default_modules()
+            if provider and provider.is_async:
+                modules = get_async_default_modules()
+            else:
+                modules = get_default_modules()
 
         self.attach_modules(modules)
 

--- a/web3/main.py
+++ b/web3/main.py
@@ -133,7 +133,7 @@ if TYPE_CHECKING:
 def get_async_default_modules() -> Dict[str, Union[Type[Module], Sequence[Any]]]:
     return {
         "eth": AsyncEth,
-        "async_net": AsyncNet,
+        "net": AsyncNet,
         "geth": (
             Geth,
             {
@@ -237,8 +237,7 @@ class Web3:
     # mypy Types
     eth: Eth
     geth: Geth
-    net: Net
-    async_net: AsyncNet
+    net: Union[Net, AsyncNet]
 
     def __init__(
         self,
@@ -256,10 +255,11 @@ class Web3:
         self.codec = ABICodec(build_default_registry())
 
         if modules is None:
-            if provider and provider.is_async:
-                modules = get_async_default_modules()
-            else:
-                modules = get_default_modules()
+            modules = (
+                get_async_default_modules()
+                if provider and provider.is_async
+                else get_default_modules()
+            )
 
         self.attach_modules(modules)
 

--- a/web3/main.py
+++ b/web3/main.py
@@ -237,7 +237,7 @@ class Web3:
     # mypy Types
     eth: Eth
     geth: Geth
-    net: Union[Net, AsyncNet]
+    net: Net
 
     def __init__(
         self,

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -149,8 +149,7 @@ class RequestManager:
     @staticmethod
     def async_default_middlewares(w3: "Web3") -> List[Tuple[Middleware, str]]:
         """
-        List the default middlewares for the request manager.
-        Leaving ens unspecified will prevent the middleware from resolving names.
+        List the default async middlewares for the request manager.
         """
         return [
             (async_gas_price_strategy_middleware, "gas_price_strategy"),

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -111,10 +111,11 @@ class RequestManager:
             self.provider = provider
 
         if middlewares is None:
-            if self.provider.is_async:
-                middlewares = self.async_default_middlewares(w3)
-            else:
-                middlewares = self.default_middlewares(w3)
+            middlewares = (
+                self.async_default_middlewares(w3)
+                if self.provider.is_async
+                else self.default_middlewares(w3)
+            )
 
         self.middleware_onion: MiddlewareOnion = NamedElementOnion(middlewares)
 

--- a/web3/providers/async_base.py
+++ b/web3/providers/async_base.py
@@ -39,6 +39,7 @@ class AsyncBaseProvider:
         None,
     )
 
+    is_async = True
     global_ccip_read_enabled: bool = True
     ccip_read_max_redirects: int = 4
 

--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -38,6 +38,7 @@ class BaseProvider:
         None,
     )
 
+    is_async = False
     global_ccip_read_enabled: bool = True
     ccip_read_max_redirects: int = 4
 


### PR DESCRIPTION
### What was wrong?

Related to #1416. This is listed as non-breaking but instead of having an `async_net` module, it seems more appropriate to set the `net` module up as the `AsyncNet` class. This will break things.

### How was it fixed?

- Add ``is_async`` flag to base provider classes and appropriately set them to ``True`` or ``False``.
- Use these flags to determine whether to load sync or async default middlewares and default modules.
- Refactor the ``Web3`` property ``async_net`` as ``net`` mapped to ``AsyncNet`` class when dealing with async and ``Net`` when dealing with sync.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
- [x] Update docs

#### Cute Animal Picture

 ___ O>
/\ /\
