### PR TITLE
remove list of AsyncHTTPProvider-supported methods

### DIFF
--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -12,6 +12,12 @@ possible for a middleware to return early from a
 call without the request ever getting to the provider (or even reaching the middlewares
 that are in deeper layers).
 
+When integrating middleware with your provider, please ensure you're choosing the right
+version. For ``AsyncWeb3`` users, select the version prefixed with ``async``, such as
+``async_attrdict_middleware``. On the other hand, ``Web3`` users should opt for versions
+lacking the ``async`` prefix. If an async version isn't listed, it implies it hasn't
+been made available yet.
+
 More information is available in the "Internals: :ref:`internals__middlewares`" section.
 
 
@@ -28,6 +34,7 @@ AttributeDict
 ~~~~~~~~~~~~~~~~~~
 
 .. py:method:: web3.middleware.attrdict_middleware
+               web3.middleware.async_attrdict_middleware
 
     This middleware recursively converts any dictionary type in the result of a call
     to an ``AttributeDict``. This enables dot-syntax access, like
@@ -65,6 +72,7 @@ Gas Price Strategy
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. py:method:: web3.middleware.gas_price_strategy_middleware
+               web3.middleware.async_gas_price_strategy_middleware
 
   .. warning::
 
@@ -72,13 +80,14 @@ Gas Price Strategy
       introduced ``maxFeePerGas`` and ``maxPriorityFeePerGas`` transaction parameters
       which should be used over ``gasPrice`` whenever possible.
 
-  This adds a gasPrice to transactions if applicable and when a gas price strategy has
+  This adds a ``gasPrice`` to transactions if applicable and when a gas price strategy has
   been set. See :ref:`Gas_Price` for information about how gas price is derived.
 
 Buffered Gas Estimate
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. py:method:: web3.middleware.buffered_gas_estimate_middleware
+               web3.middleware.async_buffered_gas_estimate_middleware
 
     This adds a gas estimate to transactions if ``gas`` is not present in the transaction
     parameters. Sets gas to:
@@ -288,12 +297,13 @@ Web3 ships with non-default middleware, for your custom use. In addition to the 
   either use ``middleware_onion.add()`` from above, or add the default middlewares to your list of
   new middlewares.
 
-Below is a list of built-in middleware, which is not enabled by default.
+Below is a list of available middlewares which are not enabled by default.
 
 Stalecheck
 ~~~~~~~~~~~~
 
 .. py:method:: web3.middleware.make_stalecheck_middleware(allowable_delay)
+               web3.middleware.async_make_stalecheck_middleware(allowable_delay)
 
     This middleware checks how stale the blockchain is, and interrupts calls with a failure
     if the blockchain is too old.
@@ -325,12 +335,13 @@ All of the caching middlewares accept these common arguments.
 
 
 .. py:method:: web3.middleware.construct_simple_cache_middleware(cache_class, rpc_whitelist, should_cache_fn)
+               web3.middleware.async_construct_simple_cache_middleware(cache_class, rpc_whitelist, should_cache_fn)
 
     Constructs a middleware which will cache the return values for any RPC
     method in the ``rpc_whitelist``.
 
-    A ready to use version of this middleware can be found at
-    ``web3.middlewares.simple_cache_middleware``.
+    Ready to use versions of this middleware can be found at
+    ``web3.middleware.simple_cache_middleware`` and ``web3.middleware.async_simple_cache_middleware``.
 
 
 .. py:method:: web3.middleware.construct_time_based_cache_middleware(cache_class, cache_expire_seconds, rpc_whitelist, should_cache_fn)
@@ -343,7 +354,7 @@ All of the caching middlewares accept these common arguments.
       remain in the cache before being evicted.
 
     A ready to use version of this middleware can be found at
-    ``web3.middlewares.time_based_cache_middleware``.
+    ``web3.middleware.time_based_cache_middleware``.
 
 
 .. py:method:: web3.middleware.construct_latest_block_based_cache_middleware(cache_class, average_block_time_sample_size, default_average_block_time, rpc_whitelist, should_cache_fn)
@@ -362,16 +373,19 @@ All of the caching middlewares accept these common arguments.
       average block time.
 
     A ready to use version of this middleware can be found at
-    ``web3.middlewares.latest_block_based_cache_middleware``.
+    ``web3.middleware.latest_block_based_cache_middleware``.
 
 .. _geth-poa:
 
 Proof of Authority
 ~~~~~~~~~~~~~~~~~~
 
+.. py:method:: web3.middleware.geth_poa_middleware
+               web3.middleware.async_geth_poa_middleware
+
 .. note::
     It's important to inject the middleware at the 0th layer of the middleware onion:
-    `w3.middleware_onion.inject(geth_poa_middleware, layer=0)`
+    ``w3.middleware_onion.inject(geth_poa_middleware, layer=0)``
 
 The ``geth_poa_middleware`` is required to connect to ``geth --dev`` or the Goerli 
 public network. It may also be needed for other EVM compatible blockchains like Polygon
@@ -380,10 +394,12 @@ or BNB Chain (Binance Smart Chain).
 If the middleware is not injected at the 0th layer of the middleware onion, you may get
 errors like the example below when interacting with your EVM node.
 
-```web3.exceptions.ExtraDataLengthError: The field extraData is 97 bytes, but should be
-32. It is quite likely that you are connected to a POA chain. Refer to
-http://web3py.readthedocs.io/en/stable/middleware.html#proof-of-authority
-for more details. The full extraData is: HexBytes('...')```
+.. code-block:: shell
+
+    web3.exceptions.ExtraDataLengthError: The field extraData is 97 bytes, but should be
+    32. It is quite likely that you are connected to a POA chain. Refer to
+    http://web3py.readthedocs.io/en/stable/middleware.html#proof-of-authority
+    for more details. The full extraData is: HexBytes('...')
 
 
 The easiest way to connect to a default ``geth --dev`` instance which loads the middleware is:
@@ -417,10 +433,10 @@ unique IPC location and loads the middleware:
     'Geth/v1.7.3-stable-4bb3c89d/linux-amd64/go1.9'
 
 Why is ``geth_poa_middleware`` necessary?
-''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+'''''''''''''''''''''''''''''''''''''''''
 
 There is no strong community consensus on a single Proof-of-Authority (PoA) standard yet.
-Some nodes have successful experiments running, though. One is go-ethereum (geth),
+Some nodes have successful experiments running though. One is go-ethereum (geth),
 which uses a prototype PoA for its development mode and the Goerli test network.
 
 Unfortunately, it does deviate from the yellow paper specification, which constrains the
@@ -431,6 +447,9 @@ Unfortunately, it does deviate from the yellow paper specification, which constr
 
 Locally Managed Log and Block Filters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. py:method:: web3.middleware.local_filter_middleware
+               web3.middleware.async_local_filter_middleware
 
 This middleware provides an alternative to ethereum node managed filters. When used, Log and
 Block filter logic are handled locally while using the same web3 filter api. Filter results are

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -259,94 +259,21 @@ AsyncHTTPProvider
     Under the hood, the ``AsyncHTTPProvider`` uses the python
     `aiohttp <https://docs.aiohttp.org/en/stable/>`_ library for making requests.
 
-Supported Methods
-^^^^^^^^^^^^^^^^^
 
-Eth
-***
-- :class:`web3.eth.account <eth_account.account.Account>`
-- :meth:`web3.eth.accounts <web3.eth.Eth.accounts>`
-- :meth:`web3.eth.block_number <web3.eth.Eth.block_number>`
-- :meth:`web3.eth.chain_id <web3.eth.Eth.chain_id>`
-- :meth:`web3.eth.coinbase <web3.eth.Eth.coinbase>`
-- :meth:`web3.eth.default_account <web3.eth.Eth.default_account>`
-- :meth:`web3.eth.default_block <web3.eth.Eth.default_block>`
-- :meth:`web3.eth.gas_price <web3.eth.Eth.gas_price>`
-- :meth:`web3.eth.hashrate <web3.eth.Eth.hashrate>`
-- :meth:`web3.eth.max_priority_fee <web3.eth.Eth.max_priority_fee>`
-- :meth:`web3.eth.mining <web3.eth.Eth.mining>`
-- :meth:`web3.eth.syncing <web3.eth.Eth.syncing>`
-- :meth:`web3.eth.call() <web3.eth.Eth.call>`
-- :meth:`web3.eth.estimate_gas() <web3.eth.Eth.estimate_gas>`
-- :meth:`web3.eth.generate_gas_price() <web3.eth.Eth.generate_gas_price>`
-- :meth:`web3.eth.get_balance() <web3.eth.Eth.get_balance>`
-- :meth:`web3.eth.get_block() <web3.eth.Eth.get_block>`
-- :meth:`web3.eth.get_code() <web3.eth.Eth.get_code>`
-- :meth:`web3.eth.get_logs() <web3.eth.Eth.get_logs>`
-- :meth:`web3.eth.get_raw_transaction() <web3.eth.Eth.get_raw_transaction>`
-- :meth:`web3.eth.get_raw_transaction_by_block() <web3.eth.Eth.get_raw_transaction_by_block>`
-- :meth:`web3.eth.get_transaction() <web3.eth.Eth.get_transaction>`
-- :meth:`web3.eth.get_transaction_count() <web3.eth.Eth.get_transaction_count>`
-- :meth:`web3.eth.get_transaction_receipt() <web3.eth.Eth.get_transaction_receipt>`
-- :meth:`web3.eth.get_storage_at() <web3.eth.Eth.get_storage_at>`
-- :meth:`web3.eth.send_transaction() <web3.eth.Eth.send_transaction>`
-- :meth:`web3.eth.send_raw_transaction() <web3.eth.Eth.send_raw_transaction>`
-- :meth:`web3.eth.wait_for_transaction_receipt() <web3.eth.Eth.wait_for_transaction_receipt>`
-- :meth:`web3.eth.sign() <web3.eth.Eth.sign>`
-- :meth:`web3.eth.sign_transaction() <web3.eth.Eth.sign_transaction>`
-- :meth:`web3.eth.modify_transaction() <web3.eth.Eth.modify_transaction>`
-- :meth:`web3.eth.replace_transaction() <web3.eth.Eth.replace_transaction>`
-- :meth:`web3.eth.get_uncle_count() <web3.eth.Eth.get_uncle_count>`
-- :meth:`web3.eth.sign_typed_data() <web3.eth.Eth.sign_typed_data>`
+    The ``AsyncHTTPProvider`` has almost all the same functionality available as the ``HTTPProvider``.
+    The only documented exceptions to this are:
 
-Net
-***
-- :meth:`web3.net.listening() <web3.net.listening>`
-- :meth:`web3.net.peer_count() <web3.net.peer_count>`
-- :meth:`web3.net.version() <web3.net.version>`
 
-Geth
-****
-- :meth:`web3.geth.admin.add_peer() <web3.geth.admin.add_peer>`
-- :meth:`web3.geth.admin.datadir() <web3.geth.admin.datadir>`
-- :meth:`web3.geth.admin.node_info() <web3.geth.admin.node_info>`
-- :meth:`web3.geth.admin.peers() <web3.geth.admin.peers>`
-- :meth:`web3.geth.admin.start_http() <web3.geth.admin.start_http>`
-- :meth:`web3.geth.admin.start_ws() <web3.geth.admin.start_ws>`
-- :meth:`web3.geth.admin.stop_http() <web3.geth.admin.stop_http>`
-- :meth:`web3.geth.admin.stop_ws() <web3.geth.admin.stop_ws>`
-- :meth:`web3.geth.personal.ec_recover()`
-- :meth:`web3.geth.personal.import_raw_key() <web3.geth.personal.import_raw_key>`
-- :meth:`web3.geth.personal.list_accounts() <web3.geth.personal.list_accounts>`
-- :meth:`web3.geth.personal.list_wallets() <web3.geth.personal.list_wallets()>`
-- :meth:`web3.geth.personal.lock_account() <web3.geth.personal.lock_account>`
-- :meth:`web3.geth.personal.new_account() <web3.geth.personal.new_account>`
-- :meth:`web3.geth.personal.send_transaction() <web3.geth.personal.send_transaction>`
-- :meth:`web3.geth.personal.sign()`
-- :meth:`web3.geth.personal.unlock_account() <web3.geth.personal.unlock_account>`
-- :meth:`web3.geth.txpool.inspect() <web3.geth.txpool.TxPool.inspect()>`
-- :meth:`web3.geth.txpool.content() <web3.geth.txpool.TxPool.content()>`
-- :meth:`web3.geth.txpool.status() <web3.geth.txpool.TxPool.status()>`
+    - **ENS Address Lookup** -All addresses that are passed to an Async contract should not be :class:`ENS` addresses.
+    - **Available Middleware** - Only these middlewares have async versions available:
 
-Contract
-^^^^^^^^
-Contract is fully implemented for the Async provider. The only documented exception to this at
-the moment is where :class:`ENS` is needed for address lookup. All addresses that are passed to Async
-contract should not be :class:`ENS` addresses.
-
-ENS
-^^^^^^^^
-ENS is fully implemented for the Async provider.
-
-Supported Middleware
-^^^^^^^^^^^^^^^^^^^^
-- :meth:`Gas Price Strategy <web3.middleware.gas_price_strategy_middleware>`
-- :meth:`Buffered Gas Estimate Middleware <web3.middleware.buffered_gas_estimate_middleware>`
-- :meth:`Stalecheck Middleware <web3.middleware.make_stalecheck_middleware>`
-- :meth:`Attribute Dict Middleware <web3.middleware.attrdict_middleware>`
-- :meth:`Validation Middleware <web3.middleware.validation>`
-- :ref:`Geth POA Middleware <geth-poa>`
-- :meth:`Simple Cache Middleware <web3.middleware.simple_cache_middleware>`
+        - :meth:`Gas Price Strategy <web3.middleware.gas_price_strategy_middleware>`
+        - :meth:`Buffered Gas Estimate Middleware <web3.middleware.buffered_gas_estimate_middleware>`
+        - :meth:`Stalecheck Middleware <web3.middleware.make_stalecheck_middleware>`
+        - :meth:`Attribute Dict Middleware <web3.middleware.attrdict_middleware>`
+        - :meth:`Validation Middleware <web3.middleware.validation>`
+        - :ref:`Geth POA Middleware <geth-poa>`
+        - :meth:`Simple Cache Middleware <web3.middleware.simple_cache_middleware>`
 
 
 .. py:currentmodule:: web3.providers.eth_tester

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -264,16 +264,17 @@ AsyncHTTPProvider
     The only documented exceptions to this are:
 
 
-    - **ENS Address Lookup** -All addresses that are passed to an Async contract should not be :class:`ENS` addresses.
-    - **Available Middleware** - Only these middlewares have async versions available:
+    - **ENS Address Lookup** - It can't resolve :class:`ENS` addresses yet. 
+    - **Available Middleware** - These middlewares have async versions available:
 
-        - :meth:`Gas Price Strategy <web3.middleware.gas_price_strategy_middleware>`
-        - :meth:`Buffered Gas Estimate Middleware <web3.middleware.buffered_gas_estimate_middleware>`
-        - :meth:`Stalecheck Middleware <web3.middleware.make_stalecheck_middleware>`
-        - :meth:`Attribute Dict Middleware <web3.middleware.attrdict_middleware>`
-        - :meth:`Validation Middleware <web3.middleware.validation>`
-        - :ref:`Geth POA Middleware <geth-poa>`
-        - :meth:`Simple Cache Middleware <web3.middleware.simple_cache_middleware>`
+        - :meth:`Attribute Dict Middleware <web3.middleware.async_attrdict_middleware>`
+        - :meth:`Buffered Gas Estimate Middleware <web3.middleware.async_buffered_gas_estimate_middleware>`
+        - :meth:`Gas Price Strategy Middleware <web3.middleware.async_gas_price_strategy_middleware>`
+        - :meth:`Geth POA Middleware <web3.middleware.async_geth_poa_middleware>`
+        - :meth:`Local Filter Middleware <web3.middleware.async_local_filter_middleware>`
+        - :meth:`Simple Cache Middleware <web3.middleware.async_construct_simple_cache_middleware>`
+        - :meth:`Stalecheck Middleware <web3.middleware.async_make_stalecheck_middleware>`
+        - :meth:`Validation Middleware <web3.middleware.async_validation>`
 
 
 .. py:currentmodule:: web3.providers.eth_tester

--- a/newsfragments/2962.docs.rst
+++ b/newsfragments/2962.docs.rst
@@ -1,0 +1,1 @@
+Removed list of `AsyncHTTPProvider`-supported methods, it supports them all now

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -19,6 +19,7 @@ from .abi import (  # noqa: F401
 )
 from .async_cache import (  # noqa: F401
     _async_simple_cache_middleware as async_simple_cache_middleware,
+    async_construct_simple_cache_middleware,
 )
 from .attrdict import (  # noqa: F401
     async_attrdict_middleware,


### PR DESCRIPTION
### What was wrong?

`AsyncHTTPProvider` had a list of supported methods, but they're all supported now!

### How was it fixed?

Removed the list and formatted the remaining differences from `HTTPProvider`
Created function headers for the async middleware in docs.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/bd9b7cad-9e0a-4921-9a6e-ac635e45782a)
