### PR TITLE
misc(provider): Change User-Agent header signature

### DIFF
--- a/newsfragments/2964.misc.rst
+++ b/newsfragments/2964.misc.rst
@@ -1,0 +1,1 @@
+Change User-Agent header signature

--- a/tests/core/providers/test_async_http_provider.py
+++ b/tests/core/providers/test_async_http_provider.py
@@ -6,6 +6,7 @@ from aiohttp import (
 
 from web3 import (
     AsyncWeb3,
+    __version__ as web3py_version,
 )
 from web3._utils import (
     request,
@@ -108,18 +109,12 @@ async def test_async_user_provided_session() -> None:
     assert cached_session == session
 
 
-def test_construct_user_agent():
-    """
-    The User-Agent used to include a stringiffied class name like:
-
-        "web3.py/6.4.0/<class 'web3.providers.async_rpc.AsyncHTTPProvider'>"
-
-    This test does minimal checks to ensure it is more like:
-
-        "web3.py/6.4.0/web3.providers.async_rpc.AsyncHTTPProvider"
-
-    """
+def test_get_request_headers():
     provider = AsyncHTTPProvider()
     headers = provider.get_request_headers()
-    assert "<" not in headers["User-Agent"]
-    assert " " not in headers["User-Agent"]
+    assert len(headers) == 2
+    assert headers["Content-Type"] == "application/json"
+    assert (
+        headers["User-Agent"] == f"web3.py/{web3py_version}/"
+        f"{AsyncHTTPProvider.__module__}.{AsyncHTTPProvider.__qualname__}"
+    )

--- a/tests/core/providers/test_async_http_provider.py
+++ b/tests/core/providers/test_async_http_provider.py
@@ -106,3 +106,20 @@ async def test_async_user_provided_session() -> None:
     cached_session = await provider.cache_async_session(session)
     assert len(request._async_session_cache) == 1
     assert cached_session == session
+
+
+def test_construct_user_agent():
+    """
+    The User-Agent used to include a stringiffied class name like:
+
+        "web3.py/6.4.0/<class 'web3.providers.async_rpc.AsyncHTTPProvider'>"
+
+    This test does minimal checks to ensure it is more like:
+
+        "web3.py/6.4.0/web3.providers.async_rpc.AsyncHTTPProvider"
+
+    """
+    provider = AsyncHTTPProvider()
+    headers = provider.get_request_headers()
+    assert "<" not in headers["User-Agent"]
+    assert " " not in headers["User-Agent"]

--- a/tests/core/providers/test_http_provider.py
+++ b/tests/core/providers/test_http_provider.py
@@ -103,3 +103,20 @@ def test_user_provided_session():
     assert isinstance(adapter, HTTPAdapter)
     assert adapter._pool_connections == 20
     assert adapter._pool_maxsize == 20
+
+
+def test_construct_user_agent():
+    """
+    The User-Agent used to include a stringiffied class name like:
+
+        "web3.py/6.4.0/<class 'web3.providers.rpc.HTTPProvider'>"
+
+    This test does minimal checks to ensure it is more like:
+
+        "web3.py/6.4.0/web3.providers.rpc.HTTPProvider"
+
+    """
+    provider = HTTPProvider()
+    headers = provider.get_request_headers()
+    assert "<" not in headers["User-Agent"]
+    assert " " not in headers["User-Agent"]

--- a/tests/core/providers/test_http_provider.py
+++ b/tests/core/providers/test_http_provider.py
@@ -9,6 +9,7 @@ from requests.adapters import (
 
 from web3 import (
     Web3,
+    __version__ as web3py_version,
 )
 from web3._utils import (
     request,
@@ -105,18 +106,12 @@ def test_user_provided_session():
     assert adapter._pool_maxsize == 20
 
 
-def test_construct_user_agent():
-    """
-    The User-Agent used to include a stringiffied class name like:
-
-        "web3.py/6.4.0/<class 'web3.providers.rpc.HTTPProvider'>"
-
-    This test does minimal checks to ensure it is more like:
-
-        "web3.py/6.4.0/web3.providers.rpc.HTTPProvider"
-
-    """
+def test_get_request_headers():
     provider = HTTPProvider()
     headers = provider.get_request_headers()
-    assert "<" not in headers["User-Agent"]
-    assert " " not in headers["User-Agent"]
+    assert len(headers) == 2
+    assert headers["Content-Type"] == "application/json"
+    assert (
+        headers["User-Agent"] == f"web3.py/{web3py_version}/"
+        f"{HTTPProvider.__module__}.{HTTPProvider.__qualname__}"
+    )

--- a/web3/_utils/http.py
+++ b/web3/_utils/http.py
@@ -1,7 +1,6 @@
-def construct_user_agent(class_name: str) -> str:
+def construct_user_agent(class_type: type) -> str:
     from web3 import (
         __version__ as web3_version,
     )
 
-    user_agent = f"web3.py/{web3_version}/{class_name}"
-    return user_agent
+    return f"web3.py/{web3_version}/{class_type.__module__}.{class_type.__qualname__}"

--- a/web3/providers/rpc/async_rpc.py
+++ b/web3/providers/rpc/async_rpc.py
@@ -84,7 +84,7 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
     def get_request_headers(self) -> Dict[str, str]:
         return {
             "Content-Type": "application/json",
-            "User-Agent": construct_user_agent(str(type(self))),
+            "User-Agent": construct_user_agent(type(self)),
         }
 
     async def _make_request(self, method: RPCEndpoint, request_data: bytes) -> bytes:

--- a/web3/providers/rpc/rpc.py
+++ b/web3/providers/rpc/rpc.py
@@ -98,7 +98,7 @@ class HTTPProvider(JSONBaseProvider):
     def get_request_headers(self) -> Dict[str, str]:
         return {
             "Content-Type": "application/json",
-            "User-Agent": construct_user_agent(str(type(self))),
+            "User-Agent": construct_user_agent(type(self)),
         }
 
     def _make_request(self, method: RPCEndpoint, request_data: bytes) -> bytes:


### PR DESCRIPTION
### What was wrong?

The User-Agent used to include a stringiffied class name like:

    "web3.py/6.4.0/<class 'web3.providers.rpc.HTTPProvider'>"
    "web3.py/6.4.0/<class 'web3.providers.async_rpc.AsyncHTTPProvider'>"

This patch sligthly changes it to:

    "web3.py/6.4.0/web3.providers.rpc.HTTPProvider"
    "web3.py/6.4.0/web3.providers.async_rpc.AsyncHTTPProvider"

### How was it fixed?

Use `type.__module__`, and `type.__qualname__`, rather then `str(type))`.

### Todo:

- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://pbs.twimg.com/profile_images/572811126035861504/5VqxkePM.jpeg)
