### PR TITLE
move ethpm deprecation warning to only show when enabled

### DIFF
--- a/ethpm/__init__.py
+++ b/ethpm/__init__.py
@@ -1,12 +1,5 @@
-import warnings
 from pathlib import Path
 
-
-warnings.warn(
-    "The ``ethPM`` module is no longer being maintained and will be "
-    "deprecated with ``web3.py`` version 7",
-    UserWarning,
-)
 
 ETHPM_DIR = Path(__file__).parent
 ASSETS_DIR = ETHPM_DIR / "assets"

--- a/newsfragments/2930.internal.rst
+++ b/newsfragments/2930.internal.rst
@@ -1,1 +1,1 @@
-`lint-roll` - dropped `isort` `--recursive` flag, not needed as of their `v5`, added black
+``lint-roll`` - dropped ``isort`` ``--recursive`` flag, not needed as of their ``v5``, added black

--- a/newsfragments/2960.docs.rst
+++ b/newsfragments/2960.docs.rst
@@ -1,1 +1,1 @@
-Completed docstrings for `ContractFunction` and `AsyncContractFunction` classes
+Completed docstrings for ``ContractFunction`` and ``AsyncContractFunction`` classes

--- a/newsfragments/2961.docs.rst
+++ b/newsfragments/2961.docs.rst
@@ -1,1 +1,1 @@
-Added 'unsupported by any current clients' note to the `Eth.sign_typed_data` docs
+Added 'unsupported by any current clients' note to the ``Eth.sign_typed_data`` docs

--- a/newsfragments/2962.docs.rst
+++ b/newsfragments/2962.docs.rst
@@ -1,1 +1,1 @@
-Removed list of `AsyncHTTPProvider`-supported methods, it supports them all now
+Removed list of ``AsyncHTTPProvider``-supported methods, it supports them all now

--- a/newsfragments/2971.docs.rst
+++ b/newsfragments/2971.docs.rst
@@ -1,1 +1,1 @@
-Removed references to defunct providers in `IPCProvider` docs
+Removed references to defunct providers in ``IPCProvider`` docs

--- a/newsfragments/2983.internal.rst
+++ b/newsfragments/2983.internal.rst
@@ -1,0 +1,1 @@
+Moved ``ethpm`` deprecation warning to only show when the module is explicitly enabled

--- a/web3/main.py
+++ b/web3/main.py
@@ -1,4 +1,5 @@
 import decimal
+import warnings
 
 from ens import (
     AsyncENS,
@@ -343,9 +344,14 @@ class BaseWeb3:
             )
 
     def enable_unstable_package_management_api(self) -> None:
-        from web3.pm import PM  # noqa: F811
-
         if not hasattr(self, "_pm"):
+            warnings.warn(
+                "The ``ethPM`` module is no longer being maintained and will be "
+                "deprecated with ``web3.py`` version 7",
+                UserWarning,
+            )
+            from web3.pm import PM  # noqa: F811
+
             self.attach_modules({"_pm": PM})
 
 


### PR DESCRIPTION
### What was wrong?

The `ethpm` deprecation warning was showing up too much. 

### How was it fixed?

Moved it to only warn when enabling with `enable_unstable_package_management_api`

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/d821ca63-052d-4bb3-909c-c29502067924)
