### PR TITLE
Fix assertion error when w3 used as abi function name

### DIFF
--- a/tests/core/contracts/test_contract_class_construction.py
+++ b/tests/core/contracts/test_contract_class_construction.py
@@ -1,6 +1,6 @@
+import copy
 import json
 import pytest
-import copy
 
 from eth_utils import (
     decode_hex,

--- a/tests/core/contracts/test_contract_class_construction.py
+++ b/tests/core/contracts/test_contract_class_construction.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+import copy
 
 from eth_utils import (
     decode_hex,
@@ -40,6 +41,30 @@ def test_abi_as_json_string(w3, math_contract_abi, some_address):
 
     math = math_contract_factory(some_address)
     assert math.abi == math_contract_abi
+
+
+def test_abi_as_json_string_with_alternative_name(w3, math_contract_abi, some_address):
+    abi = copy.deepcopy(math_contract_abi)
+    abi[1]["name"] = "something_else"
+    abi_str = json.dumps(abi)
+
+    math_contract_factory = w3.eth.contract(abi=abi_str)
+    assert math_contract_factory.abi == abi
+
+    math = math_contract_factory(some_address)
+    assert math.abi == abi
+
+
+def test_abi_as_json_string_with_w3_name(w3, math_contract_abi, some_address):
+    abi = copy.deepcopy(math_contract_abi)
+    abi[1]["name"] = "w3"
+    abi_str = json.dumps(abi)
+
+    math_contract_factory = w3.eth.contract(abi=abi_str)
+    assert math_contract_factory.abi == abi
+
+    math = math_contract_factory(some_address)
+    assert math.abi == abi
 
 
 def test_error_to_call_non_existent_fallback(

--- a/web3/contract/contract.py
+++ b/web3/contract/contract.py
@@ -577,14 +577,14 @@ class ContractCaller(BaseContractCaller):
             for func in self._functions:
                 fn = ContractFunction.factory(
                     func["name"],
-                    w3=self.w3,
+                    w3=w3,
                     contract_abi=self.abi,
                     address=self.address,
                     function_identifier=func["name"],
                     decode_tuples=decode_tuples,
                 )
 
-                block_id = parse_block_identifier(self.w3, block_identifier)
+                block_id = parse_block_identifier(w3, block_identifier)
                 caller_method = partial(
                     self.call_function,
                     fn,


### PR DESCRIPTION
### What was wrong?

Created an issue #2955 

Creating a contract from an ABI with a function called "w3" caused an exception:
```
Traceback (most recent call last):
  File "testcaseweb3.py", line 33, in <module>
    failing = w3.eth.contract(address=address, abi=failing_abi)
  File "web3.py/web3/eth/eth.py", line 652, in contract
    ContractFactory = ContractFactoryClass.factory(self.w3, **kwargs)
  File "web3.py/web3/contract/contract.py", line 320, in factory
    contract.caller = ContractCaller(
  File "web3.py/web3/contract/contract.py", line 585, in __init__
    block_id = parse_block_identifier(self.w3, block_identifier)
  File "web3.py/web3/_utils/contracts.py", line 417, in parse_block_identifier
    return w3.eth.default_block
AttributeError: 'functools.partial' object has no attribute 'eth'
```

### How was it fixed?

I copied the existing test case which used the MATH_CONTRACT_ABI to show that changing the name of the function from "add" to "w3" caused the test to fail. I also added another test case to show that changing the name to "something_else" was fine.

I'm not familiar with the internals here but it seems that members found in the ABI get added to the class directly and this is breaking any place in the class that uses `self.w3`. I thought it might be a fun fix to use a variable name that was valid in Python but not Solidity, maybe something with extended Unicode like a Japanese word, but in the end it just seemed as though I could pass the original argument variable from the constructor rather than the one in `self`.

I'm not sure if this might manifest itself as a problem elsewhere, and I didn't actually test calling a function named w3 so it would probably be prudent to do so but I figured pointing this out, getting the PR created, and letting the test suite run was probs best to do first.

Let me know if there's anything else I can do on this.

Cheers.