### PR TITLE
Fixes #2936

### DIFF
--- a/web3/middleware/signing.py
+++ b/web3/middleware/signing.py
@@ -168,7 +168,7 @@ def construct_sign_and_send_raw_middleware(
             account = accounts[transaction["from"]]
             raw_tx = account.sign_transaction(transaction).rawTransaction
 
-            return make_request(RPCEndpoint("eth_sendRawTransaction"), [raw_tx])
+            return make_request(RPCEndpoint("eth_sendRawTransaction"), [raw_tx.hex()])
 
         return middleware
 


### PR DESCRIPTION
You cannot pass Python objects to JSON-RPC. Make sure params are a hex string before calling `make_request`.

### What was wrong?

Related to Issue #2936

### How was it fixed?

Attempted fix. Still need someone to review if the fix is current.

#### Cute Animal Picture

```
\|/          (__)    
     `\------(oo)
       ||    (__)
       ||w--||     \|/
   \|/

```