### PR TITLE
add async_http_retry_request_middleware, add tests for async_http_ret…

### DIFF
--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -106,6 +106,7 @@ HTTPRequestRetry
 ~~~~~~~~~~~~~~~~~~
 
 .. py:method:: web3.middleware.http_retry_request_middleware
+               web3.middleware.async_http_retry_request_middleware
 
     This middleware is a default specifically for HTTPProvider that retries failed
     requests that return the following errors: ``ConnectionError``, ``HTTPError``, ``Timeout``,

--- a/newsfragments/3009.feature.rst
+++ b/newsfragments/3009.feature.rst
@@ -1,0 +1,1 @@
+ ``async_http_retry_request_middleware``, an async http request retry middleware for ``AsyncHTTPProvider``.

--- a/tests/core/middleware/test_http_request_retry.py
+++ b/tests/core/middleware/test_http_request_retry.py
@@ -1,10 +1,12 @@
 import pytest
 from unittest.mock import (
+    AsyncMock,
     Mock,
     patch,
 )
 
 import aiohttp
+import pytest_asyncio
 from requests.exceptions import (
     ConnectionError,
     HTTPError,
@@ -19,7 +21,6 @@ from web3 import (
 )
 from web3.middleware.exception_retry_request import (
     async_exception_retry_middleware,
-    async_http_retry_request_middleware,
     check_if_retry_on_failure,
     exception_retry_middleware,
 )
@@ -102,40 +103,45 @@ def test_check_with_all_middlewares(make_post_request_mock):
 # -- async -- #
 
 
-@pytest.fixture
+ASYNC_TEST_RETRY_COUNT = 3
+
+
+@pytest_asyncio.fixture
 async def async_exception_retry_request_setup():
-    w3 = Mock()
+    w3 = AsyncMock()
     provider = AsyncHTTPProvider()
     setup = await async_exception_retry_middleware(
         provider.make_request,
         w3,
-        (
-            TimeoutError,
-            aiohttp.ClientConnectionError,
-            aiohttp.ClientConnectorError,
-            aiohttp.ClientHttpProxyError,
-            aiohttp.ClientTimeout,
-        ),
-        5,
+        (TimeoutError, aiohttp.ClientError),
+        ASYNC_TEST_RETRY_COUNT,
+        0.1,
     )
     setup.w3 = w3
     return setup
 
 
 @pytest.mark.asyncio
-async def test_check_retry_middleware():
+@pytest.mark.parametrize(
+    "error",
+    (
+        TimeoutError,
+        aiohttp.ClientError,  # general base class for all aiohttp errors
+        # ClientError subclasses
+        aiohttp.ClientConnectionError,
+        aiohttp.ServerTimeoutError,
+        aiohttp.ClientOSError,
+    ),
+)
+async def test_check_retry_middleware(error, async_exception_retry_request_setup):
     with patch(
         "web3.providers.async_rpc.async_make_post_request"
     ) as make_post_request_mock:
-        make_post_request_mock.side_effect = TimeoutError
+        make_post_request_mock.side_effect = error
 
-        provider = AsyncHTTPProvider()
-        w3 = AsyncWeb3(provider)
-        w3.middleware_onion.add(async_http_retry_request_middleware)
-
-        with pytest.raises(TimeoutError):
-            await w3.eth.block_number
-        assert make_post_request_mock.call_count == 5
+        with pytest.raises(error):
+            await async_exception_retry_request_setup("eth_getBalance", [])
+        assert make_post_request_mock.call_count == ASYNC_TEST_RETRY_COUNT
 
 
 @pytest.mark.asyncio

--- a/tests/core/middleware/test_http_request_retry.py
+++ b/tests/core/middleware/test_http_request_retry.py
@@ -1,6 +1,5 @@
 import pytest
 from unittest.mock import (
-    AsyncMock,
     Mock,
     patch,
 )
@@ -108,7 +107,7 @@ ASYNC_TEST_RETRY_COUNT = 3
 
 @pytest_asyncio.fixture
 async def async_exception_retry_request_setup():
-    w3 = AsyncMock()
+    w3 = Mock()
     provider = AsyncHTTPProvider()
     setup = await async_exception_retry_middleware(
         provider.make_request,
@@ -152,6 +151,7 @@ async def test_check_without_retry_middleware():
         make_post_request_mock.side_effect = TimeoutError
         provider = AsyncHTTPProvider()
         w3 = AsyncWeb3(provider)
+        w3.provider._middlewares = ()
 
         with pytest.raises(TimeoutError):
             await w3.eth.block_number

--- a/tests/core/middleware/test_http_request_retry.py
+++ b/tests/core/middleware/test_http_request_retry.py
@@ -4,6 +4,7 @@ from unittest.mock import (
     patch,
 )
 
+import aiohttp
 from requests.exceptions import (
     ConnectionError,
     HTTPError,
@@ -12,7 +13,13 @@ from requests.exceptions import (
 )
 
 import web3
+from web3 import (
+    AsyncHTTPProvider,
+    AsyncWeb3,
+)
 from web3.middleware.exception_retry_request import (
+    async_exception_retry_middleware,
+    async_http_retry_request_middleware,
     check_if_retry_on_failure,
     exception_retry_middleware,
 )
@@ -90,3 +97,56 @@ def test_check_with_all_middlewares(make_post_request_mock):
     with pytest.raises(ConnectionError):
         w3.eth.block_number
     assert make_post_request_mock.call_count == 5
+
+
+# -- async -- #
+
+
+@pytest.fixture
+async def async_exception_retry_request_setup():
+    w3 = Mock()
+    provider = AsyncHTTPProvider()
+    setup = await async_exception_retry_middleware(
+        provider.make_request,
+        w3,
+        (
+            TimeoutError,
+            aiohttp.ClientConnectionError,
+            aiohttp.ClientConnectorError,
+            aiohttp.ClientHttpProxyError,
+            aiohttp.ClientTimeout,
+        ),
+        5,
+    )
+    setup.w3 = w3
+    return setup
+
+
+@pytest.mark.asyncio
+async def test_check_retry_middleware():
+    with patch(
+        "web3.providers.async_rpc.async_make_post_request"
+    ) as make_post_request_mock:
+        make_post_request_mock.side_effect = TimeoutError
+
+        provider = AsyncHTTPProvider()
+        w3 = AsyncWeb3(provider)
+        w3.middleware_onion.add(async_http_retry_request_middleware)
+
+        with pytest.raises(TimeoutError):
+            await w3.eth.block_number
+        assert make_post_request_mock.call_count == 5
+
+
+@pytest.mark.asyncio
+async def test_check_without_retry_middleware():
+    with patch(
+        "web3.providers.async_rpc.async_make_post_request"
+    ) as make_post_request_mock:
+        make_post_request_mock.side_effect = TimeoutError
+        provider = AsyncHTTPProvider()
+        w3 = AsyncWeb3(provider)
+
+        with pytest.raises(TimeoutError):
+            await w3.eth.block_number
+        assert make_post_request_mock.call_count == 1

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -41,6 +41,7 @@ from .exception_handling import (  # noqa: F401
     construct_exception_handler_middleware,
 )
 from .exception_retry_request import (  # noqa: F401
+    async_http_retry_request_middleware,
     http_retry_request_middleware,
 )
 from .filter import (  # noqa: F401

--- a/web3/middleware/exception_retry_request.py
+++ b/web3/middleware/exception_retry_request.py
@@ -141,7 +141,7 @@ async def async_exception_retry_middleware(
 ) -> AsyncMiddlewareCoroutine:
     """
     Creates middleware that retries failed HTTP requests.
-    Is a middleware for AsyncHTTPProvider.
+    Is a default middleware for AsyncHTTPProvider.
     """
 
     async def middleware(method: RPCEndpoint, params: Any) -> Optional[RPCResponse]:

--- a/web3/providers/async_rpc.py
+++ b/web3/providers/async_rpc.py
@@ -27,10 +27,17 @@ from web3._utils.request import (
     get_default_http_endpoint,
 )
 from web3.types import (
+    AsyncMiddleware,
     RPCEndpoint,
     RPCResponse,
 )
 
+from ..datastructures import (
+    NamedElementOnion,
+)
+from ..middleware.exception_retry_request import (
+    async_http_retry_request_middleware,
+)
 from .async_base import (
     AsyncJSONBaseProvider,
 )
@@ -40,6 +47,8 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
     logger = logging.getLogger("web3.providers.HTTPProvider")
     endpoint_uri = None
     _request_kwargs = None
+    # type ignored b/c conflict with _middlewares attr on AsyncBaseProvider
+    _middlewares: Tuple[AsyncMiddleware, ...] = NamedElementOnion([(async_http_retry_request_middleware, "http_retry_request")])  # type: ignore # noqa: E501
 
     def __init__(
         self,


### PR DESCRIPTION
there was no method for http_retry_request_middleware for AsyncWeb3

What was wrong?
closes #3003 

How was it fixed?
add async_http_retry_request_middleware, add tests for async_http_ret…

Todo:
- [x] Document async_http_retry_request_middleware
- [x] Add relevant newsfragments

![](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2F4.bp.blogspot.com%2F-kRzR25oOHS4%2FV9Bcm6tC7PI%2FAAAAAAAAQr4%2FtAcZ2FXjrusSHeyTjMQo8cEO-WiHUuR6QCLcB%2Fs1600%2FPangolin.jpg&f=1&nofb=1&ipt=6863178b6687355e559d4433f8c1e1e89278331478041335e57aa337bb5ac79a&ipo=images)