### PR TITLE
complete docstrings for `ContractFunction` and reorder contract classes

### DIFF
--- a/newsfragments/2960.docs.rst
+++ b/newsfragments/2960.docs.rst
@@ -1,0 +1,1 @@
+Completed docstrings for `ContractFunction` and `AsyncContractFunction` classes

--- a/newsfragments/2960.misc.rst
+++ b/newsfragments/2960.misc.rst
@@ -1,0 +1,1 @@
+Put related contract classes in similar order in their respective files

--- a/web3/contract/async_contract.py
+++ b/web3/contract/async_contract.py
@@ -93,6 +93,288 @@ if TYPE_CHECKING:
     from web3 import AsyncWeb3  # noqa: F401
 
 
+class AsyncContractEvent(BaseContractEvent):
+    # mypy types
+    w3: "AsyncWeb3"
+
+    @combomethod
+    async def get_logs(
+        self,
+        argument_filters: Optional[Dict[str, Any]] = None,
+        fromBlock: Optional[BlockIdentifier] = None,
+        toBlock: Optional[BlockIdentifier] = None,
+        block_hash: Optional[HexBytes] = None,
+    ) -> Awaitable[Iterable[EventData]]:
+        """Get events for this contract instance using eth_getLogs API.
+
+        This is a stateless method, as opposed to createFilter.
+        It can be safely called against nodes which do not provide
+        eth_newFilter API, like Infura nodes.
+
+        If there are many events,
+        like ``Transfer`` events for a popular token,
+        the Ethereum node might be overloaded and timeout
+        on the underlying JSON-RPC call.
+
+        Example - how to get all ERC-20 token transactions
+        for the latest 10 blocks:
+
+        .. code-block:: python
+
+            from = max(mycontract.web3.eth.block_number - 10, 1)
+            to = mycontract.web3.eth.block_number
+
+            events = mycontract.events.Transfer.getLogs(fromBlock=from, toBlock=to)
+
+            for e in events:
+                print(e["args"]["from"],
+                    e["args"]["to"],
+                    e["args"]["value"])
+
+        The returned processed log values will look like:
+
+        .. code-block:: python
+
+            (
+                AttributeDict({
+                 'args': AttributeDict({}),
+                 'event': 'LogNoArguments',
+                 'logIndex': 0,
+                 'transactionIndex': 0,
+                 'transactionHash': HexBytes('...'),
+                 'address': '0xF2E246BB76DF876Cef8b38ae84130F4F55De395b',
+                 'blockHash': HexBytes('...'),
+                 'blockNumber': 3
+                }),
+                AttributeDict(...),
+                ...
+            )
+
+        See also: :func:`web3.middleware.filter.local_filter_middleware`.
+
+        :param argument_filters:
+        :param fromBlock: block number or "latest", defaults to "latest"
+        :param toBlock: block number or "latest". Defaults to "latest"
+        :param blockHash: block hash. blockHash cannot be set at the
+          same time as fromBlock or toBlock
+        :yield: Tuple of :class:`AttributeDict` instances
+        """
+        abi = self._get_event_abi()
+        # Call JSON-RPC API
+        logs = await self.w3.eth.get_logs(
+            self._get_event_filter_params(
+                abi, argument_filters, fromBlock, toBlock, block_hash
+            )
+        )
+
+        # Convert raw binary data to Python proxy objects as described by ABI
+        return tuple(  # type: ignore
+            get_event_data(self.w3.codec, abi, entry) for entry in logs
+        )
+
+    @combomethod
+    async def create_filter(
+        self,
+        *,  # PEP 3102
+        argument_filters: Optional[Dict[str, Any]] = None,
+        fromBlock: Optional[BlockIdentifier] = None,
+        toBlock: BlockIdentifier = "latest",
+        address: Optional[ChecksumAddress] = None,
+        topics: Optional[Sequence[Any]] = None,
+    ) -> AsyncLogFilter:
+        """
+        Create filter object that tracks logs emitted by this contract event.
+        """
+        filter_builder = AsyncEventFilterBuilder(self._get_event_abi(), self.w3.codec)
+        self._set_up_filter_builder(
+            argument_filters,
+            fromBlock,
+            toBlock,
+            address,
+            topics,
+            filter_builder,
+        )
+        log_filter = await filter_builder.deploy(self.w3)
+        log_filter.log_entry_formatter = get_event_data(
+            self.w3.codec, self._get_event_abi()
+        )
+        log_filter.builder = filter_builder
+
+        return log_filter
+
+    @combomethod
+    def build_filter(self) -> AsyncEventFilterBuilder:
+        builder = AsyncEventFilterBuilder(
+            self._get_event_abi(),
+            self.w3.codec,
+            formatter=get_event_data(self.w3.codec, self._get_event_abi()),
+        )
+        builder.address = self.address
+        return builder
+
+
+class AsyncContractEvents(BaseContractEvents):
+    def __init__(
+        self, abi: ABI, w3: "AsyncWeb3", address: Optional[ChecksumAddress] = None
+    ) -> None:
+        super().__init__(abi, w3, AsyncContractEvent, address)
+
+
+class AsyncContractFunction(BaseContractFunction):
+    # mypy types
+    w3: "AsyncWeb3"
+
+    def __call__(self, *args: Any, **kwargs: Any) -> "AsyncContractFunction":
+        clone = copy.copy(self)
+        if args is None:
+            clone.args = tuple()
+        else:
+            clone.args = args
+
+        if kwargs is None:
+            clone.kwargs = {}
+        else:
+            clone.kwargs = kwargs
+        clone._set_function_info()
+        return clone
+
+    @classmethod
+    def factory(cls, class_name: str, **kwargs: Any) -> "AsyncContractFunction":
+        return PropertyCheckingFactory(class_name, (cls,), kwargs)(kwargs.get("abi"))
+
+    async def call(
+        self,
+        transaction: Optional[TxParams] = None,
+        block_identifier: BlockIdentifier = None,
+        state_override: Optional[CallOverride] = None,
+        ccip_read_enabled: Optional[bool] = None,
+    ) -> Any:
+        """
+        Execute a contract function call using the `eth_call` interface.
+
+        This method prepares a ``Caller`` object that exposes the contract
+        functions and public variables as callable Python functions.
+
+        Reading a public ``owner`` address variable example:
+
+        .. code-block:: python
+
+            ContractFactory = w3.eth.contract(
+                abi=wallet_contract_definition["abi"]
+            )
+
+            # Not a real contract address
+            contract = ContractFactory("0x2f70d3d26829e412A602E83FE8EeBF80255AEeA5")
+
+            # Read "owner" public variable
+            addr = contract.functions.owner().call()
+
+        :param transaction: Dictionary of transaction info for web3 interface
+        :param block_identifier TODO
+        :param state_override TODO
+        :param ccip_read_enabled TODO
+        :return: ``Caller`` object that has contract public functions
+            and variables exposed as Python methods
+        """
+        call_transaction = self._get_call_txparams(transaction)
+
+        block_id = await async_parse_block_identifier(self.w3, block_identifier)
+
+        return await async_call_contract_function(
+            self.w3,
+            self.address,
+            self._return_data_normalizers,
+            self.function_identifier,
+            call_transaction,
+            block_id,
+            self.contract_abi,
+            self.abi,
+            state_override,
+            ccip_read_enabled,
+            self.decode_tuples,
+            *self.args,
+            **self.kwargs,
+        )
+
+    async def transact(self, transaction: Optional[TxParams] = None) -> HexBytes:
+        setup_transaction = self._transact(transaction)
+        return await async_transact_with_contract_function(
+            self.address,
+            self.w3,
+            self.function_identifier,
+            setup_transaction,
+            self.contract_abi,
+            self.abi,
+            *self.args,
+            **self.kwargs,
+        )
+
+    async def estimate_gas(
+        self,
+        transaction: Optional[TxParams] = None,
+        block_identifier: Optional[BlockIdentifier] = None,
+    ) -> int:
+        setup_transaction = self._estimate_gas(transaction)
+        return await async_estimate_gas_for_function(
+            self.address,
+            self.w3,
+            self.function_identifier,
+            setup_transaction,
+            self.contract_abi,
+            self.abi,
+            block_identifier,
+            *self.args,
+            **self.kwargs,
+        )
+
+    async def build_transaction(
+        self, transaction: Optional[TxParams] = None
+    ) -> TxParams:
+        built_transaction = self._build_transaction(transaction)
+        return await async_build_transaction_for_function(
+            self.address,
+            self.w3,
+            self.function_identifier,
+            built_transaction,
+            self.contract_abi,
+            self.abi,
+            *self.args,
+            **self.kwargs,
+        )
+
+    @staticmethod
+    def get_fallback_function(
+        abi: ABI,
+        async_w3: "AsyncWeb3",
+        address: Optional[ChecksumAddress] = None,
+    ) -> "AsyncContractFunction":
+        if abi and fallback_func_abi_exists(abi):
+            return AsyncContractFunction.factory(
+                "fallback",
+                w3=async_w3,
+                contract_abi=abi,
+                address=address,
+                function_identifier=FallbackFn,
+            )()
+        return cast(AsyncContractFunction, NonExistentFallbackFunction())
+
+    @staticmethod
+    def get_receive_function(
+        abi: ABI,
+        async_w3: "AsyncWeb3",
+        address: Optional[ChecksumAddress] = None,
+    ) -> "AsyncContractFunction":
+        if abi and receive_func_abi_exists(abi):
+            return AsyncContractFunction.factory(
+                "receive",
+                w3=async_w3,
+                contract_abi=abi,
+                address=address,
+                function_identifier=ReceiveFn,
+            )()
+        return cast(AsyncContractFunction, NonExistentReceiveFunction())
+
+
 class AsyncContractFunctions(BaseContractFunctions):
     def __init__(
         self,
@@ -120,13 +402,6 @@ class AsyncContractFunctions(BaseContractFunctions):
             )
         else:
             return super().__getattribute__(function_name)
-
-
-class AsyncContractEvents(BaseContractEvents):
-    def __init__(
-        self, abi: ABI, w3: "AsyncWeb3", address: Optional[ChecksumAddress] = None
-    ) -> None:
-        super().__init__(abi, w3, AsyncContractEvent, address)
 
 
 class AsyncContract(BaseContract):
@@ -252,309 +527,6 @@ class AsyncContract(BaseContract):
         return get_function_by_identifier(fns, identifier)
 
 
-class AsyncContractConstructor(BaseContractConstructor):
-    # mypy types
-    w3: "AsyncWeb3"
-
-    @combomethod
-    async def transact(self, transaction: Optional[TxParams] = None) -> HexBytes:
-        return await self.w3.eth.send_transaction(self._get_transaction(transaction))
-
-    @combomethod
-    async def build_transaction(
-        self, transaction: Optional[TxParams] = None
-    ) -> TxParams:
-        """
-        Build the transaction dictionary without sending
-        """
-        built_transaction = self._build_transaction(transaction)
-        return await async_fill_transaction_defaults(self.w3, built_transaction)
-
-    @combomethod
-    async def estimate_gas(
-        self,
-        transaction: Optional[TxParams] = None,
-        block_identifier: Optional[BlockIdentifier] = None,
-    ) -> int:
-        transaction = self._estimate_gas(transaction)
-
-        return await self.w3.eth.estimate_gas(
-            transaction, block_identifier=block_identifier
-        )
-
-
-class AsyncContractFunction(BaseContractFunction):
-    # mypy types
-    w3: "AsyncWeb3"
-
-    def __call__(self, *args: Any, **kwargs: Any) -> "AsyncContractFunction":
-        clone = copy.copy(self)
-        if args is None:
-            clone.args = tuple()
-        else:
-            clone.args = args
-
-        if kwargs is None:
-            clone.kwargs = {}
-        else:
-            clone.kwargs = kwargs
-        clone._set_function_info()
-        return clone
-
-    @classmethod
-    def factory(cls, class_name: str, **kwargs: Any) -> "AsyncContractFunction":
-        return PropertyCheckingFactory(class_name, (cls,), kwargs)(kwargs.get("abi"))
-
-    async def call(
-        self,
-        transaction: Optional[TxParams] = None,
-        block_identifier: BlockIdentifier = None,
-        state_override: Optional[CallOverride] = None,
-        ccip_read_enabled: Optional[bool] = None,
-    ) -> Any:
-        """
-        Execute a contract function call using the `eth_call` interface.
-
-        This method prepares a ``Caller`` object that exposes the contract
-        functions and public variables as callable Python functions.
-
-        Reading a public ``owner`` address variable example:
-
-        .. code-block:: python
-
-            ContractFactory = w3.eth.contract(
-                abi=wallet_contract_definition["abi"]
-            )
-
-            # Not a real contract address
-            contract = ContractFactory("0x2f70d3d26829e412A602E83FE8EeBF80255AEeA5")
-
-            # Read "owner" public variable
-            addr = contract.functions.owner().call()
-
-        :param transaction: Dictionary of transaction info for web3 interface
-        :return: ``Caller`` object that has contract public functions
-            and variables exposed as Python methods
-        """
-        call_transaction = self._get_call_txparams(transaction)
-
-        block_id = await async_parse_block_identifier(self.w3, block_identifier)
-
-        return await async_call_contract_function(
-            self.w3,
-            self.address,
-            self._return_data_normalizers,
-            self.function_identifier,
-            call_transaction,
-            block_id,
-            self.contract_abi,
-            self.abi,
-            state_override,
-            ccip_read_enabled,
-            self.decode_tuples,
-            *self.args,
-            **self.kwargs,
-        )
-
-    async def transact(self, transaction: Optional[TxParams] = None) -> HexBytes:
-        setup_transaction = self._transact(transaction)
-        return await async_transact_with_contract_function(
-            self.address,
-            self.w3,
-            self.function_identifier,
-            setup_transaction,
-            self.contract_abi,
-            self.abi,
-            *self.args,
-            **self.kwargs,
-        )
-
-    async def estimate_gas(
-        self,
-        transaction: Optional[TxParams] = None,
-        block_identifier: Optional[BlockIdentifier] = None,
-    ) -> int:
-        setup_transaction = self._estimate_gas(transaction)
-        return await async_estimate_gas_for_function(
-            self.address,
-            self.w3,
-            self.function_identifier,
-            setup_transaction,
-            self.contract_abi,
-            self.abi,
-            block_identifier,
-            *self.args,
-            **self.kwargs,
-        )
-
-    async def build_transaction(
-        self, transaction: Optional[TxParams] = None
-    ) -> TxParams:
-        built_transaction = self._build_transaction(transaction)
-        return await async_build_transaction_for_function(
-            self.address,
-            self.w3,
-            self.function_identifier,
-            built_transaction,
-            self.contract_abi,
-            self.abi,
-            *self.args,
-            **self.kwargs,
-        )
-
-    @staticmethod
-    def get_fallback_function(
-        abi: ABI,
-        async_w3: "AsyncWeb3",
-        address: Optional[ChecksumAddress] = None,
-    ) -> "AsyncContractFunction":
-        if abi and fallback_func_abi_exists(abi):
-            return AsyncContractFunction.factory(
-                "fallback",
-                w3=async_w3,
-                contract_abi=abi,
-                address=address,
-                function_identifier=FallbackFn,
-            )()
-        return cast(AsyncContractFunction, NonExistentFallbackFunction())
-
-    @staticmethod
-    def get_receive_function(
-        abi: ABI,
-        async_w3: "AsyncWeb3",
-        address: Optional[ChecksumAddress] = None,
-    ) -> "AsyncContractFunction":
-        if abi and receive_func_abi_exists(abi):
-            return AsyncContractFunction.factory(
-                "receive",
-                w3=async_w3,
-                contract_abi=abi,
-                address=address,
-                function_identifier=ReceiveFn,
-            )()
-        return cast(AsyncContractFunction, NonExistentReceiveFunction())
-
-
-class AsyncContractEvent(BaseContractEvent):
-    # mypy types
-    w3: "AsyncWeb3"
-
-    @combomethod
-    async def get_logs(
-        self,
-        argument_filters: Optional[Dict[str, Any]] = None,
-        fromBlock: Optional[BlockIdentifier] = None,
-        toBlock: Optional[BlockIdentifier] = None,
-        block_hash: Optional[HexBytes] = None,
-    ) -> Awaitable[Iterable[EventData]]:
-        """Get events for this contract instance using eth_getLogs API.
-
-        This is a stateless method, as opposed to createFilter.
-        It can be safely called against nodes which do not provide
-        eth_newFilter API, like Infura nodes.
-
-        If there are many events,
-        like ``Transfer`` events for a popular token,
-        the Ethereum node might be overloaded and timeout
-        on the underlying JSON-RPC call.
-
-        Example - how to get all ERC-20 token transactions
-        for the latest 10 blocks:
-
-        .. code-block:: python
-
-            from = max(mycontract.web3.eth.block_number - 10, 1)
-            to = mycontract.web3.eth.block_number
-
-            events = mycontract.events.Transfer.getLogs(fromBlock=from, toBlock=to)
-
-            for e in events:
-                print(e["args"]["from"],
-                    e["args"]["to"],
-                    e["args"]["value"])
-
-        The returned processed log values will look like:
-
-        .. code-block:: python
-
-            (
-                AttributeDict({
-                 'args': AttributeDict({}),
-                 'event': 'LogNoArguments',
-                 'logIndex': 0,
-                 'transactionIndex': 0,
-                 'transactionHash': HexBytes('...'),
-                 'address': '0xF2E246BB76DF876Cef8b38ae84130F4F55De395b',
-                 'blockHash': HexBytes('...'),
-                 'blockNumber': 3
-                }),
-                AttributeDict(...),
-                ...
-            )
-
-        See also: :func:`web3.middleware.filter.local_filter_middleware`.
-
-        :param argument_filters:
-        :param fromBlock: block number or "latest", defaults to "latest"
-        :param toBlock: block number or "latest". Defaults to "latest"
-        :param blockHash: block hash. blockHash cannot be set at the
-          same time as fromBlock or toBlock
-        :yield: Tuple of :class:`AttributeDict` instances
-        """
-        abi = self._get_event_abi()
-        # Call JSON-RPC API
-        logs = await self.w3.eth.get_logs(
-            self._get_event_filter_params(
-                abi, argument_filters, fromBlock, toBlock, block_hash
-            )
-        )
-
-        # Convert raw binary data to Python proxy objects as described by ABI
-        return tuple(  # type: ignore
-            get_event_data(self.w3.codec, abi, entry) for entry in logs
-        )
-
-    @combomethod
-    async def create_filter(
-        self,
-        *,  # PEP 3102
-        argument_filters: Optional[Dict[str, Any]] = None,
-        fromBlock: Optional[BlockIdentifier] = None,
-        toBlock: BlockIdentifier = "latest",
-        address: Optional[ChecksumAddress] = None,
-        topics: Optional[Sequence[Any]] = None,
-    ) -> AsyncLogFilter:
-        """
-        Create filter object that tracks logs emitted by this contract event.
-        """
-        filter_builder = AsyncEventFilterBuilder(self._get_event_abi(), self.w3.codec)
-        self._set_up_filter_builder(
-            argument_filters,
-            fromBlock,
-            toBlock,
-            address,
-            topics,
-            filter_builder,
-        )
-        log_filter = await filter_builder.deploy(self.w3)
-        log_filter.log_entry_formatter = get_event_data(
-            self.w3.codec, self._get_event_abi()
-        )
-        log_filter.builder = filter_builder
-
-        return log_filter
-
-    @combomethod
-    def build_filter(self) -> AsyncEventFilterBuilder:
-        builder = AsyncEventFilterBuilder(
-            self._get_event_abi(),
-            self.w3.codec,
-            formatter=get_event_data(self.w3.codec, self._get_event_abi()),
-        )
-        builder.address = self.address
-        return builder
-
-
 class AsyncContractCaller(BaseContractCaller):
     # mypy types
     w3: "AsyncWeb3"
@@ -618,4 +590,35 @@ class AsyncContractCaller(BaseContractCaller):
             block_identifier=block_identifier,
             ccip_read_enabled=ccip_read_enabled,
             decode_tuples=self.decode_tuples,
+        )
+
+
+class AsyncContractConstructor(BaseContractConstructor):
+    # mypy types
+    w3: "AsyncWeb3"
+
+    @combomethod
+    async def transact(self, transaction: Optional[TxParams] = None) -> HexBytes:
+        return await self.w3.eth.send_transaction(self._get_transaction(transaction))
+
+    @combomethod
+    async def build_transaction(
+        self, transaction: Optional[TxParams] = None
+    ) -> TxParams:
+        """
+        Build the transaction dictionary without sending
+        """
+        built_transaction = self._build_transaction(transaction)
+        return await async_fill_transaction_defaults(self.w3, built_transaction)
+
+    @combomethod
+    async def estimate_gas(
+        self,
+        transaction: Optional[TxParams] = None,
+        block_identifier: Optional[BlockIdentifier] = None,
+    ) -> int:
+        transaction = self._estimate_gas(transaction)
+
+        return await self.w3.eth.estimate_gas(
+            transaction, block_identifier=block_identifier
         )

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -125,6 +125,511 @@ if TYPE_CHECKING:
     from .contract import ContractFunction  # noqa: F401
 
 
+class BaseContractEvent:
+    """Base class for contract events
+
+    An event accessed via the api `contract.events.myEvents(*args, **kwargs)`
+    is a subclass of this class.
+    """
+
+    address: ChecksumAddress = None
+    event_name: str = None
+    w3: Union["Web3", "AsyncWeb3"] = None
+    contract_abi: ABI = None
+    abi: ABIEvent = None
+
+    def __init__(self, *argument_names: Tuple[str]) -> None:
+        if argument_names is None:
+            # https://github.com/python/mypy/issues/6283
+            self.argument_names = tuple()  # type: ignore
+        else:
+            self.argument_names = argument_names
+
+        self.abi = self._get_event_abi()
+
+    @classmethod
+    def _get_event_abi(cls) -> ABIEvent:
+        return find_matching_event_abi(cls.contract_abi, event_name=cls.event_name)
+
+    @combomethod
+    def process_receipt(
+        self, txn_receipt: TxReceipt, errors: EventLogErrorFlags = WARN
+    ) -> Iterable[EventData]:
+        return self._parse_logs(txn_receipt, errors)
+
+    @to_tuple
+    def _parse_logs(
+        self, txn_receipt: TxReceipt, errors: EventLogErrorFlags
+    ) -> Iterable[EventData]:
+        try:
+            errors.name
+        except AttributeError:
+            raise AttributeError(
+                f"Error flag must be one of: {EventLogErrorFlags.flag_options()}"
+            )
+
+        for log in txn_receipt["logs"]:
+            try:
+                rich_log = get_event_data(self.w3.codec, self.abi, log)
+            except (MismatchedABI, LogTopicError, InvalidEventABI, TypeError) as e:
+                if errors == DISCARD:
+                    continue
+                elif errors == IGNORE:
+                    # type ignores b/c rich_log set on 1092 conflicts with mutated types
+                    new_log = MutableAttributeDict(log)  # type: ignore
+                    new_log["errors"] = e
+                    rich_log = AttributeDict(new_log)  # type: ignore
+                elif errors == STRICT:
+                    raise e
+                else:
+                    warnings.warn(
+                        f"The log with transaction hash: {log['transactionHash']!r} "
+                        f"and logIndex: {log['logIndex']} encountered the following "
+                        f"error during processing: {type(e).__name__}({e}). It has "
+                        "been discarded."
+                    )
+                    continue
+            yield rich_log
+
+    @combomethod
+    def process_log(self, log: HexStr) -> EventData:
+        return get_event_data(self.w3.codec, self.abi, log)
+
+    @combomethod
+    def _get_event_filter_params(
+        self,
+        abi: ABIEvent,
+        argument_filters: Optional[Dict[str, Any]] = None,
+        fromBlock: Optional[BlockIdentifier] = None,
+        toBlock: Optional[BlockIdentifier] = None,
+        blockHash: Optional[HexBytes] = None,
+    ) -> FilterParams:
+        if not self.address:
+            raise TypeError(
+                "This method can be only called on "
+                "an instated contract with an address"
+            )
+
+        if argument_filters is None:
+            argument_filters = dict()
+
+        _filters = dict(**argument_filters)
+
+        blkhash_set = blockHash is not None
+        blknum_set = fromBlock is not None or toBlock is not None
+        if blkhash_set and blknum_set:
+            raise Web3ValidationError(
+                "blockHash cannot be set at the same time as fromBlock or toBlock"
+            )
+
+        # Construct JSON-RPC raw filter presentation based on human readable
+        # Python descriptions. Namely, convert event names to their keccak signatures
+        data_filter_set, event_filter_params = construct_event_filter_params(
+            abi,
+            self.w3.codec,
+            contract_address=self.address,
+            argument_filters=_filters,
+            fromBlock=fromBlock,
+            toBlock=toBlock,
+            address=self.address,
+        )
+
+        if blockHash is not None:
+            event_filter_params["blockHash"] = blockHash
+
+        return event_filter_params
+
+    @classmethod
+    def factory(cls, class_name: str, **kwargs: Any) -> PropertyCheckingFactory:
+        return PropertyCheckingFactory(class_name, (cls,), kwargs)
+
+    @staticmethod
+    def check_for_forbidden_api_filter_arguments(
+        event_abi: ABIEvent, _filters: Dict[str, Any]
+    ) -> None:
+        name_indexed_inputs = {_input["name"]: _input for _input in event_abi["inputs"]}
+
+        for filter_name, filter_value in _filters.items():
+            _input = name_indexed_inputs[filter_name]
+            if is_array_type(_input["type"]):
+                raise TypeError(
+                    "createFilter no longer supports array type filter arguments. "
+                    "see the build_filter method for filtering array type filters."
+                )
+            if is_list_like(filter_value) and is_dynamic_sized_type(_input["type"]):
+                raise TypeError(
+                    "createFilter no longer supports setting filter argument options "
+                    "for dynamic sized types. See the build_filter method for setting "
+                    "filters with the match_any method."
+                )
+
+    @combomethod
+    def _set_up_filter_builder(
+        self,
+        argument_filters: Optional[Dict[str, Any]] = None,
+        fromBlock: Optional[BlockIdentifier] = None,
+        toBlock: BlockIdentifier = "latest",
+        address: Optional[ChecksumAddress] = None,
+        topics: Optional[Sequence[Any]] = None,
+        filter_builder: Union[EventFilterBuilder, AsyncEventFilterBuilder] = None,
+    ) -> None:
+        if fromBlock is None:
+            raise TypeError(
+                "Missing mandatory keyword argument to create_filter: fromBlock"
+            )
+
+        if argument_filters is None:
+            argument_filters = dict()
+
+        _filters = dict(**argument_filters)
+
+        event_abi = self._get_event_abi()
+
+        self.check_for_forbidden_api_filter_arguments(event_abi, _filters)
+
+        _, event_filter_params = construct_event_filter_params(
+            self._get_event_abi(),
+            self.w3.codec,
+            contract_address=self.address,
+            argument_filters=_filters,
+            fromBlock=fromBlock,
+            toBlock=toBlock,
+            address=address,
+            topics=topics,
+        )
+
+        filter_builder.address = cast(
+            ChecksumAddress, event_filter_params.get("address")
+        )
+        filter_builder.fromBlock = event_filter_params.get("fromBlock")
+        filter_builder.toBlock = event_filter_params.get("toBlock")
+        match_any_vals = {
+            arg: value
+            for arg, value in _filters.items()
+            if not is_array_type(filter_builder.args[arg].arg_type)
+            and is_list_like(value)
+        }
+        for arg, value in match_any_vals.items():
+            filter_builder.args[arg].match_any(*value)
+
+        match_single_vals = {
+            arg: value
+            for arg, value in _filters.items()
+            if not is_array_type(filter_builder.args[arg].arg_type)
+            and not is_list_like(value)
+        }
+        for arg, value in match_single_vals.items():
+            filter_builder.args[arg].match_single(value)
+
+
+class BaseContractEvents:
+    """Class containing contract event objects
+
+    This is available via:
+
+    .. code-block:: python
+
+        >>> mycontract.events
+        <web3.contract.ContractEvents object at 0x108afde10>
+
+    To get list of all supported events in the contract ABI.
+    This allows you to iterate over :class:`ContractEvent` proxy classes.
+
+    .. code-block:: python
+
+        >>> for e in mycontract.events: print(e)
+        <class 'web3._utils.datatypes.LogAnonymous'>
+        ...
+
+    """
+
+    def __init__(
+        self,
+        abi: ABI,
+        w3: Union["Web3", "AsyncWeb3"],
+        contract_event_type: Type["BaseContractEvent"],
+        address: Optional[ChecksumAddress] = None,
+    ) -> None:
+        if abi:
+            self.abi = abi
+            self._events = filter_by_type("event", self.abi)
+            for event in self._events:
+                setattr(
+                    self,
+                    event["name"],
+                    contract_event_type.factory(
+                        event["name"],
+                        w3=w3,
+                        contract_abi=self.abi,
+                        address=address,
+                        event_name=event["name"],
+                    ),
+                )
+
+    def __getattr__(self, event_name: str) -> Type["BaseContractEvent"]:
+        if "_events" not in self.__dict__:
+            raise NoABIEventsFound(
+                "The abi for this contract contains no event definitions. ",
+                "Are you sure you provided the correct contract abi?",
+            )
+        elif event_name not in self.__dict__["_events"]:
+            raise ABIEventFunctionNotFound(
+                f"The event '{event_name}' was not found in this contract's abi. ",
+                "Are you sure you provided the correct contract abi?",
+            )
+        else:
+            return super().__getattribute__(event_name)
+
+    def __getitem__(self, event_name: str) -> Type["BaseContractEvent"]:
+        return getattr(self, event_name)
+
+    def __iter__(self) -> Iterable[Type["BaseContractEvent"]]:
+        """Iterate over supported
+
+        :return: Iterable of :class:`ContractEvent`
+        """
+        for event in self._events:
+            yield self[event["name"]]
+
+    def __hasattr__(self, event_name: str) -> bool:
+        try:
+            return event_name in self.__dict__["_events"]
+        except ABIEventFunctionNotFound:
+            return False
+
+
+class BaseContractFunction:
+    """Base class for contract functions
+
+    A function accessed via the api `contract.functions.myMethod(*args, **kwargs)`
+    is a subclass of this class.
+    """
+
+    address: ChecksumAddress = None
+    function_identifier: FunctionIdentifier = None
+    w3: Union["Web3", "AsyncWeb3"] = None
+    contract_abi: ABI = None
+    abi: ABIFunction = None
+    transaction: TxParams = None
+    arguments: Tuple[Any, ...] = None
+    decode_tuples: Optional[bool] = False
+    args: Any = None
+    kwargs: Any = None
+
+    def __init__(self, abi: Optional[ABIFunction] = None) -> None:
+        self.abi = abi
+        self.fn_name = type(self).__name__
+
+    def _set_function_info(self) -> None:
+        if not self.abi:
+            self.abi = find_matching_fn_abi(
+                self.contract_abi,
+                self.w3.codec,
+                self.function_identifier,
+                self.args,
+                self.kwargs,
+            )
+        if self.function_identifier in [FallbackFn, ReceiveFn]:
+            self.selector = encode_hex(b"")
+        elif is_text(self.function_identifier):
+            # https://github.com/python/mypy/issues/4976
+            self.selector = encode_hex(
+                function_abi_to_4byte_selector(self.abi)  # type: ignore
+            )
+        else:
+            raise TypeError("Unsupported function identifier")
+
+        self.arguments = merge_args_and_kwargs(self.abi, self.args, self.kwargs)
+
+    def _get_call_txparams(self, transaction: Optional[TxParams] = None) -> TxParams:
+        if transaction is None:
+            call_transaction: TxParams = {}
+        else:
+            call_transaction = cast(TxParams, dict(**transaction))
+
+        if "data" in call_transaction:
+            raise ValueError("Cannot set 'data' field in call transaction")
+
+        if self.address:
+            call_transaction.setdefault("to", self.address)
+        if self.w3.eth.default_account is not empty:
+            # type ignored b/c check prevents an empty default_account
+            call_transaction.setdefault(
+                "from", self.w3.eth.default_account  # type: ignore
+            )
+
+        if "to" not in call_transaction:
+            if isinstance(self, type):
+                raise ValueError(
+                    "When using `Contract.[methodtype].[method].call()` from"
+                    " a contract factory you "
+                    "must provide a `to` address with the transaction"
+                )
+            else:
+                raise ValueError(
+                    "Please ensure that this contract instance has an address."
+                )
+
+        return call_transaction
+
+    def _transact(self, transaction: Optional[TxParams] = None) -> TxParams:
+        if transaction is None:
+            transact_transaction: TxParams = {}
+        else:
+            transact_transaction = cast(TxParams, dict(**transaction))
+
+        if "data" in transact_transaction:
+            raise ValueError("Cannot set 'data' field in transact transaction")
+
+        if self.address is not None:
+            transact_transaction.setdefault("to", self.address)
+        if self.w3.eth.default_account is not empty:
+            # type ignored b/c check prevents an empty default_account
+            transact_transaction.setdefault(
+                "from", self.w3.eth.default_account  # type: ignore
+            )
+
+        if "to" not in transact_transaction:
+            if isinstance(self, type):
+                raise ValueError(
+                    "When using `Contract.transact` from a contract factory you "
+                    "must provide a `to` address with the transaction"
+                )
+            else:
+                raise ValueError(
+                    "Please ensure that this contract instance has an address."
+                )
+        return transact_transaction
+
+    def _estimate_gas(self, transaction: Optional[TxParams] = None) -> TxParams:
+        if transaction is None:
+            estimate_gas_transaction: TxParams = {}
+        else:
+            estimate_gas_transaction = cast(TxParams, dict(**transaction))
+
+        if "data" in estimate_gas_transaction:
+            raise ValueError("Cannot set 'data' field in estimate_gas transaction")
+        if "to" in estimate_gas_transaction:
+            raise ValueError("Cannot set to in estimate_gas transaction")
+
+        if self.address:
+            estimate_gas_transaction.setdefault("to", self.address)
+        if self.w3.eth.default_account is not empty:
+            # type ignored b/c check prevents an empty default_account
+            estimate_gas_transaction.setdefault(
+                "from", self.w3.eth.default_account  # type: ignore
+            )
+
+        if "to" not in estimate_gas_transaction:
+            if isinstance(self, type):
+                raise ValueError(
+                    "When using `Contract.estimate_gas` from a contract factory "
+                    "you must provide a `to` address with the transaction"
+                )
+            else:
+                raise ValueError(
+                    "Please ensure that this contract instance has an address."
+                )
+        return estimate_gas_transaction
+
+    def _build_transaction(self, transaction: Optional[TxParams] = None) -> TxParams:
+        if transaction is None:
+            built_transaction: TxParams = {}
+        else:
+            built_transaction = cast(TxParams, dict(**transaction))
+
+        if "data" in built_transaction:
+            raise ValueError("Cannot set 'data' field in build transaction")
+
+        if not self.address and "to" not in built_transaction:
+            raise ValueError(
+                "When using `ContractFunction.build_transaction` from a contract "
+                "factory you must provide a `to` address with the transaction"
+            )
+        if self.address and "to" in built_transaction:
+            raise ValueError("Cannot set 'to' field in contract call build transaction")
+
+        if self.address:
+            built_transaction.setdefault("to", self.address)
+
+        if "to" not in built_transaction:
+            raise ValueError(
+                "Please ensure that this contract instance has an address."
+            )
+
+        return built_transaction
+
+    @combomethod
+    def _encode_transaction_data(cls) -> HexStr:
+        return add_0x_prefix(encode_abi(cls.w3, cls.abi, cls.arguments, cls.selector))
+
+    _return_data_normalizers: Optional[Tuple[Callable[..., Any], ...]] = tuple()
+
+    def __repr__(self) -> str:
+        if self.abi:
+            _repr = f"<Function {abi_to_signature(self.abi)}"
+            if self.arguments is not None:
+                _repr += f" bound to {self.arguments!r}"
+            return _repr + ">"
+        return f"<Function {self.fn_name}>"
+
+    @classmethod
+    def factory(
+        cls, class_name: str, **kwargs: Any
+    ) -> Union["ContractFunction", "AsyncContractFunction"]:
+        return PropertyCheckingFactory(class_name, (cls,), kwargs)(kwargs.get("abi"))
+
+
+class BaseContractFunctions:
+    """Class containing contract function objects"""
+
+    def __init__(
+        self,
+        abi: ABI,
+        w3: Union["Web3", "AsyncWeb3"],
+        contract_function_class: Union[
+            Type["ContractFunction"], Type["AsyncContractFunction"]
+        ],
+        address: Optional[ChecksumAddress] = None,
+        decode_tuples: Optional[bool] = False,
+    ) -> None:
+        self.abi = abi
+        self.w3 = w3
+        self.address = address
+
+        if self.abi:
+            self._functions = filter_by_type("function", self.abi)
+            for func in self._functions:
+                setattr(
+                    self,
+                    func["name"],
+                    contract_function_class.factory(
+                        func["name"],
+                        w3=self.w3,
+                        contract_abi=self.abi,
+                        address=self.address,
+                        decode_tuples=decode_tuples,
+                        function_identifier=func["name"],
+                    ),
+                )
+
+    def __iter__(self) -> Generator[str, None, None]:
+        if not hasattr(self, "_functions") or not self._functions:
+            return
+
+        for func in self._functions:
+            yield func["name"]
+
+    def __getitem__(self, function_name: str) -> ABIFunction:
+        return getattr(self, function_name)
+
+    def __hasattr__(self, function_name: str) -> bool:
+        try:
+            return function_name in self.__dict__["_functions"]
+        except ABIFunctionNotFound:
+            return False
+
+
 class BaseContract:
     """Base class for Contract proxy classes.
 
@@ -403,148 +908,88 @@ class BaseContract:
         return cast(function_type, NonExistentReceiveFunction())  # type: ignore
 
 
-class NonExistentFallbackFunction:
-    @staticmethod
-    def _raise_exception() -> NoReturn:
-        raise FallbackNotFound("No fallback function was found in the contract ABI.")
+class BaseContractCaller:
+    """
+    An alternative Contract API.
 
-    def __getattr__(self, attr: Any) -> Callable[[], None]:
-        return self._raise_exception
+    This call:
 
+    > contract.caller({'from': eth.accounts[1], 'gas': 100000, ...}).add(2, 3)
+    is equivalent to this call in the classic contract:
+    > contract.functions.add(2, 3).call({'from': eth.accounts[1], 'gas': 100000, ...})
 
-class NonExistentReceiveFunction:
-    @staticmethod
-    def _raise_exception() -> NoReturn:
-        raise FallbackNotFound("No receive function was found in the contract ABI.")
+    Other options for invoking this class include:
 
-    def __getattr__(self, attr: Any) -> Callable[[], None]:
-        return self._raise_exception
+    > contract.caller.add(2, 3)
 
+    or
 
-class BaseContractFunctions:
-    """Class containing contract function objects"""
+    > contract.caller().add(2, 3)
 
-    def __init__(
-        self,
-        abi: ABI,
-        w3: Union["Web3", "AsyncWeb3"],
-        contract_function_class: Union[
-            Type["ContractFunction"], Type["AsyncContractFunction"]
-        ],
-        address: Optional[ChecksumAddress] = None,
-        decode_tuples: Optional[bool] = False,
-    ) -> None:
-        self.abi = abi
-        self.w3 = w3
-        self.address = address
+    or
 
-        if self.abi:
-            self._functions = filter_by_type("function", self.abi)
-            for func in self._functions:
-                setattr(
-                    self,
-                    func["name"],
-                    contract_function_class.factory(
-                        func["name"],
-                        w3=self.w3,
-                        contract_abi=self.abi,
-                        address=self.address,
-                        decode_tuples=decode_tuples,
-                        function_identifier=func["name"],
-                    ),
-                )
-
-    def __iter__(self) -> Generator[str, None, None]:
-        if not hasattr(self, "_functions") or not self._functions:
-            return
-
-        for func in self._functions:
-            yield func["name"]
-
-    def __getitem__(self, function_name: str) -> ABIFunction:
-        return getattr(self, function_name)
-
-    def __hasattr__(self, function_name: str) -> bool:
-        try:
-            return function_name in self.__dict__["_functions"]
-        except ABIFunctionNotFound:
-            return False
-
-
-class BaseContractEvents:
-    """Class containing contract event objects
-
-    This is available via:
-
-    .. code-block:: python
-
-        >>> mycontract.events
-        <web3.contract.ContractEvents object at 0x108afde10>
-
-    To get list of all supported events in the contract ABI.
-    This allows you to iterate over :class:`ContractEvent` proxy classes.
-
-    .. code-block:: python
-
-        >>> for e in mycontract.events: print(e)
-        <class 'web3._utils.datatypes.LogAnonymous'>
-        ...
-
+    > contract.caller(transaction={'from': eth.accounts[1], 'gas': 100000, ...}).add(2, 3)  # noqa: E501
     """
 
+    # mypy types
+    _functions: List[Union[ABIFunction, ABIEvent]]
+
     def __init__(
         self,
         abi: ABI,
         w3: Union["Web3", "AsyncWeb3"],
-        contract_event_type: Type["BaseContractEvent"],
-        address: Optional[ChecksumAddress] = None,
+        address: ChecksumAddress,
+        decode_tuples: Optional[bool] = False,
     ) -> None:
-        if abi:
-            self.abi = abi
-            self._events = filter_by_type("event", self.abi)
-            for event in self._events:
-                setattr(
-                    self,
-                    event["name"],
-                    contract_event_type.factory(
-                        event["name"],
-                        w3=w3,
-                        contract_abi=self.abi,
-                        address=address,
-                        event_name=event["name"],
-                    ),
-                )
+        self.w3 = w3
+        self.address = address
+        self.abi = abi
+        self.decode_tuples = decode_tuples
+        self._functions = []
 
-    def __getattr__(self, event_name: str) -> Type["BaseContractEvent"]:
-        if "_events" not in self.__dict__:
-            raise NoABIEventsFound(
-                "The abi for this contract contains no event definitions. ",
-                "Are you sure you provided the correct contract abi?",
+    def __getattr__(self, function_name: str) -> Any:
+        if self.abi is None:
+            raise NoABIFound(
+                "There is no ABI found for this contract.",
             )
-        elif event_name not in self.__dict__["_events"]:
-            raise ABIEventFunctionNotFound(
-                f"The event '{event_name}' was not found in this contract's abi. ",
-                "Are you sure you provided the correct contract abi?",
+        elif not self._functions or len(self._functions) == 0:
+            raise NoABIFunctionsFound(
+                "The ABI for this contract contains no function definitions. ",
+                "Are you sure you provided the correct contract ABI?",
+            )
+        elif function_name not in {fn["name"] for fn in self._functions}:
+            functions_available = ", ".join([fn["name"] for fn in self._functions])
+            raise ABIFunctionNotFound(
+                f"The function '{function_name}' was not found in this contract's ABI.",
+                " Here is a list of all of the function names found: ",
+                f"{functions_available}. ",
+                "Did you mean to call one of those functions?",
             )
         else:
-            return super().__getattribute__(event_name)
-
-    def __getitem__(self, event_name: str) -> Type["BaseContractEvent"]:
-        return getattr(self, event_name)
-
-    def __iter__(self) -> Iterable[Type["BaseContractEvent"]]:
-        """Iterate over supported
-
-        :return: Iterable of :class:`ContractEvent`
-        """
-        for event in self._events:
-            yield self[event["name"]]
+            return super().__getattribute__(function_name)
 
     def __hasattr__(self, event_name: str) -> bool:
         try:
             return event_name in self.__dict__["_events"]
-        except ABIEventFunctionNotFound:
+        except ABIFunctionNotFound:
             return False
+
+    @staticmethod
+    def call_function(
+        fn: TContractFn,
+        *args: Any,
+        transaction: Optional[TxParams] = None,
+        block_identifier: BlockIdentifier = None,
+        ccip_read_enabled: Optional[bool] = None,
+        **kwargs: Any,
+    ) -> Any:
+        if transaction is None:
+            transaction = {}
+        return fn(*args, **kwargs).call(
+            transaction=transaction,
+            block_identifier=block_identifier,
+            ccip_read_enabled=ccip_read_enabled,
+        )
 
 
 class BaseContractConstructor:
@@ -640,464 +1085,19 @@ class BaseContractConstructor:
             )
 
 
-class BaseContractFunction:
-    """Base class for contract functions
-
-    A function accessed via the api `contract.functions.myMethod(*args, **kwargs)`
-    is a subclass of this class.
-    """
-
-    address: ChecksumAddress = None
-    function_identifier: FunctionIdentifier = None
-    w3: Union["Web3", "AsyncWeb3"] = None
-    contract_abi: ABI = None
-    abi: ABIFunction = None
-    transaction: TxParams = None
-    arguments: Tuple[Any, ...] = None
-    decode_tuples: Optional[bool] = False
-    args: Any = None
-    kwargs: Any = None
-
-    def __init__(self, abi: Optional[ABIFunction] = None) -> None:
-        self.abi = abi
-        self.fn_name = type(self).__name__
-
-    def _set_function_info(self) -> None:
-        if not self.abi:
-            self.abi = find_matching_fn_abi(
-                self.contract_abi,
-                self.w3.codec,
-                self.function_identifier,
-                self.args,
-                self.kwargs,
-            )
-        if self.function_identifier in [FallbackFn, ReceiveFn]:
-            self.selector = encode_hex(b"")
-        elif is_text(self.function_identifier):
-            # https://github.com/python/mypy/issues/4976
-            self.selector = encode_hex(
-                function_abi_to_4byte_selector(self.abi)  # type: ignore
-            )
-        else:
-            raise TypeError("Unsupported function identifier")
-
-        self.arguments = merge_args_and_kwargs(self.abi, self.args, self.kwargs)
-
-    def _get_call_txparams(self, transaction: Optional[TxParams] = None) -> TxParams:
-        if transaction is None:
-            call_transaction: TxParams = {}
-        else:
-            call_transaction = cast(TxParams, dict(**transaction))
-
-        if "data" in call_transaction:
-            raise ValueError("Cannot set 'data' field in call transaction")
-
-        if self.address:
-            call_transaction.setdefault("to", self.address)
-        if self.w3.eth.default_account is not empty:
-            # type ignored b/c check prevents an empty default_account
-            call_transaction.setdefault(
-                "from", self.w3.eth.default_account  # type: ignore
-            )
-
-        if "to" not in call_transaction:
-            if isinstance(self, type):
-                raise ValueError(
-                    "When using `Contract.[methodtype].[method].call()` from"
-                    " a contract factory you "
-                    "must provide a `to` address with the transaction"
-                )
-            else:
-                raise ValueError(
-                    "Please ensure that this contract instance has an address."
-                )
-
-        return call_transaction
-
-    def _transact(self, transaction: Optional[TxParams] = None) -> TxParams:
-        if transaction is None:
-            transact_transaction: TxParams = {}
-        else:
-            transact_transaction = cast(TxParams, dict(**transaction))
-
-        if "data" in transact_transaction:
-            raise ValueError("Cannot set 'data' field in transact transaction")
-
-        if self.address is not None:
-            transact_transaction.setdefault("to", self.address)
-        if self.w3.eth.default_account is not empty:
-            # type ignored b/c check prevents an empty default_account
-            transact_transaction.setdefault(
-                "from", self.w3.eth.default_account  # type: ignore
-            )
-
-        if "to" not in transact_transaction:
-            if isinstance(self, type):
-                raise ValueError(
-                    "When using `Contract.transact` from a contract factory you "
-                    "must provide a `to` address with the transaction"
-                )
-            else:
-                raise ValueError(
-                    "Please ensure that this contract instance has an address."
-                )
-        return transact_transaction
-
-    def _estimate_gas(self, transaction: Optional[TxParams] = None) -> TxParams:
-        if transaction is None:
-            estimate_gas_transaction: TxParams = {}
-        else:
-            estimate_gas_transaction = cast(TxParams, dict(**transaction))
-
-        if "data" in estimate_gas_transaction:
-            raise ValueError("Cannot set 'data' field in estimate_gas transaction")
-        if "to" in estimate_gas_transaction:
-            raise ValueError("Cannot set to in estimate_gas transaction")
-
-        if self.address:
-            estimate_gas_transaction.setdefault("to", self.address)
-        if self.w3.eth.default_account is not empty:
-            # type ignored b/c check prevents an empty default_account
-            estimate_gas_transaction.setdefault(
-                "from", self.w3.eth.default_account  # type: ignore
-            )
-
-        if "to" not in estimate_gas_transaction:
-            if isinstance(self, type):
-                raise ValueError(
-                    "When using `Contract.estimate_gas` from a contract factory "
-                    "you must provide a `to` address with the transaction"
-                )
-            else:
-                raise ValueError(
-                    "Please ensure that this contract instance has an address."
-                )
-        return estimate_gas_transaction
-
-    def _build_transaction(self, transaction: Optional[TxParams] = None) -> TxParams:
-        if transaction is None:
-            built_transaction: TxParams = {}
-        else:
-            built_transaction = cast(TxParams, dict(**transaction))
-
-        if "data" in built_transaction:
-            raise ValueError("Cannot set 'data' field in build transaction")
-
-        if not self.address and "to" not in built_transaction:
-            raise ValueError(
-                "When using `ContractFunction.build_transaction` from a contract "
-                "factory you must provide a `to` address with the transaction"
-            )
-        if self.address and "to" in built_transaction:
-            raise ValueError("Cannot set 'to' field in contract call build transaction")
-
-        if self.address:
-            built_transaction.setdefault("to", self.address)
-
-        if "to" not in built_transaction:
-            raise ValueError(
-                "Please ensure that this contract instance has an address."
-            )
-
-        return built_transaction
-
-    @combomethod
-    def _encode_transaction_data(cls) -> HexStr:
-        return add_0x_prefix(encode_abi(cls.w3, cls.abi, cls.arguments, cls.selector))
-
-    _return_data_normalizers: Optional[Tuple[Callable[..., Any], ...]] = tuple()
-
-    def __repr__(self) -> str:
-        if self.abi:
-            _repr = f"<Function {abi_to_signature(self.abi)}"
-            if self.arguments is not None:
-                _repr += f" bound to {self.arguments!r}"
-            return _repr + ">"
-        return f"<Function {self.fn_name}>"
-
-    @classmethod
-    def factory(
-        cls, class_name: str, **kwargs: Any
-    ) -> Union["ContractFunction", "AsyncContractFunction"]:
-        return PropertyCheckingFactory(class_name, (cls,), kwargs)(kwargs.get("abi"))
-
-
-class BaseContractEvent:
-    """Base class for contract events
-
-    An event accessed via the api `contract.events.myEvents(*args, **kwargs)`
-    is a subclass of this class.
-    """
-
-    address: ChecksumAddress = None
-    event_name: str = None
-    w3: Union["Web3", "AsyncWeb3"] = None
-    contract_abi: ABI = None
-    abi: ABIEvent = None
-
-    def __init__(self, *argument_names: Tuple[str]) -> None:
-        if argument_names is None:
-            # https://github.com/python/mypy/issues/6283
-            self.argument_names = tuple()  # type: ignore
-        else:
-            self.argument_names = argument_names
-
-        self.abi = self._get_event_abi()
-
-    @classmethod
-    def _get_event_abi(cls) -> ABIEvent:
-        return find_matching_event_abi(cls.contract_abi, event_name=cls.event_name)
-
-    @combomethod
-    def process_receipt(
-        self, txn_receipt: TxReceipt, errors: EventLogErrorFlags = WARN
-    ) -> Iterable[EventData]:
-        return self._parse_logs(txn_receipt, errors)
-
-    @to_tuple
-    def _parse_logs(
-        self, txn_receipt: TxReceipt, errors: EventLogErrorFlags
-    ) -> Iterable[EventData]:
-        try:
-            errors.name
-        except AttributeError:
-            raise AttributeError(
-                f"Error flag must be one of: {EventLogErrorFlags.flag_options()}"
-            )
-
-        for log in txn_receipt["logs"]:
-            try:
-                rich_log = get_event_data(self.w3.codec, self.abi, log)
-            except (MismatchedABI, LogTopicError, InvalidEventABI, TypeError) as e:
-                if errors == DISCARD:
-                    continue
-                elif errors == IGNORE:
-                    # type ignores b/c rich_log set on 1092 conflicts with mutated types
-                    new_log = MutableAttributeDict(log)  # type: ignore
-                    new_log["errors"] = e
-                    rich_log = AttributeDict(new_log)  # type: ignore
-                elif errors == STRICT:
-                    raise e
-                else:
-                    warnings.warn(
-                        f"The log with transaction hash: {log['transactionHash']!r} "
-                        f"and logIndex: {log['logIndex']} encountered the following "
-                        f"error during processing: {type(e).__name__}({e}). It has "
-                        "been discarded."
-                    )
-                    continue
-            yield rich_log
-
-    @combomethod
-    def process_log(self, log: HexStr) -> EventData:
-        return get_event_data(self.w3.codec, self.abi, log)
-
-    @combomethod
-    def _get_event_filter_params(
-        self,
-        abi: ABIEvent,
-        argument_filters: Optional[Dict[str, Any]] = None,
-        fromBlock: Optional[BlockIdentifier] = None,
-        toBlock: Optional[BlockIdentifier] = None,
-        blockHash: Optional[HexBytes] = None,
-    ) -> FilterParams:
-        if not self.address:
-            raise TypeError(
-                "This method can be only called on "
-                "an instated contract with an address"
-            )
-
-        if argument_filters is None:
-            argument_filters = dict()
-
-        _filters = dict(**argument_filters)
-
-        blkhash_set = blockHash is not None
-        blknum_set = fromBlock is not None or toBlock is not None
-        if blkhash_set and blknum_set:
-            raise Web3ValidationError(
-                "blockHash cannot be set at the same time as fromBlock or toBlock"
-            )
-
-        # Construct JSON-RPC raw filter presentation based on human readable
-        # Python descriptions. Namely, convert event names to their keccak signatures
-        data_filter_set, event_filter_params = construct_event_filter_params(
-            abi,
-            self.w3.codec,
-            contract_address=self.address,
-            argument_filters=_filters,
-            fromBlock=fromBlock,
-            toBlock=toBlock,
-            address=self.address,
-        )
-
-        if blockHash is not None:
-            event_filter_params["blockHash"] = blockHash
-
-        return event_filter_params
-
-    @classmethod
-    def factory(cls, class_name: str, **kwargs: Any) -> PropertyCheckingFactory:
-        return PropertyCheckingFactory(class_name, (cls,), kwargs)
-
+class NonExistentFallbackFunction:
     @staticmethod
-    def check_for_forbidden_api_filter_arguments(
-        event_abi: ABIEvent, _filters: Dict[str, Any]
-    ) -> None:
-        name_indexed_inputs = {_input["name"]: _input for _input in event_abi["inputs"]}
+    def _raise_exception() -> NoReturn:
+        raise FallbackNotFound("No fallback function was found in the contract ABI.")
 
-        for filter_name, filter_value in _filters.items():
-            _input = name_indexed_inputs[filter_name]
-            if is_array_type(_input["type"]):
-                raise TypeError(
-                    "createFilter no longer supports array type filter arguments. "
-                    "see the build_filter method for filtering array type filters."
-                )
-            if is_list_like(filter_value) and is_dynamic_sized_type(_input["type"]):
-                raise TypeError(
-                    "createFilter no longer supports setting filter argument options "
-                    "for dynamic sized types. See the build_filter method for setting "
-                    "filters with the match_any method."
-                )
-
-    @combomethod
-    def _set_up_filter_builder(
-        self,
-        argument_filters: Optional[Dict[str, Any]] = None,
-        fromBlock: Optional[BlockIdentifier] = None,
-        toBlock: BlockIdentifier = "latest",
-        address: Optional[ChecksumAddress] = None,
-        topics: Optional[Sequence[Any]] = None,
-        filter_builder: Union[EventFilterBuilder, AsyncEventFilterBuilder] = None,
-    ) -> None:
-        if fromBlock is None:
-            raise TypeError(
-                "Missing mandatory keyword argument to create_filter: fromBlock"
-            )
-
-        if argument_filters is None:
-            argument_filters = dict()
-
-        _filters = dict(**argument_filters)
-
-        event_abi = self._get_event_abi()
-
-        self.check_for_forbidden_api_filter_arguments(event_abi, _filters)
-
-        _, event_filter_params = construct_event_filter_params(
-            self._get_event_abi(),
-            self.w3.codec,
-            contract_address=self.address,
-            argument_filters=_filters,
-            fromBlock=fromBlock,
-            toBlock=toBlock,
-            address=address,
-            topics=topics,
-        )
-
-        filter_builder.address = cast(
-            ChecksumAddress, event_filter_params.get("address")
-        )
-        filter_builder.fromBlock = event_filter_params.get("fromBlock")
-        filter_builder.toBlock = event_filter_params.get("toBlock")
-        match_any_vals = {
-            arg: value
-            for arg, value in _filters.items()
-            if not is_array_type(filter_builder.args[arg].arg_type)
-            and is_list_like(value)
-        }
-        for arg, value in match_any_vals.items():
-            filter_builder.args[arg].match_any(*value)
-
-        match_single_vals = {
-            arg: value
-            for arg, value in _filters.items()
-            if not is_array_type(filter_builder.args[arg].arg_type)
-            and not is_list_like(value)
-        }
-        for arg, value in match_single_vals.items():
-            filter_builder.args[arg].match_single(value)
+    def __getattr__(self, attr: Any) -> Callable[[], None]:
+        return self._raise_exception
 
 
-class BaseContractCaller:
-    """
-    An alternative Contract API.
-
-    This call:
-
-    > contract.caller({'from': eth.accounts[1], 'gas': 100000, ...}).add(2, 3)
-    is equivalent to this call in the classic contract:
-    > contract.functions.add(2, 3).call({'from': eth.accounts[1], 'gas': 100000, ...})
-
-    Other options for invoking this class include:
-
-    > contract.caller.add(2, 3)
-
-    or
-
-    > contract.caller().add(2, 3)
-
-    or
-
-    > contract.caller(transaction={'from': eth.accounts[1], 'gas': 100000, ...}).add(2, 3)  # noqa: E501
-    """
-
-    # mypy types
-    _functions: List[Union[ABIFunction, ABIEvent]]
-
-    def __init__(
-        self,
-        abi: ABI,
-        w3: Union["Web3", "AsyncWeb3"],
-        address: ChecksumAddress,
-        decode_tuples: Optional[bool] = False,
-    ) -> None:
-        self.w3 = w3
-        self.address = address
-        self.abi = abi
-        self.decode_tuples = decode_tuples
-        self._functions = []
-
-    def __getattr__(self, function_name: str) -> Any:
-        if self.abi is None:
-            raise NoABIFound(
-                "There is no ABI found for this contract.",
-            )
-        elif not self._functions or len(self._functions) == 0:
-            raise NoABIFunctionsFound(
-                "The ABI for this contract contains no function definitions. ",
-                "Are you sure you provided the correct contract ABI?",
-            )
-        elif function_name not in {fn["name"] for fn in self._functions}:
-            functions_available = ", ".join([fn["name"] for fn in self._functions])
-            raise ABIFunctionNotFound(
-                f"The function '{function_name}' was not found in this contract's ABI.",
-                " Here is a list of all of the function names found: ",
-                f"{functions_available}. ",
-                "Did you mean to call one of those functions?",
-            )
-        else:
-            return super().__getattribute__(function_name)
-
-    def __hasattr__(self, event_name: str) -> bool:
-        try:
-            return event_name in self.__dict__["_events"]
-        except ABIFunctionNotFound:
-            return False
-
+class NonExistentReceiveFunction:
     @staticmethod
-    def call_function(
-        fn: TContractFn,
-        *args: Any,
-        transaction: Optional[TxParams] = None,
-        block_identifier: BlockIdentifier = None,
-        ccip_read_enabled: Optional[bool] = None,
-        **kwargs: Any,
-    ) -> Any:
-        if transaction is None:
-            transaction = {}
-        return fn(*args, **kwargs).call(
-            transaction=transaction,
-            block_identifier=block_identifier,
-            ccip_read_enabled=ccip_read_enabled,
-        )
+    def _raise_exception() -> NoReturn:
+        raise FallbackNotFound("No receive function was found in the contract ABI.")
+
+    def __getattr__(self, attr: Any) -> Callable[[], None]:
+        return self._raise_exception


### PR DESCRIPTION
### What was wrong?

`ContractFunction` and `AsyncContractFunction` were missing params in their docstrings.
Contract files have similarly named classes, but all were in different order.

### How was it fixed?
Completed docstrings for above classes and updated associated docs to match.
Ordered related classes similarly across the 3 contract files.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/bfe0eb07-7804-426c-99fc-dc7d71764a30)
