### PR TITLE
Drop resource class so third party PRs can run CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ common: &common
           - ~/.ethash
           - ~/.py-geth
         key: cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
-  resource_class: xlarge
+  resource_class: large
 
 docs_steps: &docs_steps
   working_directory: ~/repo
@@ -72,11 +72,11 @@ docs_steps: &docs_steps
           - ~/.ethash
           - ~/.py-geth
         key: cache-docs-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
-  resource_class: xlarge
+  resource_class: large
 
 geth_steps: &geth_steps
   working_directory: ~/repo
-  resource_class: xlarge
+  resource_class: large
   steps:
     - checkout
     - restore_cache:
@@ -163,7 +163,7 @@ geth_custom_steps: &geth_custom_steps
 
 ethpm_steps: &ethpm_steps
   working_directory: ~/repo
-  resource_class: xlarge
+  resource_class: large
   steps:
     - checkout
     - restore_cache:


### PR DESCRIPTION
### What was wrong?

Related to Issue #

### How was it fixed?

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
