### PR TITLE
Use TypedDict for **kwargs type checking

### DIFF
--- a/web3/_utils/compat/__init__.py
+++ b/web3/_utils/compat/__init__.py
@@ -11,4 +11,5 @@
 from typing_extensions import (
     NotRequired,  # py311
     Self,  # py311
+    Unpack,  # py311
 )

--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -444,8 +444,8 @@ class EventFilterBuilder(BaseEventFilterBuilder):
         if not isinstance(w3, web3.Web3):
             raise Web3ValueError(f"Invalid web3 argument: got: {w3!r}")
 
-        for arg in AttributeDict.values(self.args):
-            arg._immutable = True  # type: ignore[attr-defined]
+        for arg in self.args.values():
+            arg._immutable = True
         self._immutable = True
 
         log_filter = cast("LogFilter", w3.eth.filter(self.filter_params))

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -3657,7 +3657,7 @@ class EthModuleTest:
         txn_hash = w3.eth.send_transaction(txn_params)
 
         modified_txn_hash = w3.eth.modify_transaction(
-            txn_hash, gasPrice=(cast(int, txn_params["gasPrice"]) * 2), value=2
+            txn_hash, gasPrice=(cast(Wei, txn_params["gasPrice"] * 2)), value=Wei(2)
         )
         modified_txn = w3.eth.get_transaction(modified_txn_hash)
 
@@ -3686,9 +3686,9 @@ class EthModuleTest:
 
         modified_txn_hash = w3.eth.modify_transaction(
             txn_hash,
-            value=2,
-            maxPriorityFeePerGas=(cast(Wei, txn_params["maxPriorityFeePerGas"]) * 2),
-            maxFeePerGas=(cast(Wei, txn_params["maxFeePerGas"]) * 2),
+            value=Wei(2),
+            maxPriorityFeePerGas=(cast(Wei, txn_params["maxPriorityFeePerGas"] * 2)),
+            maxFeePerGas=(cast(Wei, txn_params["maxFeePerGas"] * 2)),
         )
         modified_txn = w3.eth.get_transaction(modified_txn_hash)
 

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -220,7 +220,7 @@ class AsyncEthModuleTest:
         txn_hash = await async_w3.eth.send_transaction(txn_params)
 
         modified_txn_hash = await async_w3.eth.modify_transaction(
-            txn_hash, gasPrice=(cast(int, txn_params["gasPrice"]) * 2), value=2
+            txn_hash, gasPrice=(cast(Wei, txn_params["gasPrice"] * 2)), value=Wei(2)
         )
         modified_txn = await async_w3.eth.get_transaction(modified_txn_hash)
 
@@ -252,9 +252,9 @@ class AsyncEthModuleTest:
 
         modified_txn_hash = await async_w3.eth.modify_transaction(
             txn_hash,
-            value=2,
-            maxPriorityFeePerGas=(cast(Wei, txn_params["maxPriorityFeePerGas"]) * 2),
-            maxFeePerGas=(cast(Wei, txn_params["maxFeePerGas"]) * 2),
+            value=Wei(2),
+            maxPriorityFeePerGas=(cast(Wei, txn_params["maxPriorityFeePerGas"] * 2)),
+            maxFeePerGas=(cast(Wei, txn_params["maxFeePerGas"] * 2)),
         )
         modified_txn = await async_w3.eth.get_transaction(modified_txn_hash)
 

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -35,6 +35,9 @@ from web3._utils.async_transactions import (
 from web3._utils.blocks import (
     select_method_for_block_identifier,
 )
+from web3._utils.compat import (
+    Unpack,
+)
 from web3._utils.fee_utils import (
     async_fee_history_priority_fee,
 )
@@ -594,10 +597,8 @@ class AsyncEth(BaseEth):
             self.w3, current_transaction, new_transaction
         )
 
-    # todo: Update Any to stricter kwarg checking with TxParams
-    # https://github.com/python/mypy/issues/4441
     async def modify_transaction(
-        self, transaction_hash: _Hash32, **transaction_params: Any
+        self, transaction_hash: _Hash32, **transaction_params: Unpack[TxParams]
     ) -> HexBytes:
         assert_valid_transaction_params(cast(TxParams, transaction_params))
 

--- a/web3/eth/eth.py
+++ b/web3/eth/eth.py
@@ -30,6 +30,9 @@ from hexbytes import (
 from web3._utils.blocks import (
     select_method_for_block_identifier,
 )
+from web3._utils.compat import (
+    Unpack,
+)
 from web3._utils.fee_utils import (
     fee_history_priority_fee,
 )
@@ -596,10 +599,8 @@ class Eth(BaseEth):
         current_transaction = get_required_transaction(self.w3, transaction_hash)
         return replace_transaction(self.w3, current_transaction, new_transaction)
 
-    # todo: Update Any to stricter kwarg checking with TxParams
-    # https://github.com/python/mypy/issues/4441
     def modify_transaction(
-        self, transaction_hash: _Hash32, **transaction_params: Any
+        self, transaction_hash: _Hash32, **transaction_params: Unpack[TxParams]
     ) -> HexBytes:
         assert_valid_transaction_params(cast(TxParams, transaction_params))
         current_transaction = get_required_transaction(self.w3, transaction_hash)


### PR DESCRIPTION
### What was wrong?

https://github.com/ethereum/web3.py/blob/168fceaf5c6829a8edeb510b997940064295ecf8/web3/eth/eth.py#L551-L555
After [Mypy 0.981](https://mypy-lang.blogspot.com/2022/09/mypy-0981-released.html), it supports precise type annotations for `**kwargs` using TypedDict (https://github.com/python/mypy/pull/13471), like `**transaction_params: Any` can be rewritten as `**transaction_params: Unpack[TxParams]`.

### How was it fixed?

- Upgrade Mypy to 0.981.
- Update `**kwarg` type checking with `Unpack[TxParams]`.
- Add `Unpack` type. The `Unpack` is a built-in type after Python 3.11, so I updated the `web3/_utils/compat`.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://allthatsinteresting.com/wordpress/wp-content/uploads/2020/06/baby-chinchilla.jpg)
