### PR TITLE
Fix max_priority_fee when eth_maxPriorityFeePerGas is unavailable

### DIFF
--- a/newsfragments/3002.bugfix.rst
+++ b/newsfragments/3002.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes ``max_priority_fee_per_gas``. It wasn't falling back to ``eth_feeHistory`` since the ``MethodUnavailable`` error was introduced.

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -301,6 +301,10 @@ class TestEthereumTesterEthModule(EthModuleTest):
     test_eth_max_priority_fee_with_fee_history_calculation = not_implemented(
         EthModuleTest.test_eth_max_priority_fee_with_fee_history_calculation, ValueError
     )
+    test_eth_max_priority_fee_with_fee_history_calculation_error_dict = not_implemented(
+        EthModuleTest.test_eth_max_priority_fee_with_fee_history_calculation_error_dict,
+        ValueError,
+    )
     test_eth_sign = not_implemented(EthModuleTest.test_eth_sign, ValueError)
     test_eth_sign_ens_names = not_implemented(
         EthModuleTest.test_eth_sign_ens_names, ValueError

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -806,6 +806,38 @@ class AsyncEthModuleTest:
         assert is_integer(max_priority_fee)
 
     @pytest.mark.asyncio
+    async def test_eth_max_priority_fee_with_fee_history_calculation_error_dict(
+        self, w3: "Web3"
+    ) -> None:
+        fail_max_prio_middleware = construct_error_generator_middleware(
+            {
+                RPCEndpoint("eth_maxPriorityFeePerGas"): lambda *_: {
+                    "error": {
+                        "code": -32601,
+                        "message": (
+                            "The method eth_maxPriorityFeePerGas does "
+                            "not exist/is not available"
+                        ),
+                    }
+                }
+            }
+        )
+        w3.middleware_onion.add(
+            fail_max_prio_middleware, name="fail_max_prio_middleware"
+        )
+
+        with pytest.warns(
+            UserWarning,
+            match=(
+                "There was an issue with the method eth_maxPriorityFeePerGas."
+                " Calculating using eth_feeHistory."
+            ),
+        ):
+            w3.eth.max_priority_fee
+
+        w3.middleware_onion.remove("fail_max_prio_middleware")  # clean up
+
+    @pytest.mark.asyncio
     async def test_eth_max_priority_fee_with_fee_history_calculation(
         self, async_w3: "AsyncWeb3"
     ) -> None:
@@ -818,8 +850,10 @@ class AsyncEthModuleTest:
 
         with pytest.warns(
             UserWarning,
-            match="There was an issue with the method eth_maxPriorityFeePerGas. "
-            "Calculating using eth_feeHistory.",
+            match=(
+                "There was an issue with the method eth_maxPriorityFeePerGas. "
+                "Calculating using eth_feeHistory."
+            ),
         ):
             max_priority_fee = await async_w3.eth.max_priority_fee
             assert is_integer(max_priority_fee)
@@ -2315,6 +2349,37 @@ class EthModuleTest:
         max_priority_fee = w3.eth.max_priority_fee
         assert is_integer(max_priority_fee)
 
+    def test_eth_max_priority_fee_with_fee_history_calculation_error_dict(
+        self, w3: "Web3"
+    ) -> None:
+        fail_max_prio_middleware = construct_error_generator_middleware(
+            {
+                RPCEndpoint("eth_maxPriorityFeePerGas"): lambda *_: {
+                    "error": {
+                        "code": -32601,
+                        "message": (
+                            "The method eth_maxPriorityFeePerGas does "
+                            "not exist/is not available"
+                        ),
+                    }
+                }
+            }
+        )
+        w3.middleware_onion.add(
+            fail_max_prio_middleware, name="fail_max_prio_middleware"
+        )
+
+        with pytest.warns(
+            UserWarning,
+            match=(
+                "There was an issue with the method eth_maxPriorityFeePerGas."
+                " Calculating using eth_feeHistory."
+            ),
+        ):
+            w3.eth.max_priority_fee
+
+        w3.middleware_onion.remove("fail_max_prio_middleware")  # clean up
+
     def test_eth_max_priority_fee_with_fee_history_calculation(
         self, w3: "Web3"
     ) -> None:
@@ -2327,8 +2392,10 @@ class EthModuleTest:
 
         with pytest.warns(
             UserWarning,
-            match="There was an issue with the method eth_maxPriorityFeePerGas."
-            " Calculating using eth_feeHistory.",
+            match=(
+                "There was an issue with the method eth_maxPriorityFeePerGas."
+                " Calculating using eth_feeHistory."
+            ),
         ):
             max_priority_fee = w3.eth.max_priority_fee
             assert is_integer(max_priority_fee)

--- a/web3/eth/eth.py
+++ b/web3/eth/eth.py
@@ -56,6 +56,7 @@ from web3.eth.base_eth import (
     BaseEth,
 )
 from web3.exceptions import (
+    MethodUnavailable,
     OffchainLookup,
     TimeExhausted,
     TooManyRequests,
@@ -181,7 +182,7 @@ class Eth(BaseEth):
         """
         try:
             return self._max_priority_fee()
-        except ValueError:
+        except (ValueError, MethodUnavailable):
             warnings.warn(
                 "There was an issue with the method eth_maxPriorityFeePerGas. "
                 "Calculating using eth_feeHistory."

--- a/web3/middleware/fixture.py
+++ b/web3/middleware/fixture.py
@@ -81,8 +81,17 @@ def construct_error_generator_middleware(
     ) -> Callable[[RPCEndpoint, Any], RPCResponse]:
         def middleware(method: RPCEndpoint, params: Any) -> RPCResponse:
             if method in error_generators:
-                error_msg = error_generators[method](method, params)
-                return {"error": error_msg}
+                error = error_generators[method](method, params)
+                if isinstance(error, dict) and error.get("error", False):
+                    return {
+                        "error": {
+                            "code": error.get("code", -32000),
+                            "message": error["error"].get("message", ""),
+                            "data": error.get("data", ""),
+                        }
+                    }
+                else:
+                    return {"error": error}
             else:
                 return make_request(method, params)
 
@@ -132,8 +141,17 @@ async def async_construct_error_generator_middleware(
     ) -> AsyncMiddlewareCoroutine:
         async def middleware(method: RPCEndpoint, params: Any) -> RPCResponse:
             if method in error_generators:
-                error_msg = error_generators[method](method, params)
-                return {"error": error_msg}
+                error = error_generators[method](method, params)
+                if isinstance(error, dict) and error.get("error", False):
+                    return {
+                        "error": {
+                            "code": error.get("code", -32000),
+                            "message": error["error"].get("message", ""),
+                            "data": error.get("data", ""),
+                        }
+                    }
+                else:
+                    return {"error": error}
             else:
                 return await make_request(method, params)
 


### PR DESCRIPTION
Hardhat anwers `{'code': -32601, 'message': 'Method eth_maxPriorityFeePerGas not found', 'data': {'message': 'Method eth_maxPriorityFeePerGas not found'}}` which raises `MethodUnavailable` instead of `ValueError`. 

It is not clear to me if the answer of other nodes causes ValueError or now only MethodUnavailable (so to replace the exception).

### What was wrong?

Explained above. I did not open an issue because I feel that in this case it is easier to explain the issue showing a possible fix. Sorry if this mess things, also to not provide tests.

### How was it fixed?

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

