### PR TITLE
Async name to address

### DIFF
--- a/tests/core/middleware/test_name_to_address_middleware.py
+++ b/tests/core/middleware/test_name_to_address_middleware.py
@@ -1,5 +1,7 @@
 import pytest
 
+import pytest_asyncio
+
 from web3 import (
     Web3,
     constants,
@@ -67,11 +69,12 @@ def test_fail_name_resolver(w3):
 # --- async --- #
 
 
-@pytest.fixture
-def async_w3():
+@pytest_asyncio.fixture
+async def async_w3():
     async_w3 = Web3(provider=AsyncBaseProvider(), middlewares=[])
     async_w3.ens = TempENS({NAME: ADDRESS})
-    async_w3.middleware_onion.add(async_name_to_address_middleware(async_w3))
+    _middleware = await async_name_to_address_middleware(async_w3)
+    async_w3.middleware_onion.add(_middleware, "name_to_address")
     return async_w3
 
 
@@ -87,6 +90,8 @@ async def test_async_pass_name_resolver(async_w3):
     )
     async_w3.middleware_onion.inject(return_chain_on_mainnet, layer=0)
     async_w3.middleware_onion.inject(return_balance, layer=0)
+
+    # breakpoint()
     assert await async_w3.eth.get_balance(NAME) == BALANCE
 
 

--- a/tests/core/utilities/test_async_functools.py
+++ b/tests/core/utilities/test_async_functools.py
@@ -1,0 +1,128 @@
+import asyncio
+
+from web3._utils.async_functools import (
+    async_curry,
+    is_func_or_coroutine,
+)
+
+
+def run_in_loop(coro, *args, **kw):
+    loop = asyncio.get_event_loop()
+    if is_func_or_coroutine(coro):
+        coro = coro(*args, **kw)
+    return loop.run_until_complete(coro)
+
+
+def task(x, y, baz=None, *args, **kw):
+    return x + y, baz, kw
+
+
+async def coro(x, y, baz=None, *args, **kw):
+    async def _task():
+        return task(x, y, baz=baz, *args, **kw)
+
+    return await _task()
+
+
+def test_curry_function_arity():
+    num, val, kw = run_in_loop(async_curry(task)(2)(4)(baz="foo"))
+    assert num == 6
+    assert val == "foo"
+    assert kw == {}
+
+    num, val, kw = run_in_loop(async_curry(task)(2, 4)(baz="foo"))
+    assert num == 6
+    assert val == "foo"
+    assert kw == {}
+
+    num, val, kw = run_in_loop(async_curry(task)(2, 4, baz="foo"))
+    assert num == 6
+    assert val == "foo"
+    assert kw == {}
+
+    num, val, kw = run_in_loop(async_curry(task)(2, 4, baz="foo", fee=True))
+    assert num == 6
+    assert val == "foo"
+    assert kw == {"fee": True}
+
+
+def test_curry_single_arity():
+    assert run_in_loop(async_curry(lambda x: x)(True))
+
+
+def test_curry_zero_arity():
+    assert run_in_loop(async_curry(lambda: True))
+
+
+def test_curry_custom_arity():
+    currier = async_curry(4)
+    num, val, kw = run_in_loop(currier(task)(2)(4)(baz="foo")(tee=True))
+    assert num == 6
+    assert val == "foo"
+    assert kw == {"tee": True}
+
+
+def test_curry_ignore_kwargs():
+    currier = async_curry(ignore_kwargs=True)
+    num, val, kw = run_in_loop(currier(task)(2)(4))
+    assert num == 6
+    assert val is None
+    assert kw == {}
+
+    currier = async_curry(ignore_kwargs=True)
+    num, val, kw = run_in_loop(currier(task)(2)(4, baz="foo", tee=True))
+    assert num == 6
+    assert val == "foo"
+    assert kw == {"tee": True}
+
+
+def test_curry_extra_arguments():
+    currier = async_curry(4)
+    num, val, kw = run_in_loop(currier(task)(2)(4)(baz="foo")(tee=True))
+    assert num == 6
+    assert val == "foo"
+    assert kw == {"tee": True}
+
+    currier = async_curry(4)
+    num, val, kw = run_in_loop(currier(task)(2)(4)(baz="foo")(tee=True))
+    assert num == 6
+    assert val == "foo"
+    assert kw == {"tee": True}
+
+
+def test_curry_evaluator_function():
+    def evaluator(acc, fn):
+        return len(acc[0]) < 3
+
+    def task(x, y):
+        return x * y
+
+    currier = async_curry(evaluator=evaluator)
+    assert run_in_loop(currier(task)(4, 4)) == 16
+
+
+def test_curry_decorator():
+    @async_curry
+    def task(x, y, z):
+        return x + y + z
+
+    assert run_in_loop(task(2)(4)(8)) == 14
+
+    @async_curry(4)
+    def task(x, y, *args):
+        return x + y + args[0] + args[1]
+
+    assert run_in_loop(task(2)(4)(8)(10)) == 24
+
+    @async_curry(4)
+    async def _task(x, y, *args):
+        return x + y + args[0] + args[1]
+
+    assert run_in_loop(_task(2)(4)(8)(10)) == 24
+
+
+def test_curry_coroutine():
+    num, val, kw = run_in_loop(async_curry(coro)(2)(4)(baz="foo", tee=True))
+    assert num == 6
+    assert val == "foo"
+    assert kw == {"tee": True}

--- a/web3/_utils/async_functools.py
+++ b/web3/_utils/async_functools.py
@@ -1,0 +1,233 @@
+# Imported and updated from the `paco` library (https://pypi.org/project/paco) which
+# seems to no longer be maintained.
+import asyncio
+import functools
+import inspect
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Coroutine,
+    Sequence,
+    Tuple,
+    Union,
+    ValuesView,
+    cast,
+)
+
+
+def is_func_or_coroutine(x: Any) -> bool:
+    """
+    Determine if the given value is a function or a coroutine function.
+
+    Arguments:
+        x (mixed): value to check.
+
+    Returns:
+        bool
+    """
+    return is_func_or_method(x) or asyncio.iscoroutinefunction(x)
+
+
+def is_func_or_method(x: Any) -> bool:
+    """
+    Determines if the given value is a function or method object.
+
+    Arguments:
+        x (mixed): value to check.
+
+    Returns:
+        bool
+    """
+    return not asyncio.iscoroutinefunction(x) and (
+        inspect.isfunction(x) or inspect.ismethod(x)
+    )
+
+
+def coro_wrap(fn: Callable[..., Any]) -> Callable[..., Coroutine[Any, Any, Any]]:
+    """
+    Wraps a given function as coroutine function.
+    This function can be used as decorator.
+
+    Arguments:
+        fn (function): function object to wrap.
+
+    Returns:
+        coroutine function: wrapped function as coroutine.
+
+    Usage::
+        def mul_2(num):
+            return num * 2
+
+        # Use as function wrapper:
+
+        coro = coro_wrap(mul_2)
+        await coro(2)
+        # => 4
+
+        # Use as decorator
+        @coro_wrap
+        def mul_2(num):
+            return num * 2
+        await mul_2(2)
+        # => 4
+    """
+
+    async def _async_fn(*args: Any, **kwargs: Any) -> Awaitable[Callable[..., Any]]:
+        return fn(*args, **kwargs)
+
+    return _async_fn
+
+
+def async_curry(
+    arity_or_fn: Union[int, Callable[..., Any]] = None,
+    ignore_kwargs: bool = False,
+    evaluator: Callable[..., Any] = None,
+    *args: Any,
+    **kwargs: Any,
+) -> Union[functools.partial[Coroutine[Any, Any, Any]], Callable[..., Any]]:
+    """
+    Note: functools.curry is preferred for non-async methods.
+
+    Creates a function that accepts one or more arguments of a function and
+    either invokes func returning its result if at least arity number of
+    arguments have been provided, or returns a function that accepts the
+    remaining function arguments until the function arity is satisfied.
+    This function is overloaded: you can pass a function or coroutine function
+    as first argument or an `int` indicating the explicit function arity.
+    Function arity can be inferred via function signature or explicitly
+    passed via `arity_or_fn` param.
+    You can optionally ignore keyword based arguments as well passing the
+    `ignore_kwargs` param with `True` value.
+
+    This function can be used as decorator.
+
+    Arguments:
+        arity_or_fn (int|function|coroutine function): function arity to curry
+            or function to curry.
+        ignore_kwargs (bool): ignore keyword arguments as arity to satisfy
+            during curry.
+        evaluator (function): use a custom arity evaluator function.
+        *args (mixed): mixed variadic arguments for partial function
+            application.
+        *kwargs (mixed): keyword variadic arguments for partial function
+            application.
+
+    Raises:
+        TypeError: if function is not a function or a coroutine function.
+
+    Returns:
+        function or coroutine function: function will be returned until all the
+            function arity is satisfied, where a coroutine function will be
+            returned instead.
+
+    Usage:
+        # Function signature inferred function arity:
+
+        @curry_with_async_support
+        async def task(x, y, z=0):
+            return x * y + z
+        await task(4)(4)(z=8)
+        # => 24
+
+        # User defined function arity:
+
+        @curry_with_async_support(4)
+        async def task(x, y, *args, **kw):
+            return x * y + args[0] * args[1]
+        await task(4)(4)(8)(8)
+        # => 80
+
+        # Ignore keyword arguments from arity:
+
+        @curry_with_async_support(ignore_kwargs=True)
+        async def task(x, y, z=0):
+            return x * y
+        await task(4)(4)
+        # => 16
+    """
+
+    def is_valid_arg(x: Any) -> bool:
+        return all(
+            [
+                x.kind != x.VAR_KEYWORD,
+                x.kind != x.VAR_POSITIONAL,
+                any([not ignore_kwargs, ignore_kwargs and x.default == x.empty]),
+            ]
+        )
+
+    def params(fn: Callable[..., Any]) -> ValuesView[Any]:
+        return inspect.signature(fn).parameters.values()
+
+    def infer_arity(fn: Callable[..., Any]) -> int:
+        return len([x for x in params(fn) if is_valid_arg(x)])
+
+    def merge_args(acc: Sequence[Any], args: Any, kwargs: Any) -> Tuple[Any, Any]:
+        _args, _kw = acc
+        _args = _args + args
+        _kw = _kw or {}
+        _kw.update(kwargs)
+        return _args, _kw
+
+    def currier(
+        arity: int,
+        acc: Sequence[Any],
+        fn: Callable[..., Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> functools.partial[Any]:
+        """
+        Function either continues curring of the arguments
+        or executes function if desired arguments have being collected.
+        If function curried is variadic then execution without arguments
+        will finish curring and trigger the function
+        """
+        # Merge call arguments with accumulated ones
+        _args, _kwargs = merge_args(acc, args, kwargs)
+
+        # Get current function call accumulated arity
+        current_arity = len(args)
+
+        # Count keyword params as arity to satisfy, if required
+        if not ignore_kwargs:
+            current_arity += len(kwargs)
+
+        # Decrease function arity to satisfy
+        arity -= current_arity
+
+        # Use user-defined custom arity evaluator strategy, if present
+        currify = evaluator and evaluator(acc, fn)
+
+        # If arity is not satisfied, return recursive partial function
+        if currify is not False and arity > 0:
+            return functools.partial(currier, arity, (_args, _kwargs), fn)
+
+        # If arity is satisfied, instantiate coroutine and return it
+        return fn(*_args, **_kwargs)
+
+    def wrapper(
+        fn: Callable[..., Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Union[functools.partial[Any], Callable[..., Any]]:
+        if not is_func_or_coroutine(fn):
+            raise TypeError(
+                "first argument must be a function, coroutine function, or method."
+            )
+
+        # Infer function arity, if required
+        arity = arity_or_fn if isinstance(arity_or_fn, int) else infer_arity(fn)
+
+        if is_func_or_method(fn):
+            fn = coro_wrap(fn)
+
+        # Otherwise return recursive currier function
+        return currier(arity, (args, kwargs), fn, *args, **kwargs) if arity > 0 else fn
+
+    # Return currier function or decorator wrapper
+
+    if not is_func_or_coroutine(arity_or_fn):
+        return wrapper
+
+    fn = cast(Callable[..., Any], arity_or_fn)
+    return wrapper(fn, *args, **kwargs)

--- a/web3/_utils/async_functools.py
+++ b/web3/_utils/async_functools.py
@@ -1,0 +1,233 @@
+# Imported and updated from the `paco` library (https://pypi.org/project/paco) which
+# seems to no longer be maintained.
+import asyncio
+import functools
+import inspect
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Coroutine,
+    Sequence,
+    Tuple,
+    Union,
+    ValuesView,
+    cast,
+)
+
+
+def is_func_or_coroutine(x: Any) -> bool:
+    """
+    Determine if the given value is a function or a coroutine function.
+
+    Arguments:
+        x (mixed): value to check.
+
+    Returns:
+        bool
+    """
+    return is_func_or_method(x) or asyncio.iscoroutinefunction(x)
+
+
+def is_func_or_method(x: Any) -> bool:
+    """
+    Determines if the given value is a function or method object.
+
+    Arguments:
+        x (mixed): value to check.
+
+    Returns:
+        bool
+    """
+    return not asyncio.iscoroutinefunction(x) and (
+        inspect.isfunction(x) or inspect.ismethod(x)
+    )
+
+
+def coro_wrap(fn: Callable[..., Any]) -> Callable[..., Coroutine[Any, Any, Any]]:
+    """
+    Wraps a given function as coroutine function.
+    This function can be used as decorator.
+
+    Arguments:
+        fn (function): function object to wrap.
+
+    Returns:
+        coroutine function: wrapped function as coroutine.
+
+    Usage::
+        def mul_2(num):
+            return num * 2
+
+        # Use as function wrapper:
+
+        coro = coro_wrap(mul_2)
+        await coro(2)
+        # => 4
+
+        # Use as decorator
+        @coro_wrap
+        def mul_2(num):
+            return num * 2
+        await mul_2(2)
+        # => 4
+    """
+
+    async def _async_fn(*args: Any, **kwargs: Any) -> Awaitable[Callable[..., Any]]:
+        return fn(*args, **kwargs)
+
+    return _async_fn
+
+
+def async_curry(
+    arity_or_fn: Union[int, Callable[..., Any]] = None,
+    ignore_kwargs: bool = False,
+    evaluator: Callable[..., Any] = None,
+    *args: Any,
+    **kwargs: Any,
+) -> Callable[..., Any]:
+    """
+    Note: functools.curry is preferred for non-async methods.
+
+    Creates a function that accepts one or more arguments of a function and
+    either invokes func returning its result if at least arity number of
+    arguments have been provided, or returns a function that accepts the
+    remaining function arguments until the function arity is satisfied.
+    This function is overloaded: you can pass a function or coroutine function
+    as first argument or an `int` indicating the explicit function arity.
+    Function arity can be inferred via function signature or explicitly
+    passed via `arity_or_fn` param.
+    You can optionally ignore keyword based arguments as well passing the
+    `ignore_kwargs` param with `True` value.
+
+    This function can be used as decorator.
+
+    Arguments:
+        arity_or_fn (int|function|coroutine function): function arity to curry
+            or function to curry.
+        ignore_kwargs (bool): ignore keyword arguments as arity to satisfy
+            during curry.
+        evaluator (function): use a custom arity evaluator function.
+        *args (mixed): mixed variadic arguments for partial function
+            application.
+        *kwargs (mixed): keyword variadic arguments for partial function
+            application.
+
+    Raises:
+        TypeError: if function is not a function or a coroutine function.
+
+    Returns:
+        function or coroutine function: function will be returned until all the
+            function arity is satisfied, where a coroutine function will be
+            returned instead.
+
+    Usage:
+        # Function signature inferred function arity:
+
+        @curry_with_async_support
+        async def task(x, y, z=0):
+            return x * y + z
+        await task(4)(4)(z=8)
+        # => 24
+
+        # User defined function arity:
+
+        @curry_with_async_support(4)
+        async def task(x, y, *args, **kw):
+            return x * y + args[0] * args[1]
+        await task(4)(4)(8)(8)
+        # => 80
+
+        # Ignore keyword arguments from arity:
+
+        @curry_with_async_support(ignore_kwargs=True)
+        async def task(x, y, z=0):
+            return x * y
+        await task(4)(4)
+        # => 16
+    """
+
+    def is_valid_arg(x: Any) -> bool:
+        return all(
+            [
+                x.kind != x.VAR_KEYWORD,
+                x.kind != x.VAR_POSITIONAL,
+                any([not ignore_kwargs, ignore_kwargs and x.default == x.empty]),
+            ]
+        )
+
+    def params(fn: Callable[..., Any]) -> ValuesView[Any]:
+        return inspect.signature(fn).parameters.values()
+
+    def infer_arity(fn: Callable[..., Any]) -> int:
+        return len([x for x in params(fn) if is_valid_arg(x)])
+
+    def merge_args(acc: Sequence[Any], args: Any, kwargs: Any) -> Tuple[Any, Any]:
+        _args, _kw = acc
+        _args = _args + args
+        _kw = _kw or {}
+        _kw.update(kwargs)
+        return _args, _kw
+
+    def currier(
+        arity: int,
+        acc: Sequence[Any],
+        fn: Callable[..., Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Callable[..., Any]:
+        """
+        Function either continues curring of the arguments
+        or executes function if desired arguments have being collected.
+        If function curried is variadic then execution without arguments
+        will finish curring and trigger the function
+        """
+        # Merge call arguments with accumulated ones
+        _args, _kwargs = merge_args(acc, args, kwargs)
+
+        # Get current function call accumulated arity
+        current_arity = len(args)
+
+        # Count keyword params as arity to satisfy, if required
+        if not ignore_kwargs:
+            current_arity += len(kwargs)
+
+        # Decrease function arity to satisfy
+        arity -= current_arity
+
+        # Use user-defined custom arity evaluator strategy, if present
+        currify = evaluator and evaluator(acc, fn)
+
+        # If arity is not satisfied, return recursive partial function
+        if currify is not False and arity > 0:
+            return functools.partial(currier, arity, (_args, _kwargs), fn)
+
+        # If arity is satisfied, instantiate coroutine and return it
+        return fn(*_args, **_kwargs)
+
+    def wrapper(
+        fn: Callable[..., Any],
+        *args: Any,
+        **kwargs: Any,
+    ) -> Callable[..., Any]:
+        if not is_func_or_coroutine(fn):
+            raise TypeError(
+                "first argument must be a function, coroutine function, or method."
+            )
+
+        # Infer function arity, if required
+        arity = arity_or_fn if isinstance(arity_or_fn, int) else infer_arity(fn)
+
+        if is_func_or_method(fn):
+            fn = coro_wrap(fn)
+
+        # Otherwise return recursive currier function
+        return currier(arity, (args, kwargs), fn, *args, **kwargs) if arity > 0 else fn
+
+    # Return currier function or decorator wrapper
+
+    if not is_func_or_coroutine(arity_or_fn):
+        return wrapper
+
+    fn = cast(Callable[..., Any], arity_or_fn)
+    return wrapper(fn, *args, **kwargs)

--- a/web3/_utils/ens.py
+++ b/web3/_utils/ens.py
@@ -18,7 +18,10 @@ from eth_utils import (
     is_hex_address,
 )
 
-from ens import ENS
+from ens import (
+    ENS,
+    AsyncENS,
+)
 from web3.exceptions import (
     NameNotFound,
 )
@@ -80,3 +83,15 @@ def contract_ens_addresses(
     """
     with ens_addresses(contract.w3, name_addr_pairs):
         yield
+
+
+# --- async --- #
+
+
+async def async_validate_name_has_address(
+    async_ens: AsyncENS, name: str
+) -> ChecksumAddress:
+    addr = await async_ens.address(name)
+    if not addr:
+        raise NameNotFound(f"Could not find address for name {name!r}")
+    return addr

--- a/web3/_utils/normalizers.py
+++ b/web3/_utils/normalizers.py
@@ -43,7 +43,13 @@ from hexbytes import (
     HexBytes,
 )
 
-from ens import ENS
+from ens import (
+    ENS,
+    AsyncENS,
+)
+from web3._utils.async_functools import (
+    async_curry,
+)
 from web3._utils.encoding import (
     hexstr_if_str,
     text_if_str,
@@ -275,3 +281,39 @@ def normalize_bytecode(bytecode: bytes) -> HexBytes:
         bytecode = HexBytes(bytecode)
     # type ignored b/c bytecode is converted to HexBytes above
     return bytecode  # type: ignore
+
+
+# --- async -- #
+
+
+@async_curry
+async def async_abi_ens_resolver(
+    async_w3: "Web3",
+    type_str: TypeStr,
+    val: Any,
+) -> Tuple[TypeStr, Any]:
+    if type_str == "address" and is_ens_name(val):
+        if async_w3 is None:
+            raise InvalidAddress(
+                f"Could not look up name {val!r} because no web3"
+                " connection available"
+            )
+
+        net_version = await async_w3.net.version  # type: ignore
+        net_version = int(net_version) if hasattr(async_w3, "net") else None
+
+        _async_ens = cast(AsyncENS, async_w3.ens)
+        if _async_ens is None:
+            raise InvalidAddress(
+                f"Could not look up name {val!r} because ENS is" " set to None"
+            )
+        elif net_version != 1 and not isinstance(_async_ens, StaticENS):
+            raise InvalidAddress(
+                f"Could not look up name {val!r} because web3 is"
+                " not connected to mainnet"
+            )
+        else:
+            address = await validate_name_has_address(_async_ens, val)  # type: ignore
+            return type_str, address
+    else:
+        return type_str, val

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -42,6 +42,7 @@ from .filter import (  # noqa: F401
     local_filter_middleware,
 )
 from .fixture import (  # noqa: F401
+    async_construct_fixture_middleware,
     construct_error_generator_middleware,
     construct_fixture_middleware,
     construct_result_generator_middleware,
@@ -58,6 +59,7 @@ from .geth_poa import (  # noqa: F401
     geth_poa_middleware,
 )
 from .names import (  # noqa: F401
+    async_name_to_address_middleware,
     name_to_address_middleware,
 )
 from .normalize_request_parameters import (  # noqa: F401

--- a/web3/middleware/fixture.py
+++ b/web3/middleware/fixture.py
@@ -90,6 +90,29 @@ def construct_error_generator_middleware(
 # --- async --- #
 
 
+async def async_construct_fixture_middleware(
+    fixtures: Dict[RPCEndpoint, Any]
+) -> Middleware:
+    """
+    Constructs a middleware which returns a static response for any method
+    which is found in the provided fixtures.
+    """
+
+    async def fixture_middleware(
+        make_request: Callable[[RPCEndpoint, Any], Any], _: "Web3"
+    ) -> Callable[[RPCEndpoint, Any], RPCResponse]:
+        async def middleware(method: RPCEndpoint, params: Any) -> RPCResponse:
+            if method in fixtures:
+                result = fixtures[method]
+                return {"result": result}
+            else:
+                return await make_request(method, params)
+
+        return middleware
+
+    return fixture_middleware
+
+
 async def async_construct_result_generator_middleware(
     result_generators: Dict[RPCEndpoint, Any]
 ) -> Middleware:

--- a/web3/middleware/names.py
+++ b/web3/middleware/names.py
@@ -4,6 +4,7 @@ from typing import (
 
 from web3._utils.normalizers import (
     abi_ens_resolver,
+    async_abi_ens_resolver,
 )
 from web3._utils.rpc_abi import (
     RPC_ABIS,
@@ -14,6 +15,7 @@ from web3.types import (
 )
 
 from .formatting import (
+    async_construct_formatting_middleware,
     construct_formatting_middleware,
 )
 
@@ -28,3 +30,15 @@ def name_to_address_middleware(w3: "Web3") -> Middleware:
     return construct_formatting_middleware(
         request_formatters=abi_request_formatters(normalizers, RPC_ABIS)
     )
+
+
+async def async_name_to_address_middleware(async_w3: "Web3") -> Middleware:
+    normalizers = [
+        async_abi_ens_resolver(async_w3),
+    ]
+
+    _construct_name_to_address_middleware = await async_construct_formatting_middleware(
+        request_formatters=abi_request_formatters(normalizers, RPC_ABIS)
+    )
+
+    return _construct_name_to_address_middleware


### PR DESCRIPTION
### What was wrong?

closes #2583
closes #1990

### How was it fixed?

- Import `paco`-inspired methods for async curry support and refactor code, removing deprecated `asyncio.coroutine` in place of `async def` + `await` usage.
- Add similar tests as those within the `paco` library for the new `async_curry` method.
- Add typing for the new methods introduced in `web3._utils.async_functools.py`
- Begin async support for `name_to_address_middleware`

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
- [ ] Add middleware tests and debug

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
