### PR TITLE
fix AsyncEventFilterBuilder  looking for Web3 instead of AsyncWeb3

### DIFF
--- a/newsfragments/2931.bugfix.rst
+++ b/newsfragments/2931.bugfix.rst
@@ -1,0 +1,1 @@
+fix AsyncEventFilterBuilder looking for Web3 instead of AsyncWeb3

--- a/tests/core/filtering/utils.py
+++ b/tests/core/filtering/utils.py
@@ -1,4 +1,5 @@
 from web3 import (
+    AsyncWeb3,
     Web3,
 )
 from web3.eth import (
@@ -48,7 +49,7 @@ def _emitter_fixture_logic(
 def _async_w3_fixture_logic(request):
     use_filter_middleware = request.param
     provider = AsyncEthereumTesterProvider()
-    async_w3 = Web3(provider, modules={"eth": [AsyncEth]}, middlewares=[])
+    async_w3 = AsyncWeb3(provider, modules={"eth": [AsyncEth]}, middlewares=[])
 
     if use_filter_middleware:
         async_w3.middleware_onion.add(async_local_filter_middleware)

--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -447,7 +447,7 @@ class EventFilterBuilder(BaseEventFilterBuilder):
 
 class AsyncEventFilterBuilder(BaseEventFilterBuilder):
     async def deploy(self, async_w3: "AsyncWeb3") -> "AsyncLogFilter":
-        if not isinstance(async_w3, web3.Web3):
+        if not isinstance(async_w3, web3.AsyncWeb3):
             raise ValueError(f"Invalid web3 argument: got: {async_w3!r}")
 
         for arg in AttributeDict.values(self.args):
@@ -455,6 +455,7 @@ class AsyncEventFilterBuilder(BaseEventFilterBuilder):
         self._immutable = True
 
         log_filter = await async_w3.eth.filter(self.filter_params)
+        log_filter = cast("AsyncLogFilter", log_filter)
         log_filter.filter_params = self.filter_params
         log_filter.set_data_filters(self.data_argument_values)
         log_filter.builder = self


### PR DESCRIPTION
### What was wrong?

The `AsyncEventFilterBuilder` class was validating for `Web3` instead of `AsyncWeb3`. Tests were passing because the `async_w3` fixture was also `Web3`.

Closes #2931 

### How was it fixed?

Changed `Web3` to `AsyncWeb3` where needed.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/234392136-c26db3d0-d2b8-4ac6-94a6-c93c8310b853.png)
