### PR TITLE
Replace lru cache with SimpleCache

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -9,7 +9,7 @@ force_sort_within_sections=true
 include_trailing_comma=true
 extra_standard_library=pytest
 known_first_party=web3,ens,ethpm
-known_third_party=lru,eth_tester
+known_third_party=eth_tester
 line_length=88
 use_parentheses=true
 # skip `__init__.py` files because sometimes order of initialization is important

--- a/newsfragments/2884.internal.rst
+++ b/newsfragments/2884.internal.rst
@@ -1,0 +1,1 @@
+Replaced lru cache with simple cache and removed lru-dict dependency.

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,6 @@ setup(
         "eth-utils>=2.1.0",
         "hexbytes>=0.1.0",
         "jsonschema>=4.0.0",
-        "lru-dict>=1.1.6",
         "protobuf>=4.21.6",
         "pywin32>=223;platform_system=='Windows'",
         "requests>=2.16.0",

--- a/web3/middleware/cache.py
+++ b/web3/middleware/cache.py
@@ -14,7 +14,6 @@ from typing import (
 from eth_utils import (
     is_list_like,
 )
-import lru
 
 from web3._utils.caching import (
     generate_cache_key,
@@ -193,7 +192,7 @@ def construct_time_based_cache_middleware(
 
 
 _time_based_cache_middleware = construct_time_based_cache_middleware(
-    cache_class=functools.partial(lru.LRU, 256),
+    cache_class=functools.partial(SimpleCache, 256),
 )
 
 
@@ -366,6 +365,6 @@ def construct_latest_block_based_cache_middleware(
 
 
 _latest_block_based_cache_middleware = construct_latest_block_based_cache_middleware(
-    cache_class=functools.partial(lru.LRU, 256),
+    cache_class=functools.partial(SimpleCache, 256),
     rpc_whitelist=BLOCK_NUMBER_RPC_WHITELIST,
 )


### PR DESCRIPTION
### What was wrong?

Closes https://github.com/ethereum/web3.py/issues/2884

### How was it fixed?

Replaced LRU cache with `SimpleCache` internally and removed usage of `lru-dict`.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![images](https://user-images.githubusercontent.com/3950603/233856372-f01dee22-5f5f-427f-b60a-ba1aa3f8efab.jpeg)

