### PR TITLE
Drop down resource class in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ common: &common
           - ~/.ethash
           - ~/.py-geth
         key: cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
-  resource_class: xlarge
+  resource_class: large
 
 docs_steps: &docs_steps
   working_directory: ~/repo
@@ -57,11 +57,11 @@ docs_steps: &docs_steps
           - ~/.ethash
           - ~/.py-geth
         key: cache-docs-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
-  resource_class: xlarge
+  resource_class: large
 
 geth_steps: &geth_steps
   working_directory: ~/repo
-  resource_class: xlarge
+  resource_class: large
   steps:
     - checkout
     - restore_cache:
@@ -145,7 +145,7 @@ geth_custom_steps: &geth_custom_steps
 
 ethpm_steps: &ethpm_steps
   working_directory: ~/repo
-  resource_class: xlarge
+  resource_class: large
   steps:
     - checkout
     - restore_cache:

--- a/newsfragments/2855.misc.rst
+++ b/newsfragments/2855.misc.rst
@@ -1,0 +1,1 @@
+Move resource class on CI from xlarge -> large


### PR DESCRIPTION
### What was wrong?
Apparently we don't have access to the xlarge resource class any more. I suspect something happened with billing on the devops side of the house. 

### How was it fixed?
Dropped down to large resource_class which seems to fix things. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://ichef.bbci.co.uk/news/480/cpsprodpb/3B21/production/_91073151_cheetahcubanddog2314-grahms.jonescolumbuszooandaquarium.jpg)
