### PR TITLE
Async name to address new approach

### DIFF
--- a/docs/abi_types.rst
+++ b/docs/abi_types.rst
@@ -20,10 +20,11 @@ Ethereum Addresses
 
 All addresses must be supplied in one of three ways:
 
-* While connected to mainnet, an Ethereum Name Service name (often in the form ``myname.eth``)
 * A 20-byte hexadecimal that is checksummed using the `EIP-55
   <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md>`_ spec.
-* A 20-byte binary address.
+* A 20-byte binary address (python bytes type).
+* While connected to an Ethereum Name Service (ENS) supported chain, an ENS name
+  (often in the form ``myname.eth``).
 
 Disabling Strict Bytes Type Checking
 ------------------------------------

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -40,6 +40,7 @@ Sync middlewares include:
 Async middlewares include:
 
 * ``gas_price_strategy``
+* ``name_to_address``
 * ``attrdict``
 * ``validation``
 * ``gas_estimate``
@@ -66,6 +67,7 @@ AttributeDict
 ~~~~~~~~~~~~~~~~~~~~~
 
 .. py:method:: web3.middleware.name_to_address_middleware
+               web3.middleware.async_name_to_address_middleware
 
     This middleware converts Ethereum Name Service (ENS) names into the
     address that the name points to. For example :meth:`w3.eth.send_transaction <web3.eth.Eth.send_transaction>` will

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -72,9 +72,9 @@ AttributeDict
     accept .eth names in the 'from' and 'to' fields.
 
     .. note::
-        This middleware only converts ENS names if invoked with the mainnet
-        (where the ENS contract is deployed), for all other cases will result in an
-        ``InvalidAddress`` error
+        This middleware only converts ENS names on chains where the proper ENS
+        contracts are deployed to support this functionality. All other cases will
+        result in a ``NameNotFound`` error.
 
 Gas Price Strategy
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/newsfragments/3012.docs.rst
+++ b/newsfragments/3012.docs.rst
@@ -1,0 +1,1 @@
+Update documentation relating to ENS only being available on mainnet. ENS is available on all networks where the ENS contracts are deployed.

--- a/newsfragments/3012.feature.rst
+++ b/newsfragments/3012.feature.rst
@@ -1,0 +1,1 @@
+Add async support for ENS name-to-address resolution via ``async_name_to_address_middleware``.

--- a/tests/core/manager/test_default_middlewares.py
+++ b/tests/core/manager/test_default_middlewares.py
@@ -6,6 +6,7 @@ from web3.middleware import (
     async_attrdict_middleware,
     async_buffered_gas_estimate_middleware,
     async_gas_price_strategy_middleware,
+    async_name_to_address_middleware,
     async_validation_middleware,
     attrdict_middleware,
     buffered_gas_estimate_middleware,
@@ -15,7 +16,7 @@ from web3.middleware import (
 )
 
 
-def test_default_sync_middlwares(w3):
+def test_default_sync_middlewares(w3):
     expected_middlewares = [
         (gas_price_strategy_middleware, "gas_price_strategy"),
         (name_to_address_middleware(w3), "name_to_address"),
@@ -32,9 +33,10 @@ def test_default_sync_middlwares(w3):
         assert default_middlewares[x][1] == expected_middlewares[x][1]
 
 
-def test_default_async_middlwares():
+def test_default_async_middlewares():
     expected_middlewares = [
         (async_gas_price_strategy_middleware, "gas_price_strategy"),
+        (async_name_to_address_middleware, "name_to_address"),
         (async_attrdict_middleware, "attrdict"),
         (async_validation_middleware, "validation"),
         (async_buffered_gas_estimate_middleware, "gas_estimate"),

--- a/tests/core/middleware/test_name_to_address_middleware.py
+++ b/tests/core/middleware/test_name_to_address_middleware.py
@@ -7,6 +7,7 @@ from web3 import (
     Web3,
 )
 from web3.exceptions import (
+    InvalidAddress,
     NameNotFound,
 )
 from web3.middleware import (
@@ -96,7 +97,7 @@ def test_pass_name_resolver_send_transaction_dict_args(
 
 
 def test_fail_name_resolver(w3):
-    with pytest.raises(NameNotFound, match=r".*ethereum\.eth.*"):
+    with pytest.raises(InvalidAddress, match=r".*ethereum\.eth.*"):
         w3.eth.get_balance("ethereum.eth")
 
 

--- a/tests/core/middleware/test_name_to_address_middleware.py
+++ b/tests/core/middleware/test_name_to_address_middleware.py
@@ -7,13 +7,14 @@ from web3 import (
     Web3,
 )
 from web3.exceptions import (
-    InvalidAddress,
+    NameNotFound,
 )
-from web3.middleware import (  # noqa: F401
-    construct_fixture_middleware,
+from web3.middleware import (
     name_to_address_middleware,
 )
-from web3.middleware.names import async_name_to_address_middleware
+from web3.middleware.names import (
+    async_name_to_address_middleware,
+)
 from web3.providers.eth_tester import (
     AsyncEthereumTesterProvider,
     EthereumTesterProvider,
@@ -49,24 +50,12 @@ def w3(_w3_setup, ens_mapped_address):
 
 
 def test_pass_name_resolver(w3, ens_mapped_address):
-    return_chain_on_mainnet = construct_fixture_middleware(
-        {
-            "net_version": "1",
-        }
-    )
     known_account_balance = w3.eth.get_balance(ens_mapped_address)
-    w3.middleware_onion.inject(return_chain_on_mainnet, layer=0)
     assert w3.eth.get_balance(NAME) == known_account_balance
 
 
 def test_fail_name_resolver(w3):
-    return_chain_on_mainnet = construct_fixture_middleware(
-        {
-            "net_version": "2",
-        }
-    )
-    w3.middleware_onion.inject(return_chain_on_mainnet, layer=0)
-    with pytest.raises(InvalidAddress, match=r".*ethereum\.eth.*"):
+    with pytest.raises(NameNotFound, match=r".*ethereum\.eth.*"):
         w3.eth.get_balance("ethereum.eth")
 
 
@@ -104,5 +93,5 @@ async def test_async_pass_name_resolver(async_w3, async_ens_mapped_address):
 
 @pytest.mark.asyncio
 async def test_async_fail_name_resolver(async_w3):
-    with pytest.raises(InvalidAddress, match=r".*ethereum\.eth.*"):
+    with pytest.raises(NameNotFound, match=r".*ethereum\.eth.*"):
         await async_w3.eth.get_balance("ethereum.eth")

--- a/tests/core/providers/test_async_http_provider.py
+++ b/tests/core/providers/test_async_http_provider.py
@@ -26,6 +26,7 @@ from web3.middleware import (
     async_attrdict_middleware,
     async_buffered_gas_estimate_middleware,
     async_gas_price_strategy_middleware,
+    async_name_to_address_middleware,
     async_validation_middleware,
 )
 from web3.net import (
@@ -81,11 +82,15 @@ def test_web3_with_async_http_provider_has_default_middlewares_and_modules() -> 
 
     # the following length check should fail and will need to be added to once more
     # async middlewares are added to the defaults
-    assert len(async_w3.middleware_onion.middlewares) == 4
+    assert len(async_w3.middleware_onion.middlewares) == 5
 
     assert (
         async_w3.middleware_onion.get("gas_price_strategy")
         == async_gas_price_strategy_middleware
+    )
+    assert (
+        async_w3.middleware_onion.get("name_to_address")
+        == async_name_to_address_middleware
     )
     assert async_w3.middleware_onion.get("attrdict") == async_attrdict_middleware
     assert async_w3.middleware_onion.get("validation") == async_validation_middleware

--- a/web3/_utils/ens.py
+++ b/web3/_utils/ens.py
@@ -90,3 +90,15 @@ def contract_ens_addresses(
     """
     with ens_addresses(contract.w3, name_addr_pairs):
         yield
+
+
+# --- async --- #
+
+
+async def async_validate_name_has_address(
+    async_ens: AsyncENS, name: str
+) -> ChecksumAddress:
+    addr = await async_ens.address(name)
+    if not addr:
+        raise NameNotFound(f"Could not find address for name {name!r}")
+    return addr

--- a/web3/_utils/normalizers.py
+++ b/web3/_utils/normalizers.py
@@ -218,15 +218,9 @@ def abi_ens_resolver(
             )
 
         _ens = cast(ENS, w3.ens)
-        net_version = int(w3.net.version) if hasattr(w3, "net") else None
         if _ens is None:
             raise InvalidAddress(
                 f"Could not look up name {val!r} because ENS is" " set to None"
-            )
-        elif net_version != 1 and not isinstance(_ens, StaticENS):
-            raise InvalidAddress(
-                f"Could not look up name {val!r} because web3 is"
-                " not connected to mainnet"
             )
         else:
             return type_str, validate_name_has_address(_ens, val)

--- a/web3/_utils/rpc_abi.py
+++ b/web3/_utils/rpc_abi.py
@@ -5,6 +5,7 @@ from typing import (
     Iterable,
     Sequence,
     Tuple,
+    Union,
 )
 
 from eth_typing import (
@@ -185,7 +186,7 @@ TRACE_FILTER_PARAM_ABIS = {
     "count": "int",
 }
 
-RPC_ABIS = {
+RPC_ABIS: Dict[str, Union[Sequence[Any], Dict[str, str]]] = {
     # eth
     "eth_call": TRANSACTION_PARAMS_ABIS,
     "eth_estimateGas": TRANSACTION_PARAMS_ABIS,

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -30,6 +30,7 @@ from web3.middleware import (
     async_attrdict_middleware,
     async_buffered_gas_estimate_middleware,
     async_gas_price_strategy_middleware,
+    async_name_to_address_middleware,
     async_validation_middleware,
     attrdict_middleware,
     buffered_gas_estimate_middleware,
@@ -139,7 +140,7 @@ class RequestManager:
         """
         return [
             (gas_price_strategy_middleware, "gas_price_strategy"),
-            (name_to_address_middleware(w3), "name_to_address"),  # Add Async
+            (name_to_address_middleware(w3), "name_to_address"),
             (attrdict_middleware, "attrdict"),
             (validation_middleware, "validation"),
             (abi_middleware, "abi"),
@@ -154,6 +155,7 @@ class RequestManager:
         """
         return [
             (async_gas_price_strategy_middleware, "gas_price_strategy"),
+            (async_name_to_address_middleware, "name_to_address"),
             (async_attrdict_middleware, "attrdict"),
             (async_validation_middleware, "validation"),
             (async_buffered_gas_estimate_middleware, "gas_estimate"),

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -66,6 +66,7 @@ from .geth_poa import (  # noqa: F401
     geth_poa_middleware,
 )
 from .names import (  # noqa: F401
+    async_name_to_address_middleware,
     name_to_address_middleware,
 )
 from .normalize_request_parameters import (  # noqa: F401

--- a/web3/middleware/names.py
+++ b/web3/middleware/names.py
@@ -1,24 +1,38 @@
 from typing import (
     TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Sequence,
+    Union,
 )
 
 from web3._utils.normalizers import (
     abi_ens_resolver,
+    async_abi_ens_resolver,
 )
 from web3._utils.rpc_abi import (
     RPC_ABIS,
     abi_request_formatters,
 )
 from web3.types import (
+    AsyncMiddlewareCoroutine,
     Middleware,
+    RPCEndpoint,
 )
 
+from .._utils.abi import (
+    abi_data_tree,
+)
 from .formatting import (
     construct_formatting_middleware,
 )
 
 if TYPE_CHECKING:
-    from web3 import Web3  # noqa: F401
+    from web3 import (  # noqa: F401
+        AsyncWeb3,
+        Web3,
+    )
 
 
 def name_to_address_middleware(w3: "Web3") -> Middleware:
@@ -28,3 +42,68 @@ def name_to_address_middleware(w3: "Web3") -> Middleware:
     return construct_formatting_middleware(
         request_formatters=abi_request_formatters(normalizers, RPC_ABIS)
     )
+
+
+# -- async -- #
+
+
+async def async_apply_ens_to_address_conversion(
+    async_web3: "AsyncWeb3",
+    params: Any,
+    abi_types_for_method: Union[Sequence[str], Dict[str, str]],
+) -> Any:
+    if isinstance(abi_types_for_method, Sequence):
+        formatted_params = await async_format_all_ens_names_to_address(
+            async_web3, abi_types_for_method, params
+        )
+        return formatted_params
+
+    elif isinstance(abi_types_for_method, dict):
+        param_dict = params[0]
+        fields = list(abi_types_for_method.keys() & param_dict.keys())
+        formatted_params = await async_format_all_ens_names_to_address(
+            async_web3,
+            [abi_types_for_method[field] for field in fields],
+            [param_dict[field] for field in fields],
+        )
+        formatted_dict = dict(zip(fields, formatted_params))
+        return (formatted_dict,)
+    else:
+        raise TypeError(
+            f"ABI definitions must be a list or dictionary, "
+            f"got {abi_types_for_method!r}"
+        )
+
+
+async def async_format_all_ens_names_to_address(
+    async_web3: "AsyncWeb3",
+    abi_types_for_method: Sequence[Any],
+    abi_typed_data: Sequence[Any],
+) -> Sequence[Any]:
+    formatted_params = []
+    abi_typed_params = abi_data_tree(abi_types_for_method, abi_typed_data)
+    for param in abi_typed_params:
+        _abi_type, formatted_data = await async_abi_ens_resolver(
+            async_web3,
+            param.abi_type,
+            param.data,
+        )
+        formatted_params.append(formatted_data)
+    return formatted_params
+
+
+async def async_name_to_address_middleware(
+    make_request: Callable[[RPCEndpoint, Any], Any],
+    async_w3: "AsyncWeb3",
+) -> AsyncMiddlewareCoroutine:
+    async def middleware(method: RPCEndpoint, params: Any) -> Any:
+        abi_types_for_method = RPC_ABIS.get(method, None)
+        if abi_types_for_method is not None:
+            params = await async_apply_ens_to_address_conversion(
+                async_w3,
+                params,
+                abi_types_for_method,
+            )
+        return await make_request(method, params)
+
+    return middleware


### PR DESCRIPTION
### What was wrong?

ENS name to address needs async support

- closes #1990
- closes #2758
- closes #2583

### How was it fixed?

- Add async support for ENS name to address in a way that doesn't need to utilize functools as that was a messy approach for async (see #2758).
- Make tests more robust for both sync and async name to address middleware

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)
- [x] Update relevant documentation

#### Cute Animal Picture

![20230630_173246](https://github.com/ethereum/web3.py/assets/3532824/820d85e5-fa11-4355-a3c7-9b5071c5d5f8)
