### PR TITLE
Clean up test warnings

### DIFF
--- a/newsfragments/2991.internal.rst
+++ b/newsfragments/2991.internal.rst
@@ -1,0 +1,1 @@
+Remove some warnings from test output

--- a/tests/core/pm-module/conftest.py
+++ b/tests/core/pm-module/conftest.py
@@ -60,7 +60,10 @@ def setup_w3():
     w3 = Web3(Web3.EthereumTesterProvider(ethereum_tester=t))
     w3.eth.default_account = w3.eth.accounts[0]
     w3.eth._default_contract_factory = LinkableContract
-    w3.enable_unstable_package_management_api()
+    with pytest.warns(
+        UserWarning, match="The ``ethPM`` module is no longer being maintained"
+    ):
+        w3.enable_unstable_package_management_api()
     return w3
 
 

--- a/tests/core/pm-module/test_ens_integration.py
+++ b/tests/core/pm-module/test_ens_integration.py
@@ -113,7 +113,10 @@ def ens_setup(deployer):
 def ens(ens_setup, mocker):
     mocker.patch("web3.middleware.stalecheck._is_fresh", return_value=True)
     ens_setup.w3.eth.default_account = ens_setup.w3.eth.coinbase
-    ens_setup.w3.enable_unstable_package_management_api()
+    with pytest.warns(
+        UserWarning, match="The ``ethPM`` module is no longer being maintained"
+    ):
+        ens_setup.w3.enable_unstable_package_management_api()
     return ens_setup
 
 

--- a/tests/core/pm-module/test_registry_integration.py
+++ b/tests/core/pm-module/test_registry_integration.py
@@ -28,7 +28,10 @@ def fresh_w3():
     w3 = Web3(Web3.EthereumTesterProvider())
     w3.eth.default_account = w3.eth.accounts[0]
     w3.eth._default_contract_factory = LinkableContract
-    w3.enable_unstable_package_management_api()
+    with pytest.warns(
+        UserWarning, match="The ``ethPM`` module is no longer being maintained"
+    ):
+        w3.enable_unstable_package_management_api()
     return w3
 
 

--- a/tests/core/utilities/test_request.py
+++ b/tests/core/utilities/test_request.py
@@ -270,6 +270,7 @@ async def test_async_json_make_get_request(mocker):
             total=10, connect=None, sock_read=None, sock_connect=None
         ),
     )
+    await session.close()
 
 
 @pytest.mark.asyncio
@@ -291,6 +292,7 @@ async def test_async_make_post_request(mocker):
             total=10, connect=None, sock_read=None, sock_connect=None
         ),
     )
+    await session.close()
 
 
 @pytest.mark.asyncio

--- a/tests/core/utilities/test_request.py
+++ b/tests/core/utilities/test_request.py
@@ -371,10 +371,13 @@ async def test_async_unique_cache_keys_created_per_thread_with_same_uri():
     test_sessions = []
 
     def target_function(endpoint_uri):
-        event_loop = asyncio.new_event_loop()
-        unique_session = event_loop.run_until_complete(
-            async_cache_and_return_session(endpoint_uri)
-        )
+        try:
+            event_loop = asyncio.new_event_loop()
+        finally:
+            unique_session = event_loop.run_until_complete(
+                async_cache_and_return_session(endpoint_uri)
+            )
+            event_loop.close()
         test_sessions.append(unique_session)
 
     threads = []

--- a/tests/core/utilities/test_request.py
+++ b/tests/core/utilities/test_request.py
@@ -371,13 +371,11 @@ async def test_async_unique_cache_keys_created_per_thread_with_same_uri():
     test_sessions = []
 
     def target_function(endpoint_uri):
-        try:
-            event_loop = asyncio.new_event_loop()
-        finally:
-            unique_session = event_loop.run_until_complete(
-                async_cache_and_return_session(endpoint_uri)
-            )
-            event_loop.close()
+        event_loop = asyncio.new_event_loop()
+        unique_session = event_loop.run_until_complete(
+            async_cache_and_return_session(endpoint_uri)
+        )
+        event_loop.close()
         test_sessions.append(unique_session)
 
     threads = []

--- a/tests/ens/conftest.py
+++ b/tests/ens/conftest.py
@@ -446,7 +446,9 @@ def async_ENS_registry_factory(async_w3):
 
 @pytest.fixture(scope="session")
 def event_loop():
-    return asyncio.get_event_loop()
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    yield loop
+    loop.close()
 
 
 # add session scope with above session-scoped `event_loop` for better performance


### PR DESCRIPTION
### What was wrong?

There were a bunch of warnings being emitted in various tests.

### How was it fixed?
Cleaned up some, mostly by closing loops and sessions. 

- Limiting `requests` to <=2.29.0 will get rid of the  DeprecationWarning: `/home/circleci/repo/.tox/py310-core/lib/python3.10/site-packages/urllib3/poolmanager.py:315: DeprecationWarning: The 'strict' parameter is no longer needed on Python 3+. This will raise an error in urllib3 v2.1.0.`, but I opted not to do that. I think they'll clean it up eventually. 

- The warnings from `tests/core/tools/pytest_ethereum/test_deployer.py::test_user_code_with_fixture` are due to [this file](https://github.com/ethereum/web3.py/blob/main/tests/core/providers/test_websocket_provider.py), and specifically the `w3` and `start_websocket_server` fixtures.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)
- [x] Clean up commits


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://daily.jstor.org/wp-content/uploads/2017/02/american_pika_1050x700.jpg)
