### PR TITLE
add async_http_retry_request_middleware, add tests for async_http_ret…

### DIFF
--- a/tests/core/middleware/test_http_request_retry.py
+++ b/tests/core/middleware/test_http_request_retry.py
@@ -54,7 +54,7 @@ def test_check_if_retry_on_failure_true():
 
 @patch("web3.providers.rpc.make_post_request", side_effect=ConnectionError)
 def test_check_send_transaction_called_once(
-        make_post_request_mock, exception_retry_request_setup
+    make_post_request_mock, exception_retry_request_setup
 ):
     method = "eth_sendTransaction"
     params = [
@@ -122,7 +122,7 @@ async def async_exception_retry_request_setup():
 @pytest.mark.asyncio
 async def test_check_retry_middleware():
     with patch(
-            "web3.providers.async_rpc.async_make_post_request"
+        "web3.providers.async_rpc.async_make_post_request"
     ) as make_post_request_mock:
         make_post_request_mock.side_effect = TimeoutError
 
@@ -138,7 +138,7 @@ async def test_check_retry_middleware():
 @pytest.mark.asyncio
 async def test_check_without_retry_middleware():
     with patch(
-            "web3.providers.async_rpc.async_make_post_request"
+        "web3.providers.async_rpc.async_make_post_request"
     ) as make_post_request_mock:
         make_post_request_mock.side_effect = TimeoutError
         provider = AsyncHTTPProvider()

--- a/tests/core/middleware/test_http_request_retry.py
+++ b/tests/core/middleware/test_http_request_retry.py
@@ -1,10 +1,10 @@
-import aiohttp
 import pytest
 from unittest.mock import (
     Mock,
     patch,
 )
 
+import aiohttp
 from requests.exceptions import (
     ConnectionError,
     HTTPError,
@@ -13,7 +13,10 @@ from requests.exceptions import (
 )
 
 import web3
-from web3 import AsyncHTTPProvider, AsyncWeb3
+from web3 import (
+    AsyncHTTPProvider,
+    AsyncWeb3,
+)
 from web3.middleware.exception_retry_request import (
     async_exception_retry_middleware,
     async_http_retry_request_middleware,
@@ -54,7 +57,7 @@ def test_check_if_retry_on_failure_true():
 
 @patch("web3.providers.rpc.make_post_request", side_effect=ConnectionError)
 def test_check_send_transaction_called_once(
-    make_post_request_mock, exception_retry_request_setup
+        make_post_request_mock, exception_retry_request_setup
 ):
     method = "eth_sendTransaction"
     params = [
@@ -122,7 +125,7 @@ async def async_exception_retry_request_setup():
 @pytest.mark.asyncio
 async def test_check_retry_middleware():
     with patch(
-        "web3.providers.async_rpc.async_make_post_request"
+            "web3.providers.async_rpc.async_make_post_request"
     ) as make_post_request_mock:
         make_post_request_mock.side_effect = TimeoutError
 
@@ -138,7 +141,7 @@ async def test_check_retry_middleware():
 @pytest.mark.asyncio
 async def test_check_without_retry_middleware():
     with patch(
-        "web3.providers.async_rpc.async_make_post_request"
+            "web3.providers.async_rpc.async_make_post_request"
     ) as make_post_request_mock:
         make_post_request_mock.side_effect = TimeoutError
         provider = AsyncHTTPProvider()

--- a/tests/core/middleware/test_http_request_retry.py
+++ b/tests/core/middleware/test_http_request_retry.py
@@ -120,22 +120,6 @@ async def async_exception_retry_request_setup():
 
 
 @pytest.mark.asyncio
-async def test_valid_method_retried(
-        async_exception_retry_request_setup,
-):
-    with patch(
-            "web3.providers.async_rpc.async_make_post_request"
-    ) as make_post_request_mock:
-        make_post_request_mock.side_effect = TimeoutError
-        method = "eth_getBalance"
-        params = []
-
-        with pytest.raises(TimeoutError):
-            await exception_retry_request_setup(method, params)
-        assert make_post_request_mock.call_count == 5
-
-
-@pytest.mark.asyncio
 async def test_check_retry_middleware():
     with patch(
             "web3.providers.async_rpc.async_make_post_request"

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -41,6 +41,7 @@ from .exception_handling import (  # noqa: F401
     construct_exception_handler_middleware,
 )
 from .exception_retry_request import (  # noqa: F401
+    async_http_retry_request_middleware,
     http_retry_request_middleware,
 )
 from .filter import (  # noqa: F401

--- a/web3/middleware/exception_retry_request.py
+++ b/web3/middleware/exception_retry_request.py
@@ -21,7 +21,10 @@ from web3.types import (
 )
 
 if TYPE_CHECKING:
-    from web3 import Web3  # noqa: F401
+    from web3 import (  # noqa: F401
+        AsyncWeb3,
+        Web3,
+    )
 
 whitelist = [
     "admin",

--- a/web3/middleware/exception_retry_request.py
+++ b/web3/middleware/exception_retry_request.py
@@ -4,8 +4,8 @@ from typing import (
     Any,
     Callable,
     Collection,
-    Type,
     Coroutine,
+    Type,
 )
 
 import aiohttp

--- a/web3/middleware/exception_retry_request.py
+++ b/web3/middleware/exception_retry_request.py
@@ -4,7 +4,8 @@ from typing import (
     Any,
     Callable,
     Collection,
-    Type, Coroutine,
+    Type,
+    Coroutine,
 )
 
 import aiohttp
@@ -95,10 +96,10 @@ def check_if_retry_on_failure(method: RPCEndpoint) -> bool:
 
 
 def exception_retry_middleware(
-        make_request: Callable[[RPCEndpoint, Any], RPCResponse],
-        w3: "Web3",
-        errors: Collection[Type[BaseException]],
-        retries: int = 5,
+    make_request: Callable[[RPCEndpoint, Any], RPCResponse],
+    w3: "Web3",
+    errors: Collection[Type[BaseException]],
+    retries: int = 5,
 ) -> Callable[[RPCEndpoint, Any], RPCResponse]:
     """
     Creates middleware that retries failed HTTP requests. Is a default
@@ -124,7 +125,7 @@ def exception_retry_middleware(
 
 
 def http_retry_request_middleware(
-        make_request: Callable[[RPCEndpoint, Any], Any], w3: "Web3"
+    make_request: Callable[[RPCEndpoint, Any], Any], w3: "Web3"
 ) -> Callable[[RPCEndpoint, Any], Any]:
     return exception_retry_middleware(
         make_request, w3, (ConnectionError, HTTPError, Timeout, TooManyRedirects)
@@ -132,11 +133,11 @@ def http_retry_request_middleware(
 
 
 async def async_exception_retry_middleware(
-        make_request: Callable[[RPCEndpoint, Any], Any],
-        w3: "AsyncWeb3",
-        errors: Collection[Type[BaseException]],
-        retries: int = 5,
-        backoff_factor: float = 0.3,
+    make_request: Callable[[RPCEndpoint, Any], Any],
+    w3: "AsyncWeb3",
+    errors: Collection[Type[BaseException]],
+    retries: int = 5,
+    backoff_factor: float = 0.3,
 ) -> Callable[[RPCEndpoint, Any], Coroutine[Any, Any, RPCResponse]]:
     """
     Creates middleware that retries failed HTTP requests.
@@ -166,7 +167,7 @@ async def async_exception_retry_middleware(
 
 
 async def async_http_retry_request_middleware(
-        make_request: Callable[[RPCEndpoint, Any], Any], w3: "AsyncWeb3"
+    make_request: Callable[[RPCEndpoint, Any], Any], w3: "AsyncWeb3"
 ) -> Callable[[RPCEndpoint, Any], Any]:
     return await async_exception_retry_middleware(
         make_request,

--- a/web3/middleware/exception_retry_request.py
+++ b/web3/middleware/exception_retry_request.py
@@ -1,11 +1,13 @@
+import asyncio
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
     Collection,
-    Type,
+    Type, Coroutine,
 )
 
+import aiohttp
 from requests.exceptions import (
     ConnectionError,
     HTTPError,
@@ -90,10 +92,10 @@ def check_if_retry_on_failure(method: RPCEndpoint) -> bool:
 
 
 def exception_retry_middleware(
-    make_request: Callable[[RPCEndpoint, Any], RPCResponse],
-    w3: "Web3",
-    errors: Collection[Type[BaseException]],
-    retries: int = 5,
+        make_request: Callable[[RPCEndpoint, Any], RPCResponse],
+        w3: "Web3",
+        errors: Collection[Type[BaseException]],
+        retries: int = 5,
 ) -> Callable[[RPCEndpoint, Any], RPCResponse]:
     """
     Creates middleware that retries failed HTTP requests. Is a default
@@ -119,8 +121,58 @@ def exception_retry_middleware(
 
 
 def http_retry_request_middleware(
-    make_request: Callable[[RPCEndpoint, Any], Any], w3: "Web3"
+        make_request: Callable[[RPCEndpoint, Any], Any], w3: "Web3"
 ) -> Callable[[RPCEndpoint, Any], Any]:
     return exception_retry_middleware(
         make_request, w3, (ConnectionError, HTTPError, Timeout, TooManyRedirects)
+    )
+
+
+async def async_exception_retry_middleware(
+        make_request: Callable[[RPCEndpoint, Any], Any],
+        w3: "AsyncWeb3",
+        errors: Collection[Type[BaseException]],
+        retries: int = 5,
+        backoff_factor: float = 0.3,
+) -> Callable[[RPCEndpoint, Any], Coroutine[Any, Any, RPCResponse]]:
+    """
+    Creates middleware that retries failed HTTP requests.
+    Is a middleware for AsyncHTTPProvider.
+    """
+
+    async def middleware(method, params):
+        if check_if_retry_on_failure(method):
+            for i in range(retries):
+                try:
+                    return await make_request(method, params)
+                except Exception as e:
+                    is_exc_valid = any([isinstance(e, exc) for exc in errors])
+                    if not is_exc_valid:
+                        raise e
+
+                    if i < retries - 1:
+                        await asyncio.sleep(backoff_factor)
+                        continue
+                    else:
+                        raise
+            return None
+        else:
+            return await make_request(method, params)
+
+    return middleware
+
+
+async def async_http_retry_request_middleware(
+        make_request: Callable[[RPCEndpoint, Any], Any], w3: "AsyncWeb3"
+) -> Callable[[RPCEndpoint, Any], Any]:
+    return await async_exception_retry_middleware(
+        make_request,
+        w3,
+        (
+            TimeoutError,
+            aiohttp.ClientConnectionError,
+            aiohttp.ClientConnectorError,
+            aiohttp.ClientHttpProxyError,
+            aiohttp.ClientTimeout,
+        ),
     )


### PR DESCRIPTION
there was no method for http_retry_request_middleware for AsyncWeb3

### What was wrong?

Related to Issue #3003 

### How was it fixed?
add async_http_retry_request_middleware, add tests for async_http_ret…

### Todo:
- [ ]
