### PR TITLE
Pre-release check for upstream configuration of remote

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,8 @@ notes:
 	git commit -m "Compile release notes"
 
 release: clean
-	# require that you be on a branch that's linked to upstream/main
-	git status -s -b | head -1 | grep "\.\.upstream/main"
+	# require that upstream is configured for ethereum/web3.py
+	git remote -v | grep "upstream\tgit@github.com:ethereum/web3.py.git (push)"
 	./newsfragments/validate_files.py is-empty
 	# verify that docs build correctly
 	make build-docs

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ notes:
 
 release: clean
 	# require that upstream is configured for ethereum/web3.py
-	git remote -v | grep "upstream\tgit@github.com:ethereum/web3.py.git (push)"
+	git remote -v | grep "upstream\tgit@github.com:ethereum/web3.py.git (push)\|upstream\thttps://github.com/ethereum/web3.py (push)"
 	./newsfragments/validate_files.py is-empty
 	# verify that docs build correctly
 	make build-docs

--- a/newsfragments/2988.internal.rst
+++ b/newsfragments/2988.internal.rst
@@ -1,0 +1,1 @@
+Update make release to check remote upstream is pointing to ethereum/web3.py.


### PR DESCRIPTION
### What was wrong?

The release make command was not working, which led to running the tagging/release steps manually.

### How was it fixed?

Changed the command to check the remote upstream is configured. It checks the remote repo configuration with `git remote -v` and greps for the web3.py repo is set as the upstream with ssh or https.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.usatoday.com/gcdn/presto/2022/10/24/USAT/7bf07bc7-d0ad-4fe4-a2ef-547012ad4036-8._Arthur-Telle-Thiemann_Say-cheeeese_00004382.jpg?width=980&height=654&fit=crop&format=pjpg&auto=webp)