### PR TITLE
Shanghai eth tester changes

### DIFF
--- a/docs/web3.contract.rst
+++ b/docs/web3.contract.rst
@@ -1106,7 +1106,7 @@ Event Log Object
      'blockNumber': 2})]
     >>> transfer_filter.get_new_entries()
     []
-    >>> tx_hash = contract.functions.transfer(alice, 10).transact({'gas': 899000, 'gasPrice': 674302241})
+    >>> tx_hash = contract.functions.transfer(alice, 10).transact({'gas': 899000, 'gasPrice': 1000000000})
     >>> tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
     >>> transfer_filter.get_new_entries()
     [AttributeDict({'args': AttributeDict({'from': '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf',
@@ -1115,7 +1115,7 @@ Event Log Object
      'event': 'Transfer',
      'logIndex': 0,
      'transactionIndex': 0,
-     'transactionHash': HexBytes('0xa23e7ef4d2692c5cf34ee99123c9c73099e9c3b68c7850f91c1cbcb91ac327e0'),
+     'transactionHash': HexBytes('...'),
      'address': '0xF2E246BB76DF876Cef8b38ae84130F4F55De395b',
      'blockHash': HexBytes('...'),
      'blockNumber': 3})]
@@ -1126,7 +1126,7 @@ Event Log Object
      'event': 'Transfer',
      'logIndex': 0,
      'transactionIndex': 0,
-     'transactionHash': HexBytes('0x9da859237e7259832b913d51cb128c8d73d1866056f7a41b52003c953e749678'),
+     'transactionHash': HexBytes('...'),
      'address': '0xF2E246BB76DF876Cef8b38ae84130F4F55De395b',
      'blockHash': HexBytes('...'),
      'blockNumber': 2}),
@@ -1136,7 +1136,7 @@ Event Log Object
      'event': 'Transfer',
      'logIndex': 0,
      'transactionIndex': 0,
-     'transactionHash': HexBytes('0xa23e7ef4d2692c5cf34ee99123c9c73099e9c3b68c7850f91c1cbcb91ac327e0'),
+     'transactionHash': HexBytes('...'),
      'address': '0xF2E246BB76DF876Cef8b38ae84130F4F55De395b',
      'blockHash': HexBytes('...'),
      'blockNumber': 3})]

--- a/newsfragments/2958.feature.rst
+++ b/newsfragments/2958.feature.rst
@@ -1,0 +1,1 @@
+Update ``eth-tester`` to pull in Shanghai changes and make additional changes to fully support Shanghai with ``eth-tester``.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import (
 
 extras_require = {
     "tester": [
-        "eth-tester[py-evm]==v0.8.0-b.3",
+        "eth-tester[py-evm]==v0.9.0-b.1",
         "py-geth>=3.11.0",
     ],
     "linter": [

--- a/tests/core/eth-tester-api/test_withdrawals.py
+++ b/tests/core/eth-tester-api/test_withdrawals.py
@@ -1,0 +1,55 @@
+from hexbytes import (
+    HexBytes,
+)
+
+from web3.datastructures import (
+    AttributeDict,
+)
+
+
+def test_eth_tester_apply_withdrawals(w3):
+    w3.provider.ethereum_tester.backend.apply_withdrawals(
+        [
+            {
+                "index": 2**64 - 1,
+                "validator_index": 2**64 - 1,
+                "address": b"\x01" * 20,
+                "amount": 2**64 - 1,
+            },
+            {
+                "index": 1,
+                "validator_index": 1,
+                "address": b"\x02" * 20,
+                "amount": 1,
+            },
+        ]
+    )
+    latest_block = w3.eth.get_block("latest")
+
+    # check that `withdrawals_root` (snakecase) is converted to
+    # `withdrawalsRoot` (camelcase) in the eth-tester middleware
+    assert hasattr(latest_block, "withdrawalsRoot")
+    assert latest_block["withdrawalsRoot"] == HexBytes(
+        "0xb495df754a123dffeb8c2c0daf3f575a82987e8ff32676fdf6362ed52f1aa3d3"
+    )
+    assert hasattr(latest_block, "withdrawals")
+    assert latest_block["withdrawals"] == [
+        AttributeDict(
+            {
+                "index": 2**64 - 1,
+                # check that `validator_index` (snakecase) is converted to
+                # `validatorIndex` (camelcase) in the eth-tester middleware
+                "validatorIndex": 2**64 - 1,
+                "address": f"0x{'01' * 20}",  # bytes -> hex
+                "amount": 2**64 - 1,
+            }
+        ),
+        AttributeDict(
+            {
+                "index": 1,
+                "validatorIndex": 1,  # snakecase -> camelcase
+                "address": f"0x{'02' * 20}",  # bytes -> hex
+                "amount": 1,
+            }
+        ),
+    ]

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -193,6 +193,7 @@ BLOCK_RESULT_KEY_MAPPING = {
     # there is no longer any mining happening, but the current
     # JSON-RPC spec still says miner
     "coinbase": "miner",
+    "withdrawals_root": "withdrawalsRoot",
 }
 block_result_remapper = apply_key_map(BLOCK_RESULT_KEY_MAPPING)
 

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -103,12 +103,6 @@ transaction_request_transformer = compose(
     transaction_request_formatter,
 )
 
-BLOCK_FORMATTERS = {
-    "logsBloom": integer_to_hex,
-}
-block_formatter = apply_formatters_to_dict(BLOCK_FORMATTERS)
-
-
 FILTER_REQUEST_KEY_MAPPING = {
     "fromBlock": "from_block",
     "toBlock": "to_block",
@@ -196,6 +190,14 @@ BLOCK_RESULT_KEY_MAPPING = {
     "withdrawals_root": "withdrawalsRoot",
 }
 block_result_remapper = apply_key_map(BLOCK_RESULT_KEY_MAPPING)
+
+BLOCK_FORMATTERS = {
+    "logsBloom": integer_to_hex,
+    "withdrawals": apply_list_to_array_formatter(
+        apply_key_map({"validator_index": "validatorIndex"}),
+    ),
+}
+block_formatter = apply_formatters_to_dict(BLOCK_FORMATTERS)
 
 
 RECEIPT_RESULT_FORMATTERS = {

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -191,13 +191,13 @@ BLOCK_RESULT_KEY_MAPPING = {
 }
 block_result_remapper = apply_key_map(BLOCK_RESULT_KEY_MAPPING)
 
-BLOCK_FORMATTERS = {
+BLOCK_RESULT_FORMATTERS = {
     "logsBloom": integer_to_hex,
     "withdrawals": apply_list_to_array_formatter(
         apply_key_map({"validator_index": "validatorIndex"}),
     ),
 }
-block_formatter = apply_formatters_to_dict(BLOCK_FORMATTERS)
+block_result_formatter = apply_formatters_to_dict(BLOCK_RESULT_FORMATTERS)
 
 
 RECEIPT_RESULT_FORMATTERS = {
@@ -270,11 +270,11 @@ request_formatters = {
 result_formatters: Optional[Dict[RPCEndpoint, Callable[..., Any]]] = {
     RPCEndpoint("eth_getBlockByHash"): apply_formatter_if(
         is_dict,
-        compose(block_result_remapper, block_formatter),
+        compose(block_result_remapper, block_result_formatter),
     ),
     RPCEndpoint("eth_getBlockByNumber"): apply_formatter_if(
         is_dict,
-        compose(block_result_remapper, block_formatter),
+        compose(block_result_remapper, block_result_formatter),
     ),
     RPCEndpoint("eth_getBlockTransactionCountByHash"): apply_formatter_if(
         is_dict,

--- a/web3/types.py
+++ b/web3/types.py
@@ -63,6 +63,7 @@ Nonce = NewType("Nonce", int)
 RPCEndpoint = NewType("RPCEndpoint", str)
 Timestamp = NewType("Timestamp", int)
 Wei = NewType("Wei", int)
+Gwei = NewType("Gwei", int)
 Formatters = Dict[RPCEndpoint, Callable[..., Any]]
 
 
@@ -239,6 +240,17 @@ TxParams = TypedDict(
 )
 
 
+WithdrawalData = TypedDict(
+    "WithdrawalData",
+    {
+        "index": int,
+        "validator_index": int,
+        "address": ChecksumAddress,
+        "amount": Gwei,
+    },
+)
+
+
 CallOverrideParams = TypedDict(
     "CallOverrideParams",
     {
@@ -355,10 +367,12 @@ class BlockData(TypedDict, total=False):
     stateRoot: HexBytes
     timestamp: Timestamp
     totalDifficulty: int
-    # list of tx hashes or of txdatas
     transactions: Union[Sequence[HexBytes], Sequence[TxData]]
     transactionsRoot: HexBytes
     uncles: Sequence[HexBytes]
+    withdrawals: Sequence[WithdrawalData]
+    withdrawalsRoot: HexBytes
+
     # geth_poa_middleware replaces extraData w/ proofOfAuthorityData
     proofOfAuthorityData: HexBytes
 


### PR DESCRIPTION
- Shanghai support for `eth-tester` + `py-evm` and add appropriate formatters and tests
- Update `BlockData` to include `withdrawals` and `withdrawalsRoot` fields
- Peripheral updates related to above changes

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%3Fid%3DOIP.4ThSCJktf1nn1MsERL-tvAHaE7%26pid%3DApi&f=1&ipt=8f29cb6844795f0d695a4cf9a064c0d9b5bc1fca523fd447ac94de359d323996&ipo=images)
