### PR TITLE
change lib author to EF and update examples

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Piper Merriam
+Copyright (c) 2016 The Ethereum Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/code_of_conduct.rst
+++ b/docs/code_of_conduct.rst
@@ -61,7 +61,7 @@ Enforcement
 ~~~~~~~~~~~
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at piper@pipermerriam.com. All
+reported by contacting the project team at snakecharmers@ethereum.org. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -223,7 +223,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    ("index", "Populus.tex", "Populus Documentation", "Piper Merriam", "manual"),
+    ("index", "Populus.tex", "Populus Documentation", "The Ethereum Foundation", "manual"),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -251,7 +251,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [("index", "web3", "web3.py Documentation", ["Piper Merriam"], 1)]
+man_pages = [("index", "web3", "web3.py Documentation", ["The Ethereum Foundation"], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -267,7 +267,7 @@ texinfo_documents = [
         "index",
         "web3.py",
         "web3.py Documentation",
-        "Piper Merriam",
+        "The Ethereum Foundation",
         "web3.py",
         "Backend agnostic Ethereum client interactions.",
         "Miscellaneous",

--- a/docs/web3.geth.rst
+++ b/docs/web3.geth.rst
@@ -24,7 +24,7 @@ The ``web3.geth.admin`` object exposes methods to interact with the RPC APIs und
     .. code-block:: python
 
         >>> web3.geth.admin.datadir()
-        '/Users/piper/Library/Ethereum'
+        '/Users/snakecharmers/Library/Ethereum'
 
 
 .. py:method:: node_info()

--- a/newsfragments/3023.misc.rst
+++ b/newsfragments/3023.misc.rst
@@ -1,0 +1,1 @@
+Changed library author to ``The Ethereum Foundation``

--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,8 @@ setup(
     description="""web3.py""",
     long_description_content_type="text/markdown",
     long_description=long_description,
-    author="Piper Merriam",
-    author_email="pipermerriam@gmail.com",
+    author="The Ethereum Foundation",
+    author_email="snakecharmers@ethereum.org",
     url="https://github.com/ethereum/web3.py",
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
### What was wrong?

Author was Piper Merriam

### How was it fixed?

Set author to The Ethereum Foundation, standardizing with our other libs.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/49eaed25-7d17-4f73-88db-5f14c74d171d)
