### PR TITLE
Add result formatters for reward tracing calls

### DIFF
--- a/newsfragments/2929.feature.rst
+++ b/newsfragments/2929.feature.rst
@@ -1,0 +1,1 @@
+Add support via result formatters for ``reward`` type trace actions on tracing calls.

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -552,6 +552,8 @@ TRACE_ACTION_FORMATTERS = apply_formatter_if(
             # suicide type
             "address": to_checksum_address,
             "refundAddress": to_checksum_address,
+            # reward type
+            "author": to_checksum_address,
         }
     ),
 )


### PR DESCRIPTION
### What was wrong?

- Related to observation from a [comment](https://github.com/ethereum/web3.py/issues/2914#issuecomment-1517790941) on a separate issue.

Unfortunately documentation on this type is not great. I found an example in the documented response [here](https://docs.watchdata.io/powered-api/trace/trace_block) for reference.

### How was it fixed?

- Add result formatters for `reward` trace type `action` fields. Missing formatter was `to_checksum_address` for `author`.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fi.etsystatic.com%2F28541990%2Fr%2Fil%2Faaa719%2F2958498074%2Fil_fullxfull.2958498074_hla2.jpg&f=1&nofb=1&ipt=bf0b8536aa930b36eaa08bf9ab4f2c0629b0eaf2a50a71d9695df210445eb4d4&ipo=images)
