### PR TITLE
remove isort --recursive flag from and add black to lint-roll

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ lint:
 	tox -e lint
 
 lint-roll:
-	isort --recursive web3 ens tests
+	isort web3 ens tests
+	black web3 ens tests setup.py
 	$(MAKE) lint
 
 test:

--- a/newsfragments/2930.internal.rst
+++ b/newsfragments/2930.internal.rst
@@ -1,0 +1,1 @@
+`lint-roll` - dropped `isort` `--recursive` flag, not needed as of their `v5`, added black


### PR DESCRIPTION
### What was wrong?

`isort` dropped the need for a `--recursive` flag in `v5`. See their [upgrade guide](https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0.html)

### How was it fixed?

Removed `--recursive` flag from `lint-roll`.
Added `black` to `lint-roll` while in there
Closes #2930 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/1e317aa4-d2ac-4f50-bf8e-77b8338889b4)
