### PR TITLE
remove ens docs reference to ability to specify a list of providers

### DIFF
--- a/docs/ens_overview.rst
+++ b/docs/ens_overview.rst
@@ -16,7 +16,7 @@ Setup
 Create an :class:`~ens.ENS` object (named ``ns`` below) in one of three ways:
 
 1. Automatic detection
-2. Specify an instance or list of :ref:`providers`
+2. Specify an instance of a :ref:`provider <providers>`
 3. From an existing :class:`web3.Web3` object
 
 .. code-block:: python

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -66,10 +66,6 @@ center.  The Provider then handles the request, producing a response which will
 then pass back out from the center of the onion, through each layer until it is
 finally returned by the Manager.
 
-In the situation where web3 is operating with multiple providers the same
-lifecycle applies.  The manager will iterate over each provider, returning the
-response from the first provider that returns a response.
-
 
 Providers
 ---------

--- a/newsfragments/2949.doc.rst
+++ b/newsfragments/2949.doc.rst
@@ -1,0 +1,1 @@
+remove reference to the ability to specify a list of providers - you can't anymore


### PR DESCRIPTION
### What was wrong?

Dangling reference to the ability to set multiple providers was still in the ENS docs.
Related to Issue #1701 

### How was it fixed?

Removed said reference.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/92396399-cc4e-4b40-a457-936049e6f88e)
