### PR TITLE
remove parity and trinity refs in IPCProvider docs

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -168,23 +168,12 @@ IPCProvider
         >>> from web3 import Web3
         >>> w3 = Web3(Web3.IPCProvider("~/Library/Ethereum/geth.ipc"))
 
-    If no ``ipc_path`` is specified, it will use the first IPC file
-    it can find from this list:
+    If no ``ipc_path`` is specified, it will use a default depending on your operating
+    system.
 
-    - On Linux and FreeBSD:
-
-      - ``~/.ethereum/geth.ipc``
-      - ``~/.local/share/io.parity.ethereum/jsonrpc.ipc``
-      - ``~/.local/share/trinity/mainnet/ipcs-eth1/jsonrpc.ipc``
-    - On Mac OS:
-
-      - ``~/Library/Ethereum/geth.ipc``
-      - ``~/Library/Application Support/io.parity.ethereum/jsonrpc.ipc``
-      - ``~/.local/share/trinity/mainnet/ipcs-eth1/jsonrpc.ipc``
-    - On Windows:
-
-      - ``\\\.\pipe\geth.ipc``
-      - ``\\\.\pipe\jsonrpc.ipc``
+    - On Linux and FreeBSD: ``~/.ethereum/geth.ipc``
+    - On Mac OS: ``~/Library/Ethereum/geth.ipc``
+    - On Windows: ``\\\.\pipe\geth.ipc``
 
 
 WebsocketProvider

--- a/newsfragments/2971.docs.rst
+++ b/newsfragments/2971.docs.rst
@@ -1,0 +1,1 @@
+Removed references to defunct providers in `IPCProvider` docs

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -139,10 +139,6 @@ def get_dev_ipc_path() -> Optional[str]:
         if os.path.exists(ipc_path):
             return ipc_path
 
-        ipc_path = os.path.join("\\\\", ".", "pipe", "jsonrpc.ipc")
-        if os.path.exists(ipc_path):
-            return ipc_path
-
     else:
         raise ValueError(
             f"Unsupported platform '{sys.platform}'.  Only darwin/linux/win32/"


### PR DESCRIPTION
### What was wrong?

`IPCProvider` docs still referenced ipc paths for Parity and Trinity
`get_dev_ipc_path` still had the Trinity default for Windows

### How was it fixed?

Removed references to deprecated providers.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/c25a5aad-b2fb-4917-b8fb-ebd74267f6d6)
