### PR TITLE
add eth_signTypedData not supported by any clients note to docs

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -927,7 +927,11 @@ The following methods are available on the ``web3.eth`` namespace.
 .. py:method:: Eth.sign_typed_data(account, jsonMessage)
 
     * Delegates to ``eth_signTypedData`` RPC Method
-
+      
+    .. note::
+    
+        ``eth_signTypedData`` is not currently supported by any major client (Besu, Erigon, Geth, or Nethermind)
+        
     Please note that the ``jsonMessage`` argument is the loaded JSON Object
     and **NOT** the JSON String itself.
 

--- a/newsfragments/2961.docs.rst
+++ b/newsfragments/2961.docs.rst
@@ -1,0 +1,1 @@
+Added 'unsupported by any current clients' note to the `Eth.sign_typed_data` docs


### PR DESCRIPTION
### What was wrong?

The `eth_signTypedData` is not currently supported by any client. It was supported by Parity/Openethereum, which is now defunct.

### How was it fixed?

Added a note to the Web3.eth API docs.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/711a63ac-38d8-4c23-9b5d-bc3828920013)
