### PR TITLE
Bugfix 2969

### DIFF
--- a/newsfragments/2989.bugfix.rst
+++ b/newsfragments/2989.bugfix.rst
@@ -1,0 +1,1 @@
+Catch ``UnicodeDecodeError`` for contract revert messages that cannot be decoded and issue a warning instead, raising a ``ContractLogicError`` with the raw ``data`` from the response.

--- a/web3/_utils/contract_error_handling.py
+++ b/web3/_utils/contract_error_handling.py
@@ -1,3 +1,5 @@
+import warnings
+
 from eth_abi import (
     abi,
 )
@@ -91,8 +93,12 @@ def raise_contract_logic_error_on_revert(response: RPCResponse) -> RPCResponse:
         else:
             raise ContractLogicError("execution reverted", data=data)
 
-        reason_string = bytes.fromhex(reason_as_hex).decode("utf8")
-        raise ContractLogicError(f"execution reverted: {reason_string}", data=data)
+        try:
+            reason_string = bytes.fromhex(reason_as_hex).decode("utf8")
+            raise ContractLogicError(f"execution reverted: {reason_string}", data=data)
+        except UnicodeDecodeError:
+            warnings.warn("Could not decode revert reason as UTF-8", RuntimeWarning)
+            raise ContractLogicError("execution reverted", data=data)
 
     # --- EIP-3668 | CCIP Read --- #
     if data[:10] == OFFCHAIN_LOOKUP_FUNC_SELECTOR:


### PR DESCRIPTION
### What was wrong?

closes #2969

### How was it fixed?

- Catch `UnicodeDecodeError` when trying to decode a contract revert reason and raise `ContractLogicError` with raw `data` field from the response instead.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

lepitse
![20191005_111115](https://github.com/ethereum/web3.py/assets/3532824/c8290b7f-d931-486a-8136-150de37a5913)

