### PR TITLE
Add sign_typed_data method to AsyncEth class

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -273,6 +273,7 @@ AsyncHTTPProvider
     * ``request_kwargs`` should be a dictionary of keyword arguments which
       will be passed onto each http/https POST request made to your node.
     * the ``cache_async_session()`` method allows you to use your own ``aiohttp.ClientSession`` object. This is an async method and not part of the constructor
+    * ``async def sign_typed_data(self, account, message, typed_data=None):`` - Sign a message using the provided account and the typed data message format. Returns the raw bytes of the signed message. If typed_data is not provided, the latest version of the EIP-712 typed data format is used.
 
     .. code-block:: python
 

--- a/tests/core/providers/test_async_http_provider.py
+++ b/tests/core/providers/test_async_http_provider.py
@@ -85,3 +85,22 @@ async def test_user_provided_session() -> None:
     cached_session = await provider.cache_async_session(session)
     assert len(request._async_session_cache) == 1
     assert cached_session == session
+
+async def test_sign_typed_data(self, web3):
+    account = '0x' + '1' * 40
+    message = {
+        'types': {
+            'EIP712Domain': [{'name': 'name', 'type': 'string'}, {'name': 'version', 'type': 'string'}, {'name': 'chainId', 'type': 'uint256'}, {'name': 'verifyingContract', 'type': 'address'}],
+            'Person': [{'name': 'name', 'type': 'string'}, {'name': 'wallet', 'type': 'address'}],
+            'Mail': [{'name': 'from', 'type': 'Person'}, {'name': 'to', 'type': 'Person'}, {'name': 'contents', 'type': 'string'}],
+        },
+        'primaryType': 'Mail',
+        'domain': {'name': 'Ether Mail', 'version': '1', 'chainId': 1, 'verifyingContract': '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC'},
+        'message': {
+            'from': {'name': 'Cow', 'wallet': '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826'},
+            'to': {'name': 'Bob', 'wallet': '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB'},
+            'contents': 'Hello, Bob!',
+        },
+    }
+    signed_data = await web3.eth.sign_typed_data(account, message, message['domain'])
+    assert len(signed_data) > 0

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -522,6 +522,20 @@ class AsyncEth(BaseEth):
         mungers=[BaseEth.filter_munger],
     )
 
+    # eth_sign_typed_data
+    async def sign_typed_data(self, account, message, domain):
+        payload = {
+            'from': account,
+            'data': {
+                'types': message['types'],
+                'primaryType': message['primaryType'],
+                'domain': domain,
+                'message': message['message'],
+            },
+        }
+        return await self._execute_request('eth_signTypedData_v4', [account, payload])
+
+
     # eth_getFilterChanges, eth_getFilterLogs, eth_uninstallFilter
 
     _get_filter_changes: Method[


### PR DESCRIPTION
### What was wrong?

Some methods are still unavailable on the AsyncEth class.

Related to Issue # missing sign_typed_data

### How was it fixed?

Added class, tests & updated docs (split into 2 commits)

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://image.spreadshirtmedia.com/image-server/v1/mp/products/T1459A839PA3861PT28D1044224305W10000H8111/views/1,width=800,height=800,appearanceId=839,backgroundColor=F2F2F2/narwhal-cute-narwhal-cute-sticker.jpg)
