### PR TITLE
prevent ``ethpm`` import issues without ``ipfshttpclient``

### DIFF
--- a/ethpm/_utils/backend.py
+++ b/ethpm/_utils/backend.py
@@ -10,9 +10,6 @@ from eth_typing import (
 from eth_utils import (
     to_tuple,
 )
-from ipfshttpclient.exceptions import (
-    ConnectionError,
-)
 
 from ethpm.backends.base import (
     BaseURIBackend,
@@ -30,7 +27,16 @@ from ethpm.backends.registry import (
     RegistryURIBackend,
 )
 
+try:
+    from ipfshttpclient.exceptions import (
+        ConnectionError as IpfsConnectionError,
+    )
+except ImportError:
+    pass
+
 logger = logging.getLogger("ethpm.utils.backend")
+
+IPFS_NODE_UNAVAILABLE_MSG = "No local IPFS node available on port 5001."
 
 ALL_URI_BACKENDS = [
     InfuraIPFSBackend,
@@ -50,8 +56,8 @@ def get_translatable_backends_for_uri(
         try:
             if backend().can_translate_uri(uri):  # type: ignore
                 yield backend
-        except ConnectionError:
-            logger.debug("No local IPFS node available on port 5001.", exc_info=True)
+        except IpfsConnectionError:
+            logger.debug(IPFS_NODE_UNAVAILABLE_MSG, exc_info=True)
 
 
 @to_tuple
@@ -71,7 +77,5 @@ def get_resolvable_backends_for_uri(
                 try:
                     if backend_class().can_resolve_uri(uri):  # type: ignore
                         yield backend_class
-                except ConnectionError:
-                    logger.debug(
-                        "No local IPFS node available on port 5001.", exc_info=True
-                    )
+                except IpfsConnectionError:
+                    logger.debug(IPFS_NODE_UNAVAILABLE_MSG, exc_info=True)

--- a/ethpm/_utils/ipfs.py
+++ b/ethpm/_utils/ipfs.py
@@ -9,9 +9,6 @@ from urllib import (
     parse,
 )
 
-from base58 import (
-    b58encode,
-)
 from eth_utils import (
     to_text,
 )
@@ -23,6 +20,15 @@ from ethpm._utils.protobuf.ipfs_file_pb2 import (  # type: ignore
     Data,
     PBNode,
 )
+
+try:
+    # `ipfshttpclient` backend is optional. This is only imported if the "web3[ipfs]"
+    # install extra is installed
+    from base58 import (
+        b58encode,
+    )
+except ImportError:
+    pass
 
 
 def dummy_ipfs_pin(path: Path) -> Dict[str, str]:

--- a/ethpm/backends/ipfs.py
+++ b/ethpm/backends/ipfs.py
@@ -15,7 +15,6 @@ from eth_utils import (
     import_string,
     to_bytes,
 )
-import ipfshttpclient
 
 from ethpm import (
     get_ethpm_spec_dir,
@@ -38,6 +37,13 @@ from ethpm.exceptions import (
     CannotHandleURI,
     EthPMValidationError,
 )
+
+try:
+    # `ipfshttpclient` backend is optional. This is only imported if the "web3[ipfs]"
+    # install extra is installed
+    import ipfshttpclient
+except ImportError:
+    pass
 
 
 class BaseIPFSBackend(BaseURIBackend):

--- a/newsfragments/2775.bugfix.rst
+++ b/newsfragments/2775.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``ethpm`` import issues after making ``ipfshttpclient`` optional.


### PR DESCRIPTION
### What was wrong?

Related to Issue #2774

### How was it fixed?

- Don't force imports related to ``ipfshttpclient`` for ``ethpm``

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Image from iOS (3) copy](https://user-images.githubusercontent.com/3532824/212174435-1f5c56e3-510e-41fc-8bf2-0595b876ef72.jpg)

