### PR TITLE
Deprecate `ethPM`

### DIFF
--- a/docs/ethpm.rst
+++ b/docs/ethpm.rst
@@ -3,6 +3,9 @@
 ethPM
 =====
 
+.. warning::
+   The ``ethPM`` module is no longer being maintained and will be deprecated with ``web3.py`` version 7.
+
 Overview
 --------
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -391,6 +391,9 @@ Output:
 Working with Contracts via ethPM
 --------------------------------
 
+.. warning::
+   The ``ethPM`` module is no longer being maintained and will be deprecated with ``web3.py`` version 7.
+
 `ethPM <http://www.ethpm.com/>`__ packages contain configured contracts ready for use. Web3's ``ethpm`` module (``web3.pm``)
 extends Web3's native ``Contract`` module, with a few modifications for how you instantiate ``Contract`` factories and instances.
 

--- a/ethpm/__init__.py
+++ b/ethpm/__init__.py
@@ -1,5 +1,12 @@
+import warnings
 from pathlib import Path
 
+
+warnings.warn(
+    "The ``ethPM`` module is no longer being maintained and will be "
+    "deprecated with ``web3.py`` version 7",
+    UserWarning,
+)
 
 ETHPM_DIR = Path(__file__).parent
 ASSETS_DIR = ETHPM_DIR / "assets"

--- a/newsfragments/2953.deprecation.rst
+++ b/newsfragments/2953.deprecation.rst
@@ -1,0 +1,1 @@
+add deprecation notice for `ethPM` module

--- a/newsfragments/2953.deprecation.rst
+++ b/newsfragments/2953.deprecation.rst
@@ -1,1 +1,1 @@
-add deprecation notice for `ethPM` module
+add deprecation notice for the `ethPM` module

--- a/newsfragments/2953.doc.rst
+++ b/newsfragments/2953.doc.rst
@@ -1,0 +1,1 @@
+add deprecation notice for the `ethPM` module

--- a/newsfragments/README.md
+++ b/newsfragments/README.md
@@ -11,6 +11,7 @@ Each file should be named like `<ISSUE>.<TYPE>.rst`, where
 * `feature`
 * `bugfix`
 * `performance`
+* `deprecation`
 * `doc`
 * `internal`
 * `removal`

--- a/newsfragments/validate_files.py
+++ b/newsfragments/validate_files.py
@@ -9,6 +9,7 @@ import sys
 ALLOWED_EXTENSIONS = {
     '.breaking.rst',
     '.bugfix.rst',
+    '.deprecation.rst',
     '.doc.rst',
     '.feature.rst',
     '.internal.rst',


### PR DESCRIPTION
### What was wrong?

The `ethPM` module is not being actively maintained. It will be deprecated in v7.

### How was it fixed?

Added deprecation notes to relevant docs.
Added deprecation `UserWarning` to the module.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/10ac1a67-dd54-4758-915f-d45d2e190707)
