### PR TITLE
docs: update matomo script

### DIFF
--- a/docs/_static/js/matomo.js
+++ b/docs/_static/js/matomo.js
@@ -1,11 +1,12 @@
-var _paq = window._paq || [];
+var _paq = window._paq = window._paq || [];
 /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+_paq.push(["setExcludedQueryParams", ["code","gist"]]);
 _paq.push(['trackPageView']);
 _paq.push(['enableLinkTracking']);
 (function() {
-  var u="https://matomo.ethereum.org/piwik/";
+  var u="https://ethereumfoundation.matomo.cloud/";
   _paq.push(['setTrackerUrl', u+'matomo.php']);
   _paq.push(['setSiteId', '18']);
   var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-  g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  g.async=true; g.src='//cdn.matomo.cloud/ethereumfoundation.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
 })();

--- a/newsfragments/2978.docs.rst
+++ b/newsfragments/2978.docs.rst
@@ -1,0 +1,1 @@
+Update Matomo analytics script to move to cloud services


### PR DESCRIPTION
### What was wrong?

- matomo moving from on-premises to cloud. tag script needs tweaking accordingly, and is a copy pasta from their settings page.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![](https://i.pinimg.com/originals/c5/fe/71/c5fe711459bb0f5d86ffe0580255b991.jpg)
