### PR TITLE
add async_http_retry_request_middleware, add tests for async_http_ret…

### DIFF
--- a/tests/core/middleware/test_http_request_retry.py
+++ b/tests/core/middleware/test_http_request_retry.py
@@ -4,6 +4,7 @@ from unittest.mock import (
     patch,
 )
 
+import aiohttp
 from requests.exceptions import (
     ConnectionError,
     HTTPError,
@@ -12,7 +13,13 @@ from requests.exceptions import (
 )
 
 import web3
+from web3 import (
+    AsyncHTTPProvider,
+    AsyncWeb3,
+)
 from web3.middleware.exception_retry_request import (
+    async_exception_retry_middleware,
+    async_http_retry_request_middleware,
     check_if_retry_on_failure,
     exception_retry_middleware,
 )
@@ -90,3 +97,56 @@ def test_check_with_all_middlewares(make_post_request_mock):
     with pytest.raises(ConnectionError):
         w3.eth.block_number
     assert make_post_request_mock.call_count == 5
+
+
+# -- async -- #
+
+
+@pytest.fixture
+async def async_exception_retry_request_setup():
+    w3 = Mock()
+    provider = AsyncHTTPProvider()
+    setup = await async_exception_retry_middleware(
+        provider.make_request,
+        w3,
+        (
+            TimeoutError,
+            aiohttp.ClientConnectionError,
+            aiohttp.ClientConnectorError,
+            aiohttp.ClientHttpProxyError,
+            aiohttp.ClientTimeout,
+        ),
+        5,
+    )
+    setup.w3 = w3
+    return setup
+
+
+@pytest.mark.asyncio
+async def test_check_retry_middleware():
+    with patch(
+        "web3.providers.async_rpc.async_make_post_request"
+    ) as make_post_request_mock:
+        make_post_request_mock.side_effect = TimeoutError
+
+        provider = AsyncHTTPProvider()
+        w3 = AsyncWeb3(provider)
+        w3.middleware_onion.add(async_http_retry_request_middleware)
+
+        with pytest.raises(TimeoutError):
+            await w3.eth.block_number
+        assert make_post_request_mock.call_count == 5
+
+
+@pytest.mark.asyncio
+async def test_check_without_retry_middleware():
+    with patch(
+        "web3.providers.async_rpc.async_make_post_request"
+    ) as make_post_request_mock:
+        make_post_request_mock.side_effect = TimeoutError
+        provider = AsyncHTTPProvider()
+        w3 = AsyncWeb3(provider)
+
+        with pytest.raises(TimeoutError):
+            await w3.eth.block_number
+        assert make_post_request_mock.call_count == 1

--- a/web3/middleware/exception_retry_request.py
+++ b/web3/middleware/exception_retry_request.py
@@ -16,8 +16,9 @@ from requests.exceptions import (
 )
 
 from web3.types import (
+    AsyncMiddlewareCoroutine,
     RPCEndpoint,
-    RPCResponse, AsyncMiddlewareCoroutine,
+    RPCResponse,
 )
 
 if TYPE_CHECKING:

--- a/web3/middleware/exception_retry_request.py
+++ b/web3/middleware/exception_retry_request.py
@@ -1,11 +1,14 @@
+import asyncio
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
     Collection,
+    Coroutine,
     Type,
 )
 
+import aiohttp
 from requests.exceptions import (
     ConnectionError,
     HTTPError,
@@ -19,7 +22,10 @@ from web3.types import (
 )
 
 if TYPE_CHECKING:
-    from web3 import Web3  # noqa: F401
+    from web3 import (  # noqa: F401
+        AsyncWeb3,
+        Web3,
+    )
 
 whitelist = [
     "admin",
@@ -123,4 +129,54 @@ def http_retry_request_middleware(
 ) -> Callable[[RPCEndpoint, Any], Any]:
     return exception_retry_middleware(
         make_request, w3, (ConnectionError, HTTPError, Timeout, TooManyRedirects)
+    )
+
+
+async def async_exception_retry_middleware(
+    make_request: Callable[[RPCEndpoint, Any], Any],
+    w3: "AsyncWeb3",
+    errors: Collection[Type[BaseException]],
+    retries: int = 5,
+    backoff_factor: float = 0.3,
+) -> Callable[[RPCEndpoint, Any], Coroutine[Any, Any, RPCResponse]]:
+    """
+    Creates middleware that retries failed HTTP requests.
+    Is a middleware for AsyncHTTPProvider.
+    """
+
+    async def middleware(method, params):
+        if check_if_retry_on_failure(method):
+            for i in range(retries):
+                try:
+                    return await make_request(method, params)
+                except Exception as e:
+                    is_exc_valid = any([isinstance(e, exc) for exc in errors])
+                    if not is_exc_valid:
+                        raise e
+
+                    if i < retries - 1:
+                        await asyncio.sleep(backoff_factor)
+                        continue
+                    else:
+                        raise
+            return None
+        else:
+            return await make_request(method, params)
+
+    return middleware
+
+
+async def async_http_retry_request_middleware(
+    make_request: Callable[[RPCEndpoint, Any], Any], w3: "AsyncWeb3"
+) -> Callable[[RPCEndpoint, Any], Any]:
+    return await async_exception_retry_middleware(
+        make_request,
+        w3,
+        (
+            TimeoutError,
+            aiohttp.ClientConnectionError,
+            aiohttp.ClientConnectorError,
+            aiohttp.ClientHttpProxyError,
+            aiohttp.ClientTimeout,
+        ),
     )

--- a/web3/middleware/exception_retry_request.py
+++ b/web3/middleware/exception_retry_request.py
@@ -138,13 +138,12 @@ async def async_exception_retry_middleware(
     errors: Collection[Type[BaseException]],
     retries: int = 5,
     backoff_factor: float = 0.3,
-) -> Callable[[RPCEndpoint, Any], Coroutine[Any, Any, RPCResponse]]:
+) -> Callable[[RPCEndpoint, Any], Coroutine[RPCResponse]]:
     """
     Creates middleware that retries failed HTTP requests.
     Is a middleware for AsyncHTTPProvider.
     """
-
-    async def middleware(method, params):
+    async def middleware(method: RPCEndpoint, params: Any) -> Coroutine[RPCResponse]:
         if check_if_retry_on_failure(method):
             for i in range(retries):
                 try:

--- a/web3/middleware/exception_retry_request.py
+++ b/web3/middleware/exception_retry_request.py
@@ -143,6 +143,7 @@ async def async_exception_retry_middleware(
     Creates middleware that retries failed HTTP requests.
     Is a middleware for AsyncHTTPProvider.
     """
+
     async def middleware(method: RPCEndpoint, params: Any) -> RPCResponse:
         if check_if_retry_on_failure(method):
             for i in range(retries):

--- a/web3/middleware/exception_retry_request.py
+++ b/web3/middleware/exception_retry_request.py
@@ -4,7 +4,6 @@ from typing import (
     Any,
     Callable,
     Collection,
-    Coroutine,
     Type,
 )
 

--- a/web3/middleware/exception_retry_request.py
+++ b/web3/middleware/exception_retry_request.py
@@ -18,7 +18,7 @@ from requests.exceptions import (
 
 from web3.types import (
     RPCEndpoint,
-    RPCResponse,
+    RPCResponse, AsyncMiddlewareCoroutine,
 )
 
 if TYPE_CHECKING:
@@ -138,12 +138,12 @@ async def async_exception_retry_middleware(
     errors: Collection[Type[BaseException]],
     retries: int = 5,
     backoff_factor: float = 0.3,
-) -> Callable[[RPCEndpoint, Any], Coroutine[RPCResponse]]:
+) -> AsyncMiddlewareCoroutine:
     """
     Creates middleware that retries failed HTTP requests.
     Is a middleware for AsyncHTTPProvider.
     """
-    async def middleware(method: RPCEndpoint, params: Any) -> Coroutine[RPCResponse]:
+    async def middleware(method: RPCEndpoint, params: Any) -> RPCResponse:
         if check_if_retry_on_failure(method):
             for i in range(retries):
                 try:


### PR DESCRIPTION
there was no method for http_retry_request_middleware for AsyncWeb3

What was wrong?
Related to Issue https://github.com/ethereum/web3.py/issues/3003

How was it fixed?
add async_http_retry_request_middleware, add tests for async_http_ret…

Todo:
[ ]