### PR TITLE
Ensip 15 tests and docs

### DIFF
--- a/docs/ens_overview.rst
+++ b/docs/ens_overview.rst
@@ -10,6 +10,13 @@ hexadecimal addresses, content hashes, and more.
 The :mod:`ens` module is included with web3.py. It provides an interface to look up
 domains and addresses, add resolver records, or get and set metadata.
 
+
+.. note:: ENSIP-15 introduced a new standard for ENS name normalization. This standard
+    is implemented in web3.py via the `ensip15_normalization` flag on the `ENS` /
+    `AsyncENS` class. It is also available as a flag on relevant `ens.utils.py` utility
+    methods. For more information, see :ref:`ensip15_normalization`.
+
+
 Setup
 -----
 
@@ -135,6 +142,39 @@ The first time it's used, web3.py will create the  ``ens`` instance using
 
 Usage
 -----
+
+.. _ensip15_normalization:
+
+ENSIP-15 Normalization
+~~~~~~~~~~~~~~~~~~~~~~
+
+The ENSIP-15 normalization algorithm is implemented in web3.py. It will be the default
+name normalization algorithm in web3.py ``v7`` and is available in web3.py ``v6`` via
+the ``ensip15_normalization`` flag on the ``ENS`` & ``AsyncENS`` classes. It is also
+available via the ``ensip15`` flag on relevant ``ens.utils`` utility methods:
+
+- :meth:`~ens.utils.normalize_name`
+- :meth:`~ens.utils.is_valid_name`
+- :meth:`~ens.utils.ens_encode_name`
+- :meth:`~ens.utils.label_to_hash`
+- :meth:`~ens.utils.raw_name_to_hash`
+
+and via the ``ensip15`` flag on static methods on the ``ENS`` & ``AsyncENS`` classes:
+
+- :meth:`~ens.BaseENS.namehash`
+- :meth:`~ens.BaseENS.labelhash`
+- :meth:`~ens.BaseENS.nameprep`
+- :meth:`~ens.BaseENS.is_valid_name`
+
+The ``ensip15_normalization`` flag is ``False`` by default on the ``ENS`` & ``AsyncENS``
+classes. Set this value to ``True`` to use the ENSIP-15 name normalization standard
+for all calls to ENS contracts via the ``ENS`` & ``AsyncENS`` classes.
+
+.. code-block:: python
+
+    from ens.auto import ns
+    ns.ensip15_normalization = True
+
 
 Name Info
 ~~~~~~~~~

--- a/docs/ens_overview.rst
+++ b/docs/ens_overview.rst
@@ -12,9 +12,10 @@ domains and addresses, add resolver records, or get and set metadata.
 
 
 .. note:: ENSIP-15 introduced a new standard for ENS name normalization. This standard
-    is implemented in web3.py via the `ensip15_normalization` flag on the `ENS` /
-    `AsyncENS` class. It is also available as a flag on relevant `ens.utils.py` utility
-    methods. For more information, see :ref:`ensip15_normalization`.
+    is implemented in web3.py via the ``ensip15_normalization`` flag on the ``ENS`` /
+    ``AsyncENS`` class. It is also available as a flag on relevant ``ens.utils.py``
+    utility methods. For more information, refer to the :ref:`ensip15_normalization`
+    section.
 
 
 Setup

--- a/ens/_normalization.py
+++ b/ens/_normalization.py
@@ -215,7 +215,6 @@ def _construct_whole_confusable_map() -> Dict[int, Set[str]]:
 WHOLE_CONFUSABLE_MAP = _construct_whole_confusable_map()
 VALID_CODEPOINTS = _extract_valid_codepoints()
 MAX_LEN_EMOJI_PATTERN = max(len(e) for e in NORMALIZATION_SPEC["emoji"])
-WHOLE_CONFUSABLES = NORMALIZATION_SPEC["wholes"]
 NSM_MAX = NORMALIZATION_SPEC["nsm_max"]
 
 

--- a/ens/utils.py
+++ b/ens/utils.py
@@ -224,8 +224,12 @@ def normal_name_to_hash(name: str) -> HexBytes:
     if not is_empty_name(name):
         labels = name.split(".")
         for label in reversed(labels):
-            # name is already normalized, ensip15 flag not needed
-            labelhash = label_to_hash(label)
+            with warnings.catch_warnings():
+                # name is already normalized, ensip15 flag not needed here
+                # ignore FutureWarning from label_to_hash
+                warnings.simplefilter("ignore", FutureWarning)
+                labelhash = label_to_hash(label)
+
             assert isinstance(labelhash, bytes)
             assert isinstance(node, bytes)
             node = Web3().keccak(node + labelhash)

--- a/ens/utils.py
+++ b/ens/utils.py
@@ -220,13 +220,22 @@ def label_to_hash(label: str, ensip15: bool = False) -> HexBytes:
 
 
 def normal_name_to_hash(name: str) -> HexBytes:
+    """
+    This method will not normalize the name. 'normal' name here means the name
+    should already be normalized before calling this method.
+
+    :param name:            the name to hash - should already be normalized
+    :return: namehash       the hash of the name
+    :rtype: HexBytes
+    """
     node = EMPTY_SHA3_BYTES
     if not is_empty_name(name):
         labels = name.split(".")
         for label in reversed(labels):
             with warnings.catch_warnings():
                 # name is already normalized, ensip15 flag not needed here
-                # ignore FutureWarning from label_to_hash
+                # ignore FutureWarning from label_to_hash.
+                #  TODO: remove this when ENSIP-15 is default
                 warnings.simplefilter("ignore", FutureWarning)
                 labelhash = label_to_hash(label)
 

--- a/newsfragments/3005.docs.rst
+++ b/newsfragments/3005.docs.rst
@@ -1,0 +1,1 @@
+Document ENSIP-15 normalization standard usage for web3.py ``v6`` and document that this will be the default normalization in web3.py ``v7``.

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,9 @@
 addopts= -v --showlocals --durations 10
 xfail_strict=true
 asyncio_mode=strict
+markers =
+    # TODO: remove once ENSIP-15 is default
+    ensip15: Don't silence warnings related to ENSIP-15.
 
 [pytest-watch]
 runner= pytest --failed-first --maxfail=1 --no-success-flaky-report

--- a/tests/ens/conftest.py
+++ b/tests/ens/conftest.py
@@ -14,6 +14,11 @@ from ens import (
     ENS,
     AsyncENS,
 )
+from ens._normalization import (
+    ENSNormalizedName,
+    Label,
+    TextToken,
+)
 from ens.contract_data import (
     extended_resolver_abi,
     extended_resolver_bytecode,
@@ -48,6 +53,14 @@ from web3.contract import (
 from web3.providers.eth_tester import (
     AsyncEthereumTesterProvider,
     EthereumTesterProvider,
+)
+
+ENSIP15_NORMALIZED_TESTER_DOT_ETH = ENSNormalizedName(
+    # "tester.eth"
+    [
+        Label("ascii", [TextToken([ord(c) for c in "tester"])]),
+        Label("ascii", [TextToken([ord(c) for c in "eth"])]),
+    ]
 )
 
 

--- a/tests/ens/conftest.py
+++ b/tests/ens/conftest.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import pytest
+import warnings
 
 from eth_tester import (
     EthereumTester,
@@ -62,6 +63,23 @@ ENSIP15_NORMALIZED_TESTER_DOT_ETH = ENSNormalizedName(
         Label("ascii", [TextToken([ord(c) for c in "eth"])]),
     ]
 )
+
+
+@pytest.fixture(autouse=True)
+def silence_ensip15_warnings(request):
+    # TODO: remove once ENSIP-15 is default
+    if "ensip15" in request.keywords:
+        yield
+    else:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=(
+                    "It is recommended to `normalize_name\\(\\)` with `ensip15==True`"
+                ),
+                category=FutureWarning,
+            )
+            yield
 
 
 def bytes32(val):

--- a/tests/ens/test_ens.py
+++ b/tests/ens/test_ens.py
@@ -103,6 +103,7 @@ def test_ens_strict_bytes_type_checking_is_distinct_from_w3_instance(w3):
         ("get_text", ("tester.eth", "url")),
     ),
 )
+@pytest.mark.ensip15  # remove once ENSIP-15 is default
 def test_ens_methods_with_ensip15_normalization_flag(
     ens,
     method_str,
@@ -234,6 +235,7 @@ def test_async_ens_strict_bytes_type_checking_is_distinct_from_w3_instance(
     ),
 )
 @pytest.mark.asyncio
+@pytest.mark.ensip15  # remove once ENSIP-15 is default
 async def test_async_ens_methods_with_ensip15_normalization_flag(
     async_ens,
     method_str,

--- a/tests/ens/test_ens.py
+++ b/tests/ens/test_ens.py
@@ -1,11 +1,18 @@
 import pytest
+from unittest.mock import (
+    patch,
+)
+import warnings
 
 from ens import (
     ENS,
     AsyncENS,
 )
+from tests.ens.conftest import (
+    ENSIP15_NORMALIZED_TESTER_DOT_ETH,
+)
 from web3 import (
-    Web3,
+    AsyncWeb3,
 )
 from web3.middleware import (
     async_validation_middleware,
@@ -88,79 +95,183 @@ def test_ens_strict_bytes_type_checking_is_distinct_from_w3_instance(w3):
     assert not ns._resolver_contract.w3.strict_bytes_type_checking
 
 
+@pytest.mark.parametrize(
+    "method_str,args",
+    (
+        ("owner", ("tester.eth",)),
+        ("set_text", ("tester.eth", "url", "https://www.ethereum.org")),
+        ("get_text", ("tester.eth", "url")),
+    ),
+)
+def test_ens_methods_with_ensip15_normalization_flag(
+    ens,
+    method_str,
+    args,
+):
+    address = ens.w3.eth.accounts[2]
+    method = ens.__getattribute__(method_str)
+
+    # -- ensip15_normalization is False by default -- #
+    with pytest.warns(FutureWarning, match="ENSIP-15"):
+        ens.setup_address("tester.eth", address)  # test setup_address
+
+    with pytest.warns(FutureWarning, match="ENSIP-15"):
+        ens.resolver("tester.eth")  # test resolver
+
+    with patch("ens.utils.normalize_name_ensip15") as mock_normalize_name_ensip15:
+        assert ens.ensip15_normalization is False
+
+        with pytest.warns(FutureWarning, match="ENSIP-15"):
+            method(*args)  # test parametrized method
+            mock_normalize_name_ensip15.assert_not_called()
+
+    # -- with ensip15_normalization enabled -- #
+    ens.ensip15_normalization = True
+    with warnings.catch_warnings():
+        # raise if FutureWarning is issued
+        warnings.simplefilter("error", category=FutureWarning)
+
+        ens.setup_address("tester.eth", address)  # test setup_address
+        ens.resolver("tester.eth")  # test resolver
+
+        with patch("ens.utils.normalize_name_ensip15") as mock_normalize_name_ensip15:
+            mock_normalize_name_ensip15.return_value = ENSIP15_NORMALIZED_TESTER_DOT_ETH
+
+            method(*args)  # test parametrized method
+            mock_normalize_name_ensip15.assert_called_with("tester.eth")
+
+    # cleanup
+    ens.setup_address("tester.eth", None)
+    ens.ensip15_normalization = False
+
+
 # -- async -- #
 
 
 @pytest.fixture
-def async_w3():
-    return Web3(AsyncEthereumTesterProvider())
+def local_async_w3():
+    return AsyncWeb3(AsyncEthereumTesterProvider())
 
 
-def test_async_from_web3_inherits_web3_middlewares(async_w3):
+def test_async_from_web3_inherits_web3_middlewares(local_async_w3):
     test_middleware = async_validation_middleware
-    async_w3.middleware_onion.add(test_middleware, "test_middleware")
+    local_async_w3.middleware_onion.add(test_middleware, "test_middleware")
 
-    ns = AsyncENS.from_web3(async_w3)
+    ns = AsyncENS.from_web3(local_async_w3)
     assert ns.w3.middleware_onion.get("test_middleware") == test_middleware
 
 
-def test_async_from_web3_does_not_set_w3_object_reference(async_w3):
-    assert async_w3.strict_bytes_type_checking
+def test_async_from_web3_does_not_set_w3_object_reference(local_async_w3):
+    assert local_async_w3.strict_bytes_type_checking
 
-    ns = AsyncENS.from_web3(async_w3)
+    ns = AsyncENS.from_web3(local_async_w3)
     assert ns.w3.strict_bytes_type_checking
 
-    assert async_w3 != ns.w3  # assert not the same object
+    assert local_async_w3 != ns.w3  # assert not the same object
 
-    async_w3.strict_bytes_type_checking = False
-    assert not async_w3.strict_bytes_type_checking
+    local_async_w3.strict_bytes_type_checking = False
+    assert not local_async_w3.strict_bytes_type_checking
 
     assert ns.w3.strict_bytes_type_checking  # assert unchanged instance property
 
 
-def test_async_w3_ens_for_empty_ens_sets_w3_object_reference(async_w3):
-    assert async_w3.strict_bytes_type_checking
-    assert async_w3.ens.w3.strict_bytes_type_checking
+def test_async_w3_ens_for_empty_ens_sets_w3_object_reference(local_async_w3):
+    assert local_async_w3.strict_bytes_type_checking
+    assert local_async_w3.ens.w3.strict_bytes_type_checking
 
-    assert async_w3 == async_w3.ens.w3  # assert same object
+    assert local_async_w3 == local_async_w3.ens.w3  # assert same object
 
-    async_w3.strict_bytes_type_checking = False
-    assert not async_w3.strict_bytes_type_checking
-    assert not async_w3.ens.w3.strict_bytes_type_checking
-
-
-def test_async_w3_ens_setter_sets_w3_object_reference_on_ens(async_w3):
-    ns = AsyncENS.from_web3(async_w3)
-    async_w3.ens = ns
-    assert ns == async_w3.ens
-    assert async_w3 == async_w3.ens.w3
-
-    assert async_w3.strict_bytes_type_checking
-    assert async_w3.ens.w3.strict_bytes_type_checking
-
-    async_w3.strict_bytes_type_checking = False
-    assert not async_w3.strict_bytes_type_checking
-    assert not async_w3.ens.w3.strict_bytes_type_checking
+    local_async_w3.strict_bytes_type_checking = False
+    assert not local_async_w3.strict_bytes_type_checking
+    assert not local_async_w3.ens.w3.strict_bytes_type_checking
 
 
-def test_async_ens_strict_bytes_type_checking_is_distinct_from_w3_instance(async_w3):
-    ns = AsyncENS.from_web3(async_w3)
-    assert ns.w3 != async_w3  # assert unique instance for ns
+def test_async_w3_ens_setter_sets_w3_object_reference_on_ens(local_async_w3):
+    ns = AsyncENS.from_web3(local_async_w3)
+    local_async_w3.ens = ns
+    assert ns == local_async_w3.ens
+    assert local_async_w3 == local_async_w3.ens.w3
+
+    assert local_async_w3.strict_bytes_type_checking
+    assert local_async_w3.ens.w3.strict_bytes_type_checking
+
+    local_async_w3.strict_bytes_type_checking = False
+    assert not local_async_w3.strict_bytes_type_checking
+    assert not local_async_w3.ens.w3.strict_bytes_type_checking
+
+
+def test_async_ens_strict_bytes_type_checking_is_distinct_from_w3_instance(
+    local_async_w3,
+):
+    ns = AsyncENS.from_web3(local_async_w3)
+    assert ns.w3 != local_async_w3  # assert unique instance for ns
     assert ns.w3 == ns._resolver_contract.w3  # assert same instance used under the hood
 
-    assert async_w3.strict_bytes_type_checking
+    assert local_async_w3.strict_bytes_type_checking
     assert ns.strict_bytes_type_checking
 
-    async_w3.strict_bytes_type_checking = False
-    assert not async_w3.strict_bytes_type_checking
+    local_async_w3.strict_bytes_type_checking = False
+    assert not local_async_w3.strict_bytes_type_checking
     assert ns.strict_bytes_type_checking
     assert ns.w3.strict_bytes_type_checking
     assert ns._resolver_contract.w3.strict_bytes_type_checking
 
-    async_w3.strict_bytes_type_checking = True
-    assert async_w3.strict_bytes_type_checking
+    local_async_w3.strict_bytes_type_checking = True
+    assert local_async_w3.strict_bytes_type_checking
 
     ns.strict_bytes_type_checking = False
     assert not ns.strict_bytes_type_checking
     assert not ns.w3.strict_bytes_type_checking
     assert not ns._resolver_contract.w3.strict_bytes_type_checking
+
+
+@pytest.mark.parametrize(
+    "method_str,args",
+    (
+        ("owner", ("tester.eth",)),
+        ("set_text", ("tester.eth", "url", "https://www.ethereum.org")),
+        ("get_text", ("tester.eth", "url")),
+    ),
+)
+@pytest.mark.asyncio
+async def test_async_ens_methods_with_ensip15_normalization_flag(
+    async_ens,
+    method_str,
+    args,
+):
+    accounts = await async_ens.w3.eth.accounts
+    address = accounts[2]
+    method = async_ens.__getattribute__(method_str)
+
+    # -- ensip15_normalization is False by default -- #
+    with pytest.warns(FutureWarning, match="ENSIP-15"):
+        await async_ens.setup_address("tester.eth", address)  # test setup_address
+
+    with pytest.warns(FutureWarning, match="ENSIP-15"):
+        await async_ens.resolver("tester.eth")  # test resolver
+
+    with patch("ens.utils.normalize_name_ensip15") as mock_normalize_name_ensip15:
+        assert async_ens.ensip15_normalization is False
+
+        with pytest.warns(FutureWarning, match="ENSIP-15"):
+            await method(*args)  # test parametrized method
+            mock_normalize_name_ensip15.assert_not_called()
+
+    # -- with ensip15_normalization enabled -- #
+    async_ens.ensip15_normalization = True
+    with warnings.catch_warnings():
+        # raise if FutureWarning is issued
+        warnings.simplefilter("error", category=FutureWarning)
+
+        await async_ens.setup_address("tester.eth", address)  # test setup_address
+        await async_ens.resolver("tester.eth")  # test resolver
+
+        with patch("ens.utils.normalize_name_ensip15") as mock_normalize_name_ensip15:
+            mock_normalize_name_ensip15.return_value = ENSIP15_NORMALIZED_TESTER_DOT_ETH
+
+            await method(*args)  # test parametrized method
+            mock_normalize_name_ensip15.assert_called_with("tester.eth")
+
+    # cleanup
+    await async_ens.setup_address("tester.eth", None)
+    async_ens.ensip15_normalization = False

--- a/tests/ens/test_utils.py
+++ b/tests/ens/test_utils.py
@@ -172,6 +172,7 @@ def test_normal_name_to_hash(name, hashed):
         raw_name_to_hash,
     ),
 )
+@pytest.mark.ensip15  # remove once ENSIP-15 is default
 def test_name_utility_methods_with_ensip15_flag(utility_method):
     # we already have tests for `normalize_name_ensip15` so we just need to make sure
     # that the flag is passed through to that function
@@ -190,6 +191,7 @@ def test_name_utility_methods_with_ensip15_flag(utility_method):
         normalize_name_ensip15_mock.assert_called_once_with(name)
 
 
+@pytest.mark.ensip15  # remove once ENSIP-15 is default
 def test_label_to_hash_with_ensip15_flag():
     # we already have tests for `normalize_name_ensip15` so we just need to make sure
     # that the flag is passed through to that function

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ install_command=python -m pip install {opts} {packages}
 usedevelop=True
 commands=
     core: pytest {posargs:tests/core}
-    ens: pytest {posargs:tests/ens -k "not ensip15"}
+    ens: pytest {posargs:tests/ens --ignore=tests/ens/normalization/test_normalize_name_ensip15.py}
     ensip15: pytest {posargs:tests/ens/normalization/test_normalize_name_ensip15.py -q}
     ethpm: pytest {posargs:tests/ethpm}
     integration-goethereum-ipc: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ipc.py}


### PR DESCRIPTION
### What was wrong?

- Add tests for `ensip15` flags and document ENSIP-15 use before the next release with this feature

Related to, and adds to, PR #3000 

### How was it fixed?

- [x] Add tests for `ensip15` flag for ens utils methods
- [x] Add tests for `ensip15_normalization` setting on BaseENS (ENS, AsyncENS), tracing through internal methods
- [x] Add documentation for ENSIP-15 and how best to use it with web3.py
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20230625_164125](https://github.com/ethereum/web3.py/assets/3532824/85b98660-4550-4d69-a9e3-765ec0ff97b5)
