### PR TITLE
Remove ``AttributeDict`` method formatters and opt for middleware

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -881,7 +881,7 @@ The script can be run with: ``python ./eventscanner.py <your JSON-RPC API URL>``
 
             :param event: Symbolic dictionary of the event data
 
-            :return: Internal state structure that is the result of event tranformation.
+            :return: Internal state structure that is the result of event transformation.
             """
 
         @abstractmethod

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -29,9 +29,14 @@ AttributeDict
 
 .. py:method:: web3.middleware.attrdict_middleware
 
-    This middleware converts the output of a function from a dictionary to an ``AttributeDict``
-    which enables dot-syntax access, like ``eth.get_block('latest').number``
-    in addition to ``eth.get_block('latest')['number']``.
+    This middleware recursively converts any dictionary type in the result of a call
+    to an ``AttributeDict``. This enables dot-syntax access, like
+    ``eth.get_block('latest').number`` in addition to
+    ``eth.get_block('latest')['number']``.
+
+    .. note::
+        Accessing a property via attribute breaks type hinting. For this reason, this
+        feature is available as a middleware, which may be removed if desired.
 
 .eth Name Resolution
 ~~~~~~~~~~~~~~~~~~~~~
@@ -42,10 +47,10 @@ AttributeDict
     address that the name points to. For example :meth:`w3.eth.send_transaction <web3.eth.Eth.send_transaction>` will
     accept .eth names in the 'from' and 'to' fields.
 
-.. note::
-    This middleware only converts ENS names if invoked with the mainnet
-    (where the ENS contract is deployed), for all other cases will result in an
-    ``InvalidAddress`` error
+    .. note::
+        This middleware only converts ENS names if invoked with the mainnet
+        (where the ENS contract is deployed), for all other cases will result in an
+        ``InvalidAddress`` error
 
 Pythonic
 ~~~~~~~~~~~~

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -369,6 +369,7 @@ Supported Middleware
 - :meth:`Gas Price Strategy <web3.middleware.gas_price_strategy_middleware>`
 - :meth:`Buffered Gas Estimate Middleware <web3.middleware.buffered_gas_estimate_middleware>`
 - :meth:`Stalecheck Middleware <web3.middleware.make_stalecheck_middleware>`
+- :meth:`Attribute Dict Middleware <web3.middleware.attrdict_middleware>`
 - :meth:`Validation Middleware <web3.middleware.validation>`
 - :ref:`Geth POA Middleware <geth-poa>`
 - :meth:`Simple Cache Middleware <web3.middleware.simple_cache_middleware>`

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -40,9 +40,11 @@ you can find the latest block number in these two ways:
         TypeError: This data is immutable -- create a copy instead of modifying
 
 This feature is available via the ``attrdict_middleware`` which is a default middleware.
-Of note, accessing a property via attribute will break type hinting. If typing is
-crucial for your application, accessing via key / value, as well as removing the
-``attrdict_middleware`` altogether, may be desired.
+
+.. note::
+    Accessing an ``AttributeDict`` property via attribute will break type hinting. If
+    typing is crucial for your application, accessing via key / value, as well as
+    removing the ``attrdict_middleware`` altogether, may be desired.
 
 
 Properties

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -16,7 +16,7 @@ web3.eth API
 The ``web3.eth`` object exposes the following properties and methods to
 interact with the RPC APIs under the ``eth_`` namespace.
 
-Often, when a property or method returns a mapping of keys to values, it
+By default, when a property or method returns a mapping of keys to values, it
 will return an ``AttributeDict`` which acts like a ``dict`` but you can
 access the keys as attributes and cannot modify its fields. For example,
 you can find the latest block number in these two ways:
@@ -38,6 +38,11 @@ you can find the latest block number in these two ways:
         >>> block.number = 4022282
         Traceback # ... etc ...
         TypeError: This data is immutable -- create a copy instead of modifying
+
+This feature is available via the ``attrdict_middleware`` which is a default middleware.
+Of note, accessing a property via attribute will break type hinting. If typing is
+crucial for your application, accessing via key / value, as well as removing the
+``attrdict_middleware`` altogether, may be desired.
 
 
 Properties
@@ -332,7 +337,8 @@ The following methods are available on the ``web3.eth`` namespace.
 
     * Merkle proof verification using py-trie.
 
-    The following example verifies that the values returned in the AttributeDict are included in the state of given trie ``root``.
+    The following example verifies that the values returned in the ``AttributeDict``
+    are included in the state of given trie ``root``.
 
     .. code-block:: python
 

--- a/newsfragments/2805.breaking.rst
+++ b/newsfragments/2805.breaking.rst
@@ -1,0 +1,1 @@
+``dict`` to ``AttributeDict`` conversion is no longer a default result formatter. This conversion is now done via a default middleware that may be removed.

--- a/tests/core/method-class/test_method.py
+++ b/tests/core/method-class/test_method.py
@@ -337,11 +337,11 @@ def test_process_params(
             object(), *args, **kwargs
         )
         assert request_params == expected_request_result
-        first_formatter = (output_formatter[0].first,)
-        all_other_formatters = output_formatter[0].funcs
 
-        # the expected result formatters length is 2
-        assert len(first_formatter + all_other_formatters) == 2
+        first_formatter = (output_formatter[0],)
+
+        # the expected result formatters length is 1
+        assert len(first_formatter) == 1
 
 
 def keywords(module, keyword_one, keyword_two):

--- a/tests/core/middleware/test_attrdict_middleware.py
+++ b/tests/core/middleware/test_attrdict_middleware.py
@@ -1,0 +1,156 @@
+import pytest
+
+from web3 import (
+    EthereumTesterProvider,
+    Web3,
+)
+from web3.datastructures import (
+    AttributeDict,
+)
+from web3.middleware import (
+    async_attrdict_middleware,
+    async_construct_result_generator_middleware,
+    attrdict_middleware,
+    construct_result_generator_middleware,
+)
+from web3.providers.eth_tester import (
+    AsyncEthereumTesterProvider,
+)
+from web3.types import (
+    RPCEndpoint,
+)
+
+GENERATED_NESTED_DICT_RESULT = {
+    "result": {
+        "a": 1,
+        "b": {
+            "b1": 1,
+            "b2": {"b2a": 1, "b2b": {"b2b1": 1, "b2b2": {"test": "fin"}}},
+        },
+    }
+}
+
+
+def _assert_dict_and_not_attrdict(value):
+    assert not isinstance(value, AttributeDict)
+    assert isinstance(value, dict)
+
+
+def test_attrdict_middleware_default_for_ethereum_tester_provider():
+    w3 = Web3(EthereumTesterProvider())
+    assert w3.middleware_onion.get("attrdict") == attrdict_middleware
+
+
+def test_attrdict_middleware_is_recursive(w3):
+    w3.middleware_onion.inject(
+        construct_result_generator_middleware(
+            {RPCEndpoint("fake_endpoint"): lambda *_: GENERATED_NESTED_DICT_RESULT}
+        ),
+        "result_gen",
+        layer=0,
+    )
+    response = w3.manager.request_blocking("fake_endpoint", [])
+
+    result = response["result"]
+    assert isinstance(result, AttributeDict)
+    assert response.result == result
+
+    assert isinstance(result["b"], AttributeDict)
+    assert result.b == result["b"]
+    assert isinstance(result.b["b2"], AttributeDict)
+    assert result.b.b2 == result.b["b2"]
+    assert isinstance(result.b.b2["b2b"], AttributeDict)
+    assert result.b.b2.b2b == result.b.b2["b2b"]
+    assert isinstance(result.b.b2.b2b["b2b2"], AttributeDict)
+    assert result.b.b2.b2b.b2b2 == result.b.b2.b2b["b2b2"]
+
+    # cleanup
+    w3.middleware_onion.remove("result_gen")
+
+
+def test_no_attrdict_middleware_does_not_convert_dicts_to_attrdict():
+    w3 = Web3(EthereumTesterProvider())
+
+    w3.middleware_onion.inject(
+        construct_result_generator_middleware(
+            {RPCEndpoint("fake_endpoint"): lambda *_: GENERATED_NESTED_DICT_RESULT}
+        ),
+        "result_gen",
+        layer=0,
+    )
+
+    # remove attrdict middleware
+    w3.middleware_onion.remove("attrdict")
+
+    response = w3.manager.request_blocking("fake_endpoint", [])
+
+    result = response["result"]
+
+    _assert_dict_and_not_attrdict(result)
+    _assert_dict_and_not_attrdict(result["b"])
+    _assert_dict_and_not_attrdict(result["b"]["b2"])
+    _assert_dict_and_not_attrdict(result["b"]["b2"]["b2b"])
+    _assert_dict_and_not_attrdict(result["b"]["b2"]["b2b"]["b2b2"])
+
+
+# --- async --- #
+
+
+@pytest.mark.asyncio
+async def test_async_attrdict_middleware_default_for_async_ethereum_tester_provider():
+    async_w3 = Web3(AsyncEthereumTesterProvider())
+    assert async_w3.middleware_onion.get("attrdict") == async_attrdict_middleware
+
+
+@pytest.mark.asyncio
+async def test_async_attrdict_middleware_is_recursive(async_w3):
+    async_w3.middleware_onion.inject(
+        await async_construct_result_generator_middleware(
+            {RPCEndpoint("fake_endpoint"): lambda *_: GENERATED_NESTED_DICT_RESULT}
+        ),
+        "result_gen",
+        layer=0,
+    )
+    response = await async_w3.manager.coro_request("fake_endpoint", [])
+
+    result = response["result"]
+    assert isinstance(result, AttributeDict)
+    assert response.result == result
+
+    assert isinstance(result["b"], AttributeDict)
+    assert result.b == result["b"]
+    assert isinstance(result.b["b2"], AttributeDict)
+    assert result.b.b2 == result.b["b2"]
+    assert isinstance(result.b.b2["b2b"], AttributeDict)
+    assert result.b.b2.b2b == result.b.b2["b2b"]
+    assert isinstance(result.b.b2.b2b["b2b2"], AttributeDict)
+    assert result.b.b2.b2b.b2b2 == result.b.b2.b2b["b2b2"]
+
+    # cleanup
+    async_w3.middleware_onion.remove("result_gen")
+
+
+@pytest.mark.asyncio
+async def test_no_async_attrdict_middleware_does_not_convert_dicts_to_attrdict():
+    async_w3 = Web3(AsyncEthereumTesterProvider())
+
+    async_w3.middleware_onion.inject(
+        await async_construct_result_generator_middleware(
+            {RPCEndpoint("fake_endpoint"): lambda *_: GENERATED_NESTED_DICT_RESULT}
+        ),
+        "result_gen",
+        layer=0,
+    )
+
+    # remove attrdict middleware
+    async_w3.middleware_onion.remove("attrdict")
+
+    response = await async_w3.manager.coro_request("fake_endpoint", [])
+
+    result = response["result"]
+
+    _assert_dict_and_not_attrdict(result)
+    _assert_dict_and_not_attrdict(result["b"])
+    _assert_dict_and_not_attrdict(result["b"]["b2"])
+    _assert_dict_and_not_attrdict(result["b"]["b2"]["b2b"])
+    _assert_dict_and_not_attrdict(result["b"]["b2"]["b2b"]["b2b2"])

--- a/tests/core/middleware/test_filter_middleware.py
+++ b/tests/core/middleware/test_filter_middleware.py
@@ -15,8 +15,10 @@ from web3.eth import (
     AsyncEth,
 )
 from web3.middleware import (
+    async_attrdict_middleware,
     async_construct_result_generator_middleware,
     async_local_filter_middleware,
+    attrdict_middleware,
     construct_result_generator_middleware,
     local_filter_middleware,
 )
@@ -105,6 +107,7 @@ def w3_base():
 @pytest.fixture(scope="function")
 def w3(w3_base, result_generator_middleware):
     w3_base.middleware_onion.add(result_generator_middleware)
+    w3_base.middleware_onion.add(attrdict_middleware)
     w3_base.middleware_onion.add(local_filter_middleware)
     return w3_base
 
@@ -284,6 +287,7 @@ def async_w3_base():
 @pytest.fixture(scope="function")
 def async_w3(async_w3_base, async_result_generator_middleware):
     async_w3_base.middleware_onion.add(async_result_generator_middleware)
+    async_w3_base.middleware_onion.add(async_attrdict_middleware)
     async_w3_base.middleware_onion.add(async_local_filter_middleware)
     return async_w3_base
 

--- a/tests/core/providers/test_async_http_provider.py
+++ b/tests/core/providers/test_async_http_provider.py
@@ -20,6 +20,7 @@ from web3.geth import (
     Geth,
 )
 from web3.middleware import (
+    async_attrdict_middleware,
     async_buffered_gas_estimate_middleware,
     async_gas_price_strategy_middleware,
     async_validation_middleware,
@@ -63,12 +64,13 @@ def test_web3_with_async_http_provider_has_default_middlewares_and_modules() -> 
 
     # the following length check should fail and will need to be added to once more
     # async middlewares are added to the defaults
-    assert len(async_w3.middleware_onion.middlewares) == 3
+    assert len(async_w3.middleware_onion.middlewares) == 4
 
     assert (
         async_w3.middleware_onion.get("gas_price_strategy")
         == async_gas_price_strategy_middleware
     )
+    assert async_w3.middleware_onion.get("attrdict") == async_attrdict_middleware
     assert async_w3.middleware_onion.get("validation") == async_validation_middleware
     assert (
         async_w3.middleware_onion.get("gas_estimate")

--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -208,7 +208,9 @@ def get_event_abi_types_for_decoding(
 
 @curry
 def get_event_data(
-    abi_codec: ABICodec, event_abi: ABIEvent, log_entry: LogReceipt
+    abi_codec: ABICodec,
+    event_abi: ABIEvent,
+    log_entry: LogReceipt,
 ) -> EventData:
     """
     Given an event ABI and a log entry for that event, return the decoded
@@ -269,18 +271,21 @@ def get_event_data(
         )
     )
 
-    event_data = {
-        "args": event_args,
-        "event": event_abi["name"],
-        "logIndex": log_entry["logIndex"],
-        "transactionIndex": log_entry["transactionIndex"],
-        "transactionHash": log_entry["transactionHash"],
-        "address": log_entry["address"],
-        "blockHash": log_entry["blockHash"],
-        "blockNumber": log_entry["blockNumber"],
-    }
+    event_data = EventData(
+        args=event_args,
+        event=event_abi["name"],
+        logIndex=log_entry["logIndex"],
+        transactionIndex=log_entry["transactionIndex"],
+        transactionHash=log_entry["transactionHash"],
+        address=log_entry["address"],
+        blockHash=log_entry["blockHash"],
+        blockNumber=log_entry["blockNumber"],
+    )
 
-    return cast(EventData, AttributeDict.recursive(event_data))
+    if isinstance(log_entry, AttributeDict):
+        return cast(EventData, AttributeDict.recursive(event_data))
+
+    return event_data
 
 
 @to_tuple

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -152,14 +152,14 @@ def is_attrdict(val: Any) -> bool:
     return isinstance(val, AttributeDict)
 
 
-not_attrdict = complement(is_attrdict)
-
-
 @curry
 def type_aware_apply_formatters_to_dict(
     formatters: Formatters,
     value: Union[AttributeDict[str, Any], Dict[str, Any]],
 ) -> Union[ReadableAttributeDict[str, Any], Dict[str, Any]]:
+    """
+    Preserve ``AttributeDict`` types if original ``value`` was an ``AttributeDict``.
+    """
     formatted_dict: Dict[str, Any] = apply_formatters_to_dict(formatters, dict(value))
     return (
         AttributeDict.recursive(formatted_dict)

--- a/web3/contract/async_contract.py
+++ b/web3/contract/async_contract.py
@@ -414,8 +414,8 @@ class AsyncContractEvent(BaseContractEvent):
         )
 
         # Convert raw binary data to Python proxy objects as described by ABI
-        return tuple(
-            get_event_data(self.w3.codec, abi, entry) for entry in logs  # type: ignore
+        return tuple(  # type: ignore
+            get_event_data(self.w3.codec, abi, entry) for entry in logs
         )
 
     @combomethod

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -40,6 +40,7 @@ from web3.exceptions import (
 )
 from web3.middleware import (
     abi_middleware,
+    async_attrdict_middleware,
     async_buffered_gas_estimate_middleware,
     async_gas_price_strategy_middleware,
     async_validation_middleware,
@@ -115,7 +116,7 @@ class RequestManager:
 
         if middlewares is None:
             middlewares = (
-                self.async_default_middlewares(w3)
+                self.async_default_middlewares()
                 if self.provider.is_async
                 else self.default_middlewares(w3)
             )
@@ -143,7 +144,7 @@ class RequestManager:
             (request_parameter_normalizer, "request_param_normalizer"),  # Delete
             (gas_price_strategy_middleware, "gas_price_strategy"),
             (name_to_address_middleware(w3), "name_to_address"),  # Add Async
-            (attrdict_middleware, "attrdict"),  # Delete
+            (attrdict_middleware, "attrdict"),
             (pythonic_middleware, "pythonic"),  # Delete
             (validation_middleware, "validation"),
             (abi_middleware, "abi"),  # Delete
@@ -151,12 +152,13 @@ class RequestManager:
         ]
 
     @staticmethod
-    def async_default_middlewares(w3: "Web3") -> List[Tuple[Middleware, str]]:
+    def async_default_middlewares() -> List[Tuple[Middleware, str]]:
         """
         List the default async middlewares for the request manager.
         """
         return [
             (async_gas_price_strategy_middleware, "gas_price_strategy"),
+            (async_attrdict_middleware, "attrdict"),
             (async_validation_middleware, "validation"),
             (async_buffered_gas_estimate_middleware, "gas_estimate"),
         ]

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -6,9 +6,6 @@ from typing import (
     Sequence,
 )
 
-from web3.middleware.async_cache import (  # noqa: F401
-    _async_simple_cache_middleware as async_simple_cache_middleware,
-)
 from web3.types import (
     Middleware,
     RPCEndpoint,
@@ -18,7 +15,11 @@ from web3.types import (
 from .abi import (  # noqa: F401
     abi_middleware,
 )
+from .async_cache import (  # noqa: F401
+    _async_simple_cache_middleware as async_simple_cache_middleware,
+)
 from .attrdict import (  # noqa: F401
+    async_attrdict_middleware,
     attrdict_middleware,
 )
 from .buffered_gas_estimate import (  # noqa: F401

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -20,6 +20,10 @@ from eth_utils import (
 from web3._utils.compat import (
     Literal,
 )
+from web3.middleware.attrdict import (
+    async_attrdict_middleware,
+    attrdict_middleware,
+)
 from web3.middleware.buffered_gas_estimate import (
     async_buffered_gas_estimate_middleware,
 )
@@ -48,6 +52,7 @@ if TYPE_CHECKING:
 
 class AsyncEthereumTesterProvider(AsyncBaseProvider):
     middlewares = (
+        async_attrdict_middleware,
         async_buffered_gas_estimate_middleware,
         async_default_transaction_fields_middleware,
         async_ethereum_tester_middleware,
@@ -77,6 +82,7 @@ class AsyncEthereumTesterProvider(AsyncBaseProvider):
 
 class EthereumTesterProvider(BaseProvider):
     middlewares = (
+        attrdict_middleware,
         default_transaction_fields_middleware,
         ethereum_tester_middleware,
     )


### PR DESCRIPTION
### What was wrong?

- ``AttributeDict`` leads to typing complications when properties are accessed via attribute, rather than key / value. This doesn't complicate too much since a user can opt for key / value every time but it isn't ideal to provide an option that breaks typing.

closes #1656

### How was it fixed?

The approach suggested in #1656 does not feel like a great resolution since `NamedTuple` will rename any reserved python keywords to `_0`, `_1`, `_2`, etc... Seeing as JSON-RPC responses commonly have properties like `from`, for example, this would not lead to a very good user experience.

- ``AttributeDict`` conversion was removed from the result formatters and moved back to being only in the middleware. A more inclusive recursive approach was taken to make sure all results get passed through the recursive checks for conversion of `dict` to `AttributeDict`. Users who wish to turn off all recursive conversion to ``AttributeDict`` can simply remove the ``attrdict_middleware`` (or ``async_attrdict_middleware``) and not worry about possible typing complications.

- In order for this to work for async as well, support for ``async_attrdict_middleware`` was introduced. This is also now one of the default middlewares for the ``EthereumTesterProvider`` (and `AsyncEthereumTesterProvider`) as `dict` -> `AttributeDict` was the default behavior, via result formatters, for `EthereumTesterProvider`.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
- [x] Fix some broken tests that expect the attrdict result formatter to be present
- [x] Update docs / add new documentation around these changes.
- [x] Add new tests for ``attrdict_middleware`` + ``async_attrdict_middleware``

#### Cute Animal Picture

![20230205_142431](https://user-images.githubusercontent.com/3532824/217056305-a11e286e-d370-45e5-aa53-7faa4280c109.jpg)
