### PR TITLE
Resources page

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -1,0 +1,49 @@
+.. _resources:
+
+Resources and learning material
+===============================
+
+Web3.py has an active community. You can find third party libraries, tutorials,
+examples, courses and other learning material.
+
+Courses
+-------
+
+- `freeCodeCamp Solidity and Python course <https://www.youtube.com/watch?v=umg2fWQX6jM>`__
+- `Blockchain Python programming tutorial (old, 2019) <https://www.youtube.com/watch?v=pZSegEXtgAE>`__
+
+Frameworks and tooling
+----------------------
+
+- `ApeWorX - The Ethereum development framework for Python Developers, Data Scientists, and Security Professionals <https://www.apeworx.io/>`__
+- `Brownie - A Python-based development and testing framework for smart contracts targeting the Ethereum Virtual Machine. <https://github.com/eth-brownie/brownie>`__
+
+.. warning ::
+
+    Brownie lacks active maintenance. 
+    `See migration guide to ApeWorX <https://academy.apeworx.io/articles/porting-brownie-to-ape>`__
+
+    
+
+Libraries
+---------
+
+- `web3-ethereum-defi - Library for DeFi trading and protocols (Uniswap, PancakeSwap, Sushi, Aave, Chainlink) <https://github.com/tradingstrategy-ai/web3-ethereum-defi>`__
+- `lighter-v1-python - Lighter.xyz client for Python - <https://github.com/elliottech/lighter-v1-python>`__
+- `uniswap-python - a library lets you easily retrieve prices and make trades on all Uniswap versions. <https://uniswap-python.com/>`__
+- `pyWalletConnect - A WalletConnect implementation for wallets in Python <https://github.com/bitlogik/pyWalletConnect>`__
+- `dydx-v3-python - Python client for dYdX v3 <https://github.com/dydxprotocol/dydx-v3-python>`__
+- `Lido Python SDK - A library with which you can get all Lido validator's signatures and check their validity <https://github.com/lidofinance/lido-python-sdk>`__
+
+Conference presentations and videos
+-----------------------------------
+
+- `Web3.Py - Now And Near Future by Marc Garreau (2022, 15 mins) <https://www.youtube.com/watch?v=hj6ubyyE_TY>`__
+- `Python and DeFi by Curve Finance (2022, 15 mins) <https://www.youtube.com/watch?v=4HOU3z0LoDg>`__
+- `Working with MetaMask in Python by Rishab Kattimani (2022, 15 mins) <https://www.youtube.com/watch?v=cFB1BGeCpn0>`__
+
+Applications
+------------
+
+- `StakeWise Oracle <https://github.com/stakewise/oracle/>`__
+

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -23,7 +23,10 @@ Frameworks and tooling
     Brownie lacks active maintenance. 
     `See migration guide to ApeWorX <https://academy.apeworx.io/articles/porting-brownie-to-ape>`__
 
-    
+Smart contracts programming languages
+-------------------------------------
+
+- `Vyper - Contract-oriented, pythonic programming language that targets EVM <https://docs.vyperlang.org/en/stable/>`__
 
 Libraries
 ---------

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -1,18 +1,25 @@
 .. _resources:
 
-Resources and learning material
+
+Resources and Learning Material
 ===============================
 
-Web3.py has an active community. You can find third party libraries, tutorials,
-examples, courses and other learning material.
+Web3.py has an active community of developers and educators. Here you'll find find third-party
+libraries, tutorials, examples, courses and other learning material.
+
+.. warning ::
+
+  Links on this page are community submissions and are not vetted by the team that maintains
+  web3.py. As always, DYOR (Do Your Own Research).
 
 Courses
 -------
 
-- `freeCodeCamp Solidity and Python course <https://www.youtube.com/watch?v=umg2fWQX6jM>`__
-- `Blockchain Python programming tutorial (old, 2019) <https://www.youtube.com/watch?v=pZSegEXtgAE>`__
+- `freeCodeCamp Solidity and Python Course (2022) <https://www.youtube.com/watch?v=umg2fWQX6jM>`__
+- `Blockchain Python Programming Tutorial (2019) <https://www.youtube.com/watch?v=pZSegEXtgAE>`__
 
-Frameworks and tooling
+
+Frameworks and Tooling
 ----------------------
 
 - `ApeWorX - The Ethereum development framework for Python Developers, Data Scientists, and Security Professionals <https://www.apeworx.io/>`__
@@ -20,13 +27,15 @@ Frameworks and tooling
 
 .. warning ::
 
-    Brownie lacks active maintenance. 
-    `See migration guide to ApeWorX <https://academy.apeworx.io/articles/porting-brownie-to-ape>`__
+  Brownie lacks active maintenance. 
+  `See migration guide to ApeWorX <https://academy.apeworx.io/articles/porting-brownie-to-ape>`__.
 
-Smart contracts programming languages
--------------------------------------
+
+Smart Contract Programming Languages
+------------------------------------
 
 - `Vyper - Contract-oriented, pythonic programming language that targets EVM <https://docs.vyperlang.org/en/stable/>`__
+
 
 Libraries
 ---------
@@ -38,15 +47,16 @@ Libraries
 - `dydx-v3-python - Python client for dYdX v3 <https://github.com/dydxprotocol/dydx-v3-python>`__
 - `Lido Python SDK - Library with which you can get all Lido validator's signatures and check their validity <https://github.com/lidofinance/lido-python-sdk>`__
 
-Conference presentations and videos
+
+Conference Presentations and Videos
 -----------------------------------
 
 - `Web3.Py - Now And Near Future by Marc Garreau (2022, 15 mins) <https://www.youtube.com/watch?v=hj6ubyyE_TY>`__
 - `Python and DeFi by Curve Finance (2022, 15 mins) <https://www.youtube.com/watch?v=4HOU3z0LoDg>`__
 - `Working with MetaMask in Python by Rishab Kattimani (2022, 15 mins) <https://www.youtube.com/watch?v=cFB1BGeCpn0>`__
 
+
 Applications
 ------------
 
 - `StakeWise Oracle <https://github.com/stakewise/oracle/>`__
-

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -16,7 +16,7 @@ Frameworks and tooling
 ----------------------
 
 - `ApeWorX - The Ethereum development framework for Python Developers, Data Scientists, and Security Professionals <https://www.apeworx.io/>`__
-- `Brownie - A Python-based development and testing framework for smart contracts targeting the Ethereum Virtual Machine. <https://github.com/eth-brownie/brownie>`__
+- `Brownie - A Python-based development and testing framework for smart contracts targeting EVM. <https://github.com/eth-brownie/brownie>`__
 
 .. warning ::
 
@@ -28,12 +28,12 @@ Frameworks and tooling
 Libraries
 ---------
 
-- `web3-ethereum-defi - Library for DeFi trading and protocols (Uniswap, PancakeSwap, Sushi, Aave, Chainlink) <https://github.com/tradingstrategy-ai/web3-ethereum-defi>`__
-- `lighter-v1-python - Lighter.xyz client for Python - <https://github.com/elliottech/lighter-v1-python>`__
-- `uniswap-python - a library lets you easily retrieve prices and make trades on all Uniswap versions. <https://uniswap-python.com/>`__
-- `pyWalletConnect - A WalletConnect implementation for wallets in Python <https://github.com/bitlogik/pyWalletConnect>`__
+- `Web3 Ethereum DeFi - Library for DeFi trading and protocols (Uniswap, PancakeSwap, Sushi, Aave, Chainlink) <https://github.com/tradingstrategy-ai/web3-ethereum-defi>`__
+- `lighter-v1-python - Lighter.xyz DEX client for Python <https://github.com/elliottech/lighter-v1-python>`__
+- `uniswap-python - Library lets you easily retrieve prices and make trades on all Uniswap versions. <https://uniswap-python.com/>`__
+- `pyWalletConnect - WalletConnect implementation for wallets in Python <https://github.com/bitlogik/pyWalletConnect>`__
 - `dydx-v3-python - Python client for dYdX v3 <https://github.com/dydxprotocol/dydx-v3-python>`__
-- `Lido Python SDK - A library with which you can get all Lido validator's signatures and check their validity <https://github.com/lidofinance/lido-python-sdk>`__
+- `Lido Python SDK - Library with which you can get all Lido validator's signatures and check their validity <https://github.com/lidofinance/lido-python-sdk>`__
 
 Conference presentations and videos
 -----------------------------------

--- a/docs/toc.rst
+++ b/docs/toc.rst
@@ -51,6 +51,7 @@ Table of Contents
     :maxdepth: 1
     :caption: Community
 
+    resources
     contributing
     code_of_conduct
 

--- a/newsfragments/2957.docs.rst
+++ b/newsfragments/2957.docs.rst
@@ -1,0 +1,1 @@
+Introduces resources page to documentation


### PR DESCRIPTION
### What was wrong?

There was no good starting point to explore and learn the wider Web3.py ecosystem.

### How was it fixed?

Added **Resources and learning material page** in Documentation.

<img width="1086" alt="image" src="https://github.com/ethereum/web3.py/assets/49922/ab02af3b-899f-4077-91a0-f4995d94a342">


[Inspired by the similar Vyper page](https://docs.vyperlang.org/en/latest/resources.html).

I hope to add more material and links later.

**Note**: We should make sure the page is also published in the stable branch of documentation.

#### Cute Animal Picture

```
              (      )
              ~(^^^^)~
               ) @@ \~_          |\
              /     | \        \~ /
             ( 0  0  ) \        | |
              ---___/~  \       | |
               /'__/ |   ~-_____/ |
o          _   ~----~      ___---~
  O       //     |         |
         ((~\  _|         -|
   o  O //-_ \/ |        ~  |
        ^   \_ /         ~  |
               |          ~ |
               |     /     ~ |
               |     (       |
                \     \      /\
               / -_____-\   \ ~~-*
               |  /       \  \
               / /         / /
             /~  |       /~  |
             ~~~~        ~~~~
```
