### PR TITLE
added function to tupleize lists inside (nested) dicts

### DIFF
--- a/newsfragments/2908.bugfix.rst
+++ b/newsfragments/2908.bugfix.rst
@@ -1,0 +1,1 @@
+fix AttributeDicts unhashable if they contain lists recursively tupleizing them

--- a/tests/core/datastructures/test_tuplelize_nested_lists.py
+++ b/tests/core/datastructures/test_tuplelize_nested_lists.py
@@ -1,0 +1,37 @@
+from web3.datastructures import AttributeDict, tupleize_lists_nested
+
+DICT_1 = {
+    "mylst": [1, 2, 3, [4, 5, [6, 7], 8], 9, 10],
+    "nested": {"mylst": [1, 2, 3, [1], [2, 3]]},
+}
+EXPECTED_1 = AttributeDict(
+    {
+        "mylst": (1, 2, 3, (4, 5, (6, 7), 8), 9, 10),
+        "nested": AttributeDict({"mylst": (1, 2, 3, (1,), (2, 3))}),
+    }
+)
+
+DICT_2 = AttributeDict(
+    {
+        "mylst": [1, 2, 3, [4, 5, [6, 7], 8], 9, 10],
+        "nested": AttributeDict({"mylst": [1, 2, 3, [1], [2, 3]]}),
+    }
+)
+EXPECTED_2 = AttributeDict(
+    {
+        "mylst": (1, 2, 3, (4, 5, (6, 7), 8), 9, 10),
+        "nested": AttributeDict({"mylst": (1, 2, 3, (1,), (2, 3))}),
+    }
+)
+
+
+def test_dict_tupleization():
+    assert tupleize_lists_nested(DICT_1) == EXPECTED_1
+    assert tupleize_lists_nested(DICT_2) == EXPECTED_2
+
+
+def test_hashing_success():
+    try:
+        hash(DICT_2)
+    except TypeError:
+        assert False

--- a/tests/core/datastructures/test_tuplelize_nested_lists.py
+++ b/tests/core/datastructures/test_tuplelize_nested_lists.py
@@ -1,4 +1,5 @@
 import pytest
+import re
 
 from web3.datastructures import (
     AttributeDict,
@@ -52,6 +53,42 @@ from web3.datastructures import (
 def test_tupleization_and_hashing(input, expected):
     assert tupleize_lists_nested(input) == expected
     assert hash(AttributeDict(input)) == hash(expected)
+
+
+@pytest.mark.parametrize(
+    "input, error",
+    (
+        (
+            AttributeDict(
+                {
+                    "myset": set({1, 2, 3}),
+                    "nested": AttributeDict({"mylst": (1, 2, 3, (1,), (2, 3))}),
+                }
+            ),
+            {
+                "expected_exception": TypeError,
+                "match": "Found unhashable type 'set': {(1, 2, 3)}",
+            },
+        ),
+        (
+            AttributeDict(
+                {
+                    "mybytearray": bytearray((1, 2, 3)),
+                    "nested": AttributeDict({"mylst": [1, 2, 3, [1], [2, 3]]}),
+                }
+            ),
+            {
+                "expected_exception": TypeError,
+                "match": re.escape(
+                    "Found unhashable type 'bytearray': bytearray(b'\\x01\\x02\\x03')"
+                ),
+            },
+        ),
+    ),
+)
+def test_tupleization_and_hashing_error(input, error):
+    with pytest.raises(**error):
+        assert hash(input)
 
 
 @pytest.mark.parametrize(

--- a/web3/datastructures.py
+++ b/web3/datastructures.py
@@ -129,7 +129,7 @@ def tupleize_lists_nested(d: Mapping[TKey, TValue]) -> AttributeDict[TKey, TValu
     This method converts them to tuples, rendering them hashable.
     """
 
-    def _to_tuple(lst: list) -> tuple:
+    def _to_tuple(lst: List[Any]) -> Any:
         return tuple(_to_tuple(i) if isinstance(i, list) else i for i in lst)
 
     ret = dict()

--- a/web3/datastructures.py
+++ b/web3/datastructures.py
@@ -125,8 +125,9 @@ class AttributeDict(ReadableAttributeDict[TKey, TValue], Hashable):
 
 def tupleize_lists_nested(d: Mapping[TKey, TValue]) -> AttributeDict[TKey, TValue]:
     """
-    Lists inside dicts will throw an error if attempted to be hashed.
-    This method converts them to tuples, rendering them hashable.
+    Unhashable types inside dicts will throw an error if attempted to be hashed.
+    This method converts lists to tuples, rendering them hashable.
+    Other unhashable types found will raise a TypeError
     """
 
     def _to_tuple(lst: List[Any]) -> Any:
@@ -134,10 +135,12 @@ def tupleize_lists_nested(d: Mapping[TKey, TValue]) -> AttributeDict[TKey, TValu
 
     ret = dict()
     for k, v in d.items():
-        if isinstance(v, list):
+        if isinstance(v, List):
             ret[k] = _to_tuple(v)
-        elif isinstance(v, dict) or isinstance(v, ReadableAttributeDict):
+        elif isinstance(v, Mapping):
             ret[k] = tupleize_lists_nested(v)
+        elif not isinstance(v, Hashable):
+            raise TypeError(f"Found unhashable type '{type(v).__name__}': {v}")
         else:
             ret[k] = v
     return AttributeDict(ret)


### PR DESCRIPTION
### What was wrong?

Closes #2908

### How was it fixed?

Tupleized (nested) lists to render them hash-able inside `AttributeDict` instances

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://dl5zpyw5k3jeb.cloudfront.net/photos/pets/61590987/1/?bust=1682356824&width=720)

This is Rosie. Adoption profile here: https://www.petfinder.com/dog/rosie-61590987/ny/canastota/wanderers-rest-humane-association-ny79/
