### PR TITLE
Use the latest available solidity version for compiling test contracts

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -246,8 +246,8 @@ argument at the command line.
 
 Arguments for the script are:
     -v or --version         Solidity version to be used to compile the contracts. If
-                            blank, the script uses the latest hard-coded version
-                            specified within the script.
+                            blank, the script uses the latest available version from
+                            solcx.
 
     -f or --filename        If left blank, all .sol files will be compiled and the
                             respective contract data will be generated. Pass in a

--- a/web3/_utils/contract_sources/compile_contracts.py
+++ b/web3/_utils/contract_sources/compile_contracts.py
@@ -64,11 +64,13 @@ arg_parser.add_argument(
 )
 user_args = arg_parser.parse_args()
 
-CONFIGURED_SOLIDITY_VERSION = "0.8.18"
-# establish Solidity version from user-provided arg or use hard-coded version
+LATEST_AVAILABLE_SOLIDITY_VERSION = sorted(solcx.get_compilable_solc_versions())[-1]
+# establish Solidity version from user-provided arg or use latest available version
 user_sol_version = user_args.version
 
-solidity_version = user_sol_version if user_sol_version else CONFIGURED_SOLIDITY_VERSION
+solidity_version = (
+    user_sol_version if user_sol_version else LATEST_AVAILABLE_SOLIDITY_VERSION
+)
 solcx.install_solc(solidity_version)
 solcx.set_solc_version(solidity_version)
 


### PR DESCRIPTION
### What was wrong?

Nothing was really wrong but we should just use the latest available solidity version for compiling maybe? Seems like a chore to keep changing that static version. I don't think we should ever rely on that lazy-configured version anyways but this seems like a nicer default.

### How was it fixed?

Grab the solidity version from the latest version in the supported versions sorted list.

#### Cute Animal Picture

```
 (\  /)
 ( o o )
   ' '
 \_| |
```