### PR TITLE
fix(utils): Missing single quote in arguments count error message

### DIFF
--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -394,7 +394,7 @@ def merge_args_and_kwargs(
     # Ensure the function is being applied to the correct number of args
     if len(args) + len(kwargs) != len(function_abi.get("inputs", [])):
         raise TypeError(
-            f"Incorrect argument count. Expected '{len(function_abi['inputs'])}"
+            f"Incorrect argument count. Expected '{len(function_abi['inputs'])}'"
             f". Got '{len(args) + len(kwargs)}'"
         )
 


### PR DESCRIPTION
### What was wrong?

When calling a function with an inappropriate number of arguments, current error is like:

```
TypeError: Incorrect argument count. Expected '3. Got '2'
```
Note the missing single quote around `'3`.

### How was it fixed?

Add the missing quote.

### Todo:

- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
