### PR TITLE
input_munger error handling and refactor

### DIFF
--- a/newsfragments/2987.internal.rst
+++ b/newsfragments/2987.internal.rst
@@ -1,0 +1,1 @@
+Refactor logic for the ``input_munger()`` method on the ``Method`` class.

--- a/web3/method.py
+++ b/web3/method.py
@@ -171,9 +171,8 @@ class Method(Generic[TFunc]):
 
     def input_munger(self, module: "Module", args: Any, kwargs: Any) -> List[Any]:
         # This function takes the input parameters and munges them.
-        # See the test_process_params test
-        # in tests/core/method-class/test_method.py for an example
-        # with multiple mungers.
+        # See the test_process_params test in ``tests/core/method-class/test_method.py``
+        # for an example with multiple mungers.
         return functools.reduce(
             lambda args, munger: munger(module, *args, **kwargs), self.mungers, args
         )

--- a/web3/method.py
+++ b/web3/method.py
@@ -179,7 +179,8 @@ class Method(Generic[TFunc]):
                 args = munger(module, *args, **kwargs)
             except TypeError:
                 raise TypeError(
-                    f"Munger {munger.__name__} failed to process args {args} and kwargs {kwargs}."
+                    f"Munger {munger.__name__} failed to process parameters."
+                    "Args: {args} and kwargs: {kwargs}."
                     "Please check the parameters you are passing to the method."
                 )
         return args

--- a/web3/method.py
+++ b/web3/method.py
@@ -1,4 +1,3 @@
-import functools
 from typing import (
     TYPE_CHECKING,
     Any,

--- a/web3/method.py
+++ b/web3/method.py
@@ -1,3 +1,4 @@
+import functools
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -173,16 +174,9 @@ class Method(Generic[TFunc]):
         # See the test_process_params test
         # in tests/core/method-class/test_method.py for an example
         # with multiple mungers.
-        for munger in self.mungers:
-            try:
-                args = munger(module, *args, **kwargs)
-            except TypeError:
-                raise TypeError(
-                    f"Munger {munger.__name__} failed to process parameters."
-                    "Args: {args} and kwargs: {kwargs}."
-                    "Please check the parameters you are passing to the method."
-                )
-        return args
+        return functools.reduce(
+            lambda args, munger: munger(module, *args, **kwargs), self.mungers, args
+        )
 
     def process_params(
         self, module: "Module", *args: Any, **kwargs: Any


### PR DESCRIPTION
### What was wrong?

The `input_munger` function had no friendly error output, as well as readability issues and verbose logic. This PR also makes it faster in my local testing. We can reduce the `input_munger` function down to a single line with: 

```
return functools.reduce(lambda args, munger: munger(module, *args, **kwargs), self.mungers, args)
```

if desirable.


### How was it fixed?

- Refactor `pipe` the `munged_inputs` to a `for` loop.
- Catch TypeErrors while mungers are munging input parameters.
- Remove `_munger_star_apply` function.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-preview.redd.it/aXVvcHdubWNkczRiMXVIe3HwzvMtY_kgSPufQjlwi_2SD8kizI-isc179Z9A.png?width=960&crop=smart&format=pjpg&auto=webp&v=enabled&s=267bcb3ef6da584d4d3f6e3d78dc66cb9ac59ebc)
