### PR TITLE
bugfix: Unique caches for simple_cache_middleware instances

### DIFF
--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -31,7 +31,7 @@ are likely to change regularly, so this list may not include the latest version'
 You can find the latest defaults in the constructor in ``web3/manager.py``
 
 AttributeDict
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~
 
 .. py:method:: web3.middleware.attrdict_middleware
                web3.middleware.async_attrdict_middleware
@@ -185,7 +185,7 @@ the order of: ``[2, 1, 0]``.
 See "Internals: :ref:`internals__middlewares`" for a deeper dive to how middlewares work.
 
 Middleware Stack API
-~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 To add or remove items in different layers, use the following API:
 
@@ -282,7 +282,7 @@ To add or remove items in different layers, use the following API:
 
 
 Optional Middleware
------------------------
+-------------------
 
 Web3 ships with non-default middleware, for your custom use. In addition to the other ways of
 :ref:`Modifying_Middleware`, you can specify a list of middleware when initializing Web3, with:
@@ -327,16 +327,19 @@ Stalecheck
 Cache
 ~~~~~
 
-.. py:method:: web3.middleware.construct_simple_cache_middleware(cache_class, rpc_whitelist, should_cache_fn)
-               web3.middleware.async_construct_simple_cache_middleware(cache_class, rpc_whitelist, should_cache_fn)
+Simple Cache Middleware
+'''''''''''''''''''''''
+
+.. py:method:: web3.middleware.construct_simple_cache_middleware(cache, rpc_whitelist, should_cache_fn)
+               web3.middleware.async_construct_simple_cache_middleware(cache, rpc_whitelist, should_cache_fn)
 
     These simple cache constructor methods accept the following arguments:
 
-    * ``cache`` must be an instance of the ``web3.utils.caching.SimpleCache`` class.
+    :param cache: Must be an instance of the ``web3.utils.caching.SimpleCache`` class.
         If a cache instance is not provided, a new instance will be created.
-    * ``rpc_whitelist`` must be an iterable, preferably a set, of the RPC methods that
+    :param rpc_whitelist: Must be an iterable, preferably a set, of the RPC methods that
         may be cached. A default list is used if none is provided.
-    * ``should_cache_fn`` must be a callable with the signature
+    :param should_cache_fn: Must be a callable with the signature
         ``fn(method, params, response)`` which returns whether the response should
         be cached.
 
@@ -345,26 +348,28 @@ Cache
 
     Ready to use versions of this middleware can be found at
     ``web3.middleware.simple_cache_middleware`` and
-    ``web3.middleware.async_simple_cache_middleware``.
+    ``web3.middleware.async_simple_cache_middleware``. These are the equivalent of using
+    the constructor methods with the default arguments.
 
-The time-based and latest-block-based cache constructor methods accept the
-following arguments:
-
-    .. note::
-            These ``cache_class`` argument is likely to change to the ``cache``
-            argument with ``web3.utils.caching.SimpleCache`` instance in the future,
-            as is the current state of the simple cache middleware above.
-
-
-* ``cache_class`` must be a callable which returns an object which implements the
-    dictionary API.
-* ``rpc_whitelist`` must be an iterable, preferably a set, of the RPC methods that
-    may be cached. A default list is used if none is provided.
-* ``should_cache_fn`` must be a callable with the signature
-    ``fn(method, params, response)`` which returns whether the response should
-    be cached.
+Time-based Cache Middleware
+'''''''''''''''''''''''''''
 
 .. py:method:: web3.middleware.construct_time_based_cache_middleware(cache_class, cache_expire_seconds, rpc_whitelist, should_cache_fn)
+
+    The time-based cache constructor method accepts the following arguments:
+
+    :param cache_class: Must be a callable which returns an object which implements the
+        dictionary API.
+    :param rpc_whitelist: Must be an iterable, preferably a set, of the RPC methods that
+        may be cached. A default list is used if none is provided.
+    :param should_cache_fn: Must be a callable with the signature
+        ``fn(method, params, response)`` which returns whether the response should
+        be cached.
+
+    .. warning::
+      The ``cache_class`` argument is slated to change to the ``cache``
+      argument with ``web3.utils.caching.SimpleCache`` instance in web3.py ``v7``,
+      as is the current state of the simple cache middleware above.
 
     Constructs a middleware which will cache the return values for any RPC
     method in the ``rpc_whitelist`` for an amount of time defined by
@@ -378,6 +383,21 @@ following arguments:
 
 
 .. py:method:: web3.middleware.construct_latest_block_based_cache_middleware(cache_class, average_block_time_sample_size, default_average_block_time, rpc_whitelist, should_cache_fn)
+
+    The latest-block-based cache constructor method accepts the following arguments:
+
+    :param cache_class: Must be a callable which returns an object which implements the
+        dictionary API.
+    :param rpc_whitelist: Must be an iterable, preferably a set, of the RPC methods that
+        may be cached. A default list is used if none is provided.
+    :param should_cache_fn: Must be a callable with the signature
+        ``fn(method, params, response)`` which returns whether the response should
+        be cached.
+
+    .. warning::
+      The ``cache_class`` argument is slated to change to the ``cache``
+      argument with ``web3.utils.caching.SimpleCache`` instance in web3.py ``v7``,
+      as is the current state of the simple cache middleware above.
 
     Constructs a middleware which will cache the return values for any RPC
     method in the ``rpc_whitelist`` for the latest block.

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -325,24 +325,44 @@ Stalecheck
 
 
 Cache
-~~~~~~~~~~~
-
-All of the caching middlewares accept these common arguments.
-
-* ``cache_class`` must be a callable which returns an object which implements the dictionary API.
-* ``rpc_whitelist`` must be an iterable, preferably a set, of the RPC methods that may be cached.
-* ``should_cache_fn`` must be a callable with the signature ``fn(method, params, response)`` which returns whether the response should be cached.
-
+~~~~~
 
 .. py:method:: web3.middleware.construct_simple_cache_middleware(cache_class, rpc_whitelist, should_cache_fn)
                web3.middleware.async_construct_simple_cache_middleware(cache_class, rpc_whitelist, should_cache_fn)
+
+    These simple cache constructor methods accept the following arguments:
+
+    * ``cache`` must be an instance of the ``web3.utils.caching.SimpleCache`` class.
+        If a cache instance is not provided, a new instance will be created.
+    * ``rpc_whitelist`` must be an iterable, preferably a set, of the RPC methods that
+        may be cached. A default list is used if none is provided.
+    * ``should_cache_fn`` must be a callable with the signature
+        ``fn(method, params, response)`` which returns whether the response should
+        be cached.
 
     Constructs a middleware which will cache the return values for any RPC
     method in the ``rpc_whitelist``.
 
     Ready to use versions of this middleware can be found at
-    ``web3.middleware.simple_cache_middleware`` and ``web3.middleware.async_simple_cache_middleware``.
+    ``web3.middleware.simple_cache_middleware`` and
+    ``web3.middleware.async_simple_cache_middleware``.
 
+The time-based and latest-block-based cache constructor methods accept the
+following arguments:
+
+    .. note::
+            These ``cache_class`` argument is likely to change to the ``cache``
+            argument with ``web3.utils.caching.SimpleCache`` instance in the future,
+            as is the current state of the simple cache middleware above.
+
+
+* ``cache_class`` must be a callable which returns an object which implements the
+    dictionary API.
+* ``rpc_whitelist`` must be an iterable, preferably a set, of the RPC methods that
+    may be cached. A default list is used if none is provided.
+* ``should_cache_fn`` must be a callable with the signature
+    ``fn(method, params, response)`` which returns whether the response should
+    be cached.
 
 .. py:method:: web3.middleware.construct_time_based_cache_middleware(cache_class, cache_expire_seconds, rpc_whitelist, should_cache_fn)
 

--- a/newsfragments/2979.bugfix.rst
+++ b/newsfragments/2979.bugfix.rst
@@ -1,0 +1,1 @@
+Properly create a fresh cache for each instance of ``simple_cache_middleware`` if no cache is provided. Fixes a bug when using this middleware with multiple instances of ``Web3``.

--- a/web3/middleware/async_cache.py
+++ b/web3/middleware/async_cache.py
@@ -56,27 +56,33 @@ async def async_construct_simple_cache_middleware(
         ``response`` and returns a boolean as to whether the response should be
         cached.
     """
-    if cache is None:
-        cache = SimpleCache(256)
 
     async def async_simple_cache_middleware(
         make_request: Callable[[RPCEndpoint, Any], Any], _async_w3: "AsyncWeb3"
     ) -> AsyncMiddlewareCoroutine:
         lock = threading.Lock()
 
+        # It's not imperative that we define ``_cache`` here rather than in
+        # ``async_construct_simple_cache_middleware``. Due to the nature of async,
+        # construction is awaited and doesn't happen at import. This means separate
+        # instances would still get unique caches. However, to keep the code consistent
+        # with the synchronous version, and provide less ambiguity, we define it
+        # similarly to the synchronous version here.
+        _cache = cache if cache else SimpleCache(256)
+
         async def middleware(method: RPCEndpoint, params: Any) -> RPCResponse:
             if method in rpc_whitelist:
                 cache_key = generate_cache_key(
                     f"{threading.get_ident()}:{(method, params)}"
                 )
-                cached_request = cache.get_cache_entry(cache_key)
+                cached_request = _cache.get_cache_entry(cache_key)
                 if cached_request is not None:
                     return cached_request
 
                 response = await make_request(method, params)
                 if should_cache_fn(method, params, response):
                     async with async_lock(_async_request_thread_pool, lock):
-                        cache.cache(cache_key, response)
+                        _cache.cache(cache_key, response)
                 return response
             else:
                 return await make_request(method, params)


### PR DESCRIPTION
### What was wrong?

closes #2977 

### How was it fixed?

- For undefined `cache` arguments to `*construct_simple_cache_middleware` methods, only create the cache at the middleware definition, not at the constructor method. This makes sure that a fresh cache is created each time the middleware is called (once for each instance). This was previously the case and I believe I broke it when we refactored the LRU cache out of this middleware.

- Tests added inspired by @cygnusv 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20230604_154722](https://github.com/ethereum/web3.py/assets/3532824/1e8f50a8-0c01-4ac1-9778-f726c1d3c267)
