### PR TITLE
drop pluggy from dev reqs

### DIFF
--- a/newsfragments/2992.internal.rst
+++ b/newsfragments/2992.internal.rst
@@ -1,0 +1,1 @@
+Removed `pluggy` from dev requirements

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ extras_require = {
         "tox>=3.18.0",
         "tqdm>4.32",
         "twine>=1.13",
-        "pluggy==0.13.1",
         "when-changed>=0.3.0",
         "build>=0.9.0",
     ],


### PR DESCRIPTION
### What was wrong?

We had the pin `pluggy==0.13.1`.  We don't use it directly - `pytest` and `tox` have it as a dependency.
We'll be bumping to `tox>=4.0.0` soonish, which requires `pluggy>=1.0.0`.

### How was it fixed?
Removed our explicit dev requirement for `pluggy`

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/bdc830d5-b6a1-42b9-a6b5-21d7da5bd678)
