### PR TITLE
bugfix: Fix potential race condition when writing cache entries in simple_cache_middleware

### DIFF
--- a/newsfragments/2981.bugfix.rst
+++ b/newsfragments/2981.bugfix.rst
@@ -1,0 +1,1 @@
+Fix potential race condition when writing cache entries in ``simple_cache_middleware``

--- a/web3/middleware/cache.py
+++ b/web3/middleware/cache.py
@@ -103,11 +103,11 @@ def construct_simple_cache_middleware(
 
                 response = make_request(method, params)
                 if should_cache_fn(method, params, response):
-                    lock.acquire(blocking=False)
-                    try:
-                        cache.cache(cache_key, response)
-                    finally:
-                        lock.release()
+                    if lock.acquire(blocking=False):
+                        try:
+                            cache.cache(cache_key, response)
+                        finally:
+                            lock.release()
                 return response
             else:
                 return make_request(method, params)


### PR DESCRIPTION
### What was wrong?

Closes #2976 

In `simple_cache_middleware`, current code tries to get the lock without blocking when writing cache entries, but later doesn't verify whether it did get the lock: https://github.com/ethereum/web3.py/blob/955e10c49d81ff6627c23f2486407919edbd77e6/web3/middleware/cache.py#L106-L110

### How was it fixed?

Just check if you did get the lock, and only write in that case.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://user-images.githubusercontent.com/2564234/243561576-f51f5617-1f2c-4447-bee2-f654b53a46a1.png)
