### PR TITLE
Don't format if 'withdrawals' coming back from get_block is null

### DIFF
--- a/newsfragments/2941.bugfix.rst
+++ b/newsfragments/2941.bugfix.rst
@@ -1,0 +1,1 @@
+Add check for null withdrawal field on get_block response

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -297,7 +297,9 @@ BLOCK_FORMATTERS = {
         )
     ),
     "transactionsRoot": apply_formatter_if(is_not_null, to_hexbytes(32)),
-    "withdrawals": apply_formatter_to_array(withdrawal_result_formatter),
+    "withdrawals": apply_formatter_if(
+        is_not_null, apply_list_to_array_formatter(withdrawal_result_formatter)
+    ),
     "withdrawalsRoot": apply_formatter_if(is_not_null, to_hexbytes(32)),
 }
 


### PR DESCRIPTION
### What was wrong?
Before 1.11.1, Geth was sending back the `withdrawal` field as nil (See: https://github.com/ethereum/go-ethereum/pull/26707)

Closes #2932 

### How was it fixed?

Added a is_not_null check to the `withdrawals` field on the block formatter results.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/1200x/46/46/fa/4646fa202ac0f1dac9342dd42dd09d2d.jpg)
