### PR TITLE
docs: modernize filter guide, emphasize get_logs

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -752,6 +752,7 @@ If you want to run your application logging in debug mode, below is an example o
 
         return logger
 
+.. _advanced_token_fetch:
 
 Advanced example: Fetching all token transfer events
 ----------------------------------------------------

--- a/docs/toc.rst
+++ b/docs/toc.rst
@@ -15,10 +15,8 @@ Table of Contents
 
     node
     providers
-    transactions
-    examples
-    troubleshooting
     web3.eth.account
+    transactions
     filters
     web3.contract
     abi_types
@@ -26,6 +24,8 @@ Table of Contents
     internals
     ethpm
     ens_overview
+    examples
+    troubleshooting
     v6_migration
     v5_migration
     v4_migration

--- a/docs/web3.contract.rst
+++ b/docs/web3.contract.rst
@@ -952,6 +952,20 @@ For example:
 
 :py:class:`ContractEvent` provides methods to interact with contract events. Positional and keyword arguments supplied to the contract event subclass will be used to find the contract event by signature.
 
+.. _contract_get_logs:
+
+.. py:method:: ContractEvents.myEvent(*args, **kwargs).get_logs(filter_params, errors=WARN)
+   :noindex:
+
+   Fetches all logs for a given event within a set of
+   `filter params <https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_newfilter>`_.
+
+    .. code-block:: python
+
+        myContract = web3.eth.contract(address=contract_address, abi=contract_abi)
+        filter_params = {"fromBlock": "latest"}
+        myContract.events.myEvent().get_logs(filter_params)
+
 .. _process_receipt:
 
 .. py:method:: ContractEvents.myEvent(*args, **kwargs).process_receipt(transaction_receipt, errors=WARN)

--- a/newsfragments/2968.docs.rst
+++ b/newsfragments/2968.docs.rst
@@ -1,0 +1,1 @@
+Modernize the filtering guide, emphasizing ``get_logs``


### PR DESCRIPTION
### What was wrong?

- filtering guide has gone mostly untouched for a long while. `get_logs` is hardly mentioned, but is the most reliable way to fetch events today.
- `get_logs` not even listed as a method on the ContractEvent docs

### How was it fixed?

- change the name of the page and put the most frequently asked question up front: "how do i keep track of contract interactions?"
- reference the advanced token `get_logs` example in the guide
- warning about unreliability of filters
- include quick definition of `get_logs` in the contract docs
- shuffles the table of contents around a bit. this is a WIP. eventually, i'd like to see the `Examples` page get broken into separate guides. feels a lot like random questions were answered there over time and each can benefit from living alongside more relevant context.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://styles.redditmedia.com/t5_2z6fi/styles/communityIcon_ozo0tnmvegq91.png)
