### PR TITLE
Turn on ENSIP-15 by default

### DIFF
--- a/docs/ens_overview.rst
+++ b/docs/ens_overview.rst
@@ -12,10 +12,8 @@ domains and addresses, add resolver records, or get and set metadata.
 
 
 .. note:: ENSIP-15 introduced a new standard for ENS name normalization. This standard
-    is implemented in web3.py via the ``ensip15_normalization`` flag on the ``ENS`` /
-    ``AsyncENS`` class. It is also available as a flag on relevant ``ens.utils.py``
-    utility methods. For more information, refer to the :ref:`ensip15_normalization`
-    section.
+    is implemented in web3.py by default since any name that does not pass this
+    validation is considered invalid.
 
 
 Setup
@@ -149,33 +147,8 @@ Usage
 ENSIP-15 Normalization
 ~~~~~~~~~~~~~~~~~~~~~~
 
-The ENSIP-15 normalization algorithm is implemented in web3.py. It will be the default
-name normalization algorithm in web3.py ``v7`` and is available in web3.py ``v6`` via
-the ``ensip15_normalization`` flag on the ``ENS`` & ``AsyncENS`` classes. It is also
-available via the ``ensip15`` flag on relevant ``ens.utils`` utility methods:
-
-- :meth:`~ens.utils.normalize_name`
-- :meth:`~ens.utils.is_valid_name`
-- :meth:`~ens.utils.ens_encode_name`
-- :meth:`~ens.utils.label_to_hash`
-- :meth:`~ens.utils.raw_name_to_hash`
-
-and via the ``ensip15`` flag on static methods on the ``ENS`` & ``AsyncENS`` classes:
-
-- :meth:`~ens.BaseENS.namehash`
-- :meth:`~ens.BaseENS.labelhash`
-- :meth:`~ens.BaseENS.nameprep`
-- :meth:`~ens.BaseENS.is_valid_name`
-
-The ``ensip15_normalization`` flag is ``False`` by default on the ``ENS`` & ``AsyncENS``
-classes. Set this value to ``True`` to use the ENSIP-15 name normalization standard
-for all calls to ENS contracts via the ``ENS`` & ``AsyncENS`` classes.
-
-.. code-block:: python
-
-    from ens.auto import ns
-    ns.ensip15_normalization = True
-
+The ENSIP-15 normalization algorithm is implemented in web3.py and is the default
+name normalization algorithm in web3.py as of ``v6.0.6``.
 
 Name Info
 ~~~~~~~~~

--- a/docs/ens_overview.rst
+++ b/docs/ens_overview.rst
@@ -13,9 +13,9 @@ domains and addresses, add resolver records, or get and set metadata.
 
 .. note::
 
-    web3.py ``v6.1.0`` introduced ENS name normalization standard
-    `ENSIP-15 <https://docs.ens.domains/ens-improvement-proposals/ensip-15-normalization-standard>`_
-    by default. This update to ENS name validation and normalization won't affect ~99%
+    web3.py ``v6.6.0`` introduced ENS name normalization standard
+    `ENSIP-15 <https://docs.ens.domains/ens-improvement-proposals/ensip-15-normalization-standard>`_.
+    This update to ENS name validation and normalization won't affect ~99%
     of names but may prevent invalid names from being created and from interacting with
     the ENS contracts via web3.py. We feel strongly that this change, though breaking,
     is in the best interest of our users as it ensures compatibility with the latest ENS

--- a/docs/ens_overview.rst
+++ b/docs/ens_overview.rst
@@ -11,9 +11,15 @@ The :mod:`ens` module is included with web3.py. It provides an interface to look
 domains and addresses, add resolver records, or get and set metadata.
 
 
-.. note:: ENSIP-15 introduced a new standard for ENS name normalization. This standard
-    is implemented in web3.py by default since any name that does not pass this
-    validation is considered invalid.
+.. note::
+
+    web3.py ``v6.1.0`` introduced ENS name normalization standard
+    `ENSIP-15 <https://docs.ens.domains/ens-improvement-proposals/ensip-15-normalization-standard>`_
+    by default. This update to ENS name validation and normalization won't affect ~99%
+    of names but may prevent invalid names from being created and from interacting with
+    the ENS contracts via web3.py. We feel strongly that this change, though breaking,
+    is in the best interest of our users as it ensures compatibility with the latest ENS
+    standards.
 
 
 Setup
@@ -141,14 +147,6 @@ The first time it's used, web3.py will create the  ``ens`` instance using
 
 Usage
 -----
-
-.. _ensip15_normalization:
-
-ENSIP-15 Normalization
-~~~~~~~~~~~~~~~~~~~~~~
-
-The ENSIP-15 normalization algorithm is implemented in web3.py and is the default
-name normalization algorithm in web3.py as of ``v6.0.6``.
 
 Name Info
 ~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,16 @@
 .. meta::
    :description: Python Web3 SDK for Ethereum and EVM blockchains
 
+.. important::
+
+    For **ENS (Ethereum Name Service)** users, web3.py ``v6.1.0`` introduced ENS name
+    normalization standard
+    `ENSIP-15 <https://docs.ens.domains/ens-improvement-proposals/ensip-15-normalization-standard>`_
+    by default. This update to ENS name validation and normalization won't affect ~99%
+    of names but may prevent invalid names from being created and from interacting with
+    the ENS contracts via web3.py. We feel strongly that this change, though breaking,
+    is in the best interest of our users as it ensures compatibility with the latest ENS
+    standards.
 
 gm
 ==

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,10 +3,10 @@
 
 .. important::
 
-    For **ENS (Ethereum Name Service)** users, web3.py ``v6.1.0`` introduced ENS name
+    For **ENS (Ethereum Name Service)** users, web3.py ``v6.6.0`` introduced ENS name
     normalization standard
-    `ENSIP-15 <https://docs.ens.domains/ens-improvement-proposals/ensip-15-normalization-standard>`_
-    by default. This update to ENS name validation and normalization won't affect ~99%
+    `ENSIP-15 <https://docs.ens.domains/ens-improvement-proposals/ensip-15-normalization-standard>`_.
+    This update to ENS name validation and normalization won't affect ~99%
     of names but may prevent invalid names from being created and from interacting with
     the ENS contracts via web3.py. We feel strongly that this change, though breaking,
     is in the best interest of our users as it ensures compatibility with the latest ENS

--- a/ens/async_ens.py
+++ b/ens/async_ens.py
@@ -190,7 +190,7 @@ class AsyncENS(BaseENS):
 
         resolver: "AsyncContract" = await self._set_resolver(name, transact=transact)
         return await resolver.functions.setAddr(
-            raw_name_to_hash(name, ensip15=self.ensip15_normalization), address
+            raw_name_to_hash(name), address
         ).transact(transact)
 
     async def name(self, address: ChecksumAddress) -> Optional[str]:
@@ -271,7 +271,7 @@ class AsyncENS(BaseENS):
         :return: owner address
         :rtype: str
         """
-        node = raw_name_to_hash(name, ensip15=self.ensip15_normalization)
+        node = raw_name_to_hash(name)
         return await self.ens.caller.owner(node)
 
     async def setup_owner(
@@ -332,7 +332,7 @@ class AsyncENS(BaseENS):
 
         :param str name: The ENS name
         """
-        normal_name = normalize_name(name, ensip15=self.ensip15_normalization)
+        normal_name = normalize_name(name)
         resolver = await self._get_resolver(normal_name)
         return resolver[0]
 
@@ -354,7 +354,7 @@ class AsyncENS(BaseENS):
             the "0x59d1d43c" interface id
         :raises ResolverNotFound: If no resolver is found for the provided name
         """
-        node = raw_name_to_hash(name, ensip15=self.ensip15_normalization)
+        node = raw_name_to_hash(name)
 
         r = await self.resolver(name)
         if r:
@@ -395,8 +395,8 @@ class AsyncENS(BaseENS):
             transact = {}
 
         owner = await self.owner(name)
-        node = raw_name_to_hash(name, ensip15=self.ensip15_normalization)
-        normal_name = normalize_name(name, ensip15=self.ensip15_normalization)
+        node = raw_name_to_hash(name)
+        normal_name = normalize_name(name)
 
         transaction_dict = merge({"from": owner}, transact)
 
@@ -455,7 +455,7 @@ class AsyncENS(BaseENS):
         transact = deepcopy(transact)
         if is_none_or_zero_address(resolver_addr):
             resolver_addr = await self.address("resolver.eth")
-        namehash = raw_name_to_hash(name, ensip15=self.ensip15_normalization)
+        namehash = raw_name_to_hash(name)
         if await self.ens.caller.resolver(namehash) != resolver_addr:
             await self.ens.functions.setResolver(  # type: ignore
                 namehash, resolver_addr
@@ -467,13 +467,13 @@ class AsyncENS(BaseENS):
         name: str,
         fn_name: str = "addr",
     ) -> Optional[Union[ChecksumAddress, str]]:
-        normal_name = normalize_name(name, ensip15=self.ensip15_normalization)
+        normal_name = normalize_name(name)
 
         resolver, current_name = await self._get_resolver(normal_name, fn_name)
         if not resolver:
             return None
 
-        node = self.namehash(normal_name, ensip15=self.ensip15_normalization)
+        node = self.namehash(normal_name)
 
         # handle extended resolver case
         if await _async_resolver_supports_interface(
@@ -483,7 +483,7 @@ class AsyncENS(BaseENS):
 
             calldata = resolver.encodeABI(*contract_func_with_args)
             contract_call_result = await resolver.caller.resolve(
-                ens_encode_name(normal_name, ensip15=self.ensip15_normalization),
+                ens_encode_name(normal_name),
                 calldata,
             )
             result = self._decode_ensip10_resolve_data(
@@ -520,7 +520,7 @@ class AsyncENS(BaseENS):
         """
         owner = None
         unowned = []
-        pieces = normalize_name(name, ensip15=self.ensip15_normalization).split(".")
+        pieces = normalize_name(name).split(".")
         while pieces and is_none_or_zero_address(owner):
             name = ".".join(pieces)
             owner = await self.owner(name)
@@ -542,8 +542,8 @@ class AsyncENS(BaseENS):
         transact["from"] = old_owner or owner
         for label in reversed(unowned):
             await self.ens.functions.setSubnodeOwner(  # type: ignore
-                raw_name_to_hash(owned, ensip15=self.ensip15_normalization),
-                label_to_hash(label, ensip15=self.ensip15_normalization),
+                raw_name_to_hash(owned),
+                label_to_hash(label),
                 owner,
             ).transact(transact)
             owned = f"{label}.{owned}"
@@ -554,7 +554,7 @@ class AsyncENS(BaseENS):
         address: ChecksumAddress,
         transact: Optional["TxParams"] = None,
     ) -> HexBytes:
-        name = normalize_name(name, ensip15=self.ensip15_normalization) if name else ""
+        name = normalize_name(name) if name else ""
         if not transact:
             transact = {}
         transact = deepcopy(transact)

--- a/ens/base_ens.py
+++ b/ens/base_ens.py
@@ -41,8 +41,6 @@ class BaseENS:
     _resolver_contract: Union[Type["Contract"], Type["AsyncContract"]] = None
     _reverse_resolver_contract: Union[Type["Contract"], Type["AsyncContract"]] = None
 
-    ensip15_normalization: bool = False
-
     @property
     def strict_bytes_type_checking(self) -> bool:
         return self.w3.strict_bytes_type_checking
@@ -53,23 +51,23 @@ class BaseENS:
 
     @staticmethod
     @wraps(label_to_hash)
-    def labelhash(label: str, ensip15: bool = False) -> HexBytes:
-        return label_to_hash(label, ensip15=ensip15)
+    def labelhash(label: str) -> HexBytes:
+        return label_to_hash(label)
 
     @staticmethod
     @wraps(raw_name_to_hash)
-    def namehash(name: str, ensip15: bool = False) -> HexBytes:
-        return raw_name_to_hash(name, ensip15=ensip15)
+    def namehash(name: str) -> HexBytes:
+        return raw_name_to_hash(name)
 
     @staticmethod
     @wraps(normalize_name)
-    def nameprep(name: str, ensip15: bool = False) -> str:
-        return normalize_name(name, ensip15=ensip15)
+    def nameprep(name: str) -> str:
+        return normalize_name(name)
 
     @staticmethod
     @wraps(is_valid_name)
-    def is_valid_name(name: str, ensip15: bool = False) -> bool:
-        return is_valid_name(name, ensip15=ensip15)
+    def is_valid_name(name: str) -> bool:
+        return is_valid_name(name)
 
     @staticmethod
     @wraps(address_to_reverse_domain)

--- a/ens/ens.py
+++ b/ens/ens.py
@@ -187,9 +187,9 @@ class ENS(BaseENS):
         transact["from"] = owner
 
         resolver: "Contract" = self._set_resolver(name, transact=transact)
-        return resolver.functions.setAddr(
-            raw_name_to_hash(name, ensip15=self.ensip15_normalization), address
-        ).transact(transact)
+        return resolver.functions.setAddr(raw_name_to_hash(name), address).transact(
+            transact
+        )
 
     def name(self, address: ChecksumAddress) -> Optional[str]:
         """
@@ -267,7 +267,7 @@ class ENS(BaseENS):
         :return: owner address
         :rtype: str
         """
-        node = raw_name_to_hash(name, ensip15=self.ensip15_normalization)
+        node = raw_name_to_hash(name)
         return self.ens.caller.owner(node)
 
     def setup_owner(
@@ -328,7 +328,7 @@ class ENS(BaseENS):
 
         :param str name: The ENS name
         """
-        normal_name = normalize_name(name, ensip15=self.ensip15_normalization)
+        normal_name = normalize_name(name)
         return self._get_resolver(normal_name)[0]
 
     def reverser(self, target_address: ChecksumAddress) -> Optional["Contract"]:
@@ -347,7 +347,7 @@ class ENS(BaseENS):
             the "0x59d1d43c" interface id
         :raises ResolverNotFound: If no resolver is found for the provided name
         """
-        node = raw_name_to_hash(name, ensip15=self.ensip15_normalization)
+        node = raw_name_to_hash(name)
 
         r = self.resolver(name)
         if r:
@@ -388,7 +388,7 @@ class ENS(BaseENS):
             transact = {}
 
         owner = self.owner(name)
-        node = raw_name_to_hash(name, ensip15=self.ensip15_normalization)
+        node = raw_name_to_hash(name)
 
         transaction_dict = merge({"from": owner}, transact)
 
@@ -443,7 +443,7 @@ class ENS(BaseENS):
         transact = deepcopy(transact)
         if is_none_or_zero_address(resolver_addr):
             resolver_addr = self.address("resolver.eth")
-        namehash = raw_name_to_hash(name, ensip15=self.ensip15_normalization)
+        namehash = raw_name_to_hash(name)
         if self.ens.caller.resolver(namehash) != resolver_addr:
             self.ens.functions.setResolver(namehash, resolver_addr).transact(transact)
         return cast("Contract", self._resolver_contract(address=resolver_addr))
@@ -451,13 +451,13 @@ class ENS(BaseENS):
     def _resolve(
         self, name: str, fn_name: str = "addr"
     ) -> Optional[Union[ChecksumAddress, str]]:
-        normal_name = normalize_name(name, ensip15=self.ensip15_normalization)
+        normal_name = normalize_name(name)
 
         resolver, current_name = self._get_resolver(normal_name, fn_name)
         if not resolver:
             return None
 
-        node = self.namehash(normal_name, ensip15=self.ensip15_normalization)
+        node = self.namehash(normal_name)
 
         # handle extended resolver case
         if _resolver_supports_interface(resolver, EXTENDED_RESOLVER_INTERFACE_ID):
@@ -465,7 +465,7 @@ class ENS(BaseENS):
 
             calldata = resolver.encodeABI(*contract_func_with_args)
             contract_call_result = resolver.caller.resolve(
-                ens_encode_name(normal_name, ensip15=self.ensip15_normalization),
+                ens_encode_name(normal_name),
                 calldata,
             )
             result = self._decode_ensip10_resolve_data(
@@ -502,7 +502,7 @@ class ENS(BaseENS):
         """
         owner = None
         unowned = []
-        pieces = normalize_name(name, ensip15=self.ensip15_normalization).split(".")
+        pieces = normalize_name(name).split(".")
         while pieces and is_none_or_zero_address(owner):
             name = ".".join(pieces)
             owner = self.owner(name)
@@ -524,8 +524,8 @@ class ENS(BaseENS):
         transact["from"] = old_owner or owner
         for label in reversed(unowned):
             self.ens.functions.setSubnodeOwner(
-                raw_name_to_hash(owned, ensip15=self.ensip15_normalization),
-                label_to_hash(label, ensip15=self.ensip15_normalization),
+                raw_name_to_hash(owned),
+                label_to_hash(label),
                 owner,
             ).transact(transact)
             owned = f"{label}.{owned}"
@@ -536,7 +536,7 @@ class ENS(BaseENS):
         address: ChecksumAddress,
         transact: Optional["TxParams"] = None,
     ) -> HexBytes:
-        name = normalize_name(name, ensip15=self.ensip15_normalization) if name else ""
+        name = normalize_name(name) if name else ""
         if not transact:
             transact = {}
         transact = deepcopy(transact)

--- a/ens/utils.py
+++ b/ens/utils.py
@@ -127,6 +127,9 @@ def normalize_name(name: str, ensip15: bool = False) -> str:
     :param bool ensip15: if True, normalize as per ENSIP-15
     :raises InvalidName: if ``name`` has invalid syntax
     """
+    if is_empty_name(name):
+        return ""
+
     if ensip15:
         return normalize_name_ensip15(name).as_text
 
@@ -137,9 +140,7 @@ def normalize_name(name: str, ensip15: bool = False) -> str:
         FutureWarning,
     )
 
-    if not name:
-        return name
-    elif isinstance(name, (bytes, bytearray)):
+    if isinstance(name, (bytes, bytearray)):
         name = name.decode("utf-8")
 
     try:

--- a/newsfragments/3000.feature.rst
+++ b/newsfragments/3000.feature.rst
@@ -1,1 +1,0 @@
-Add support for ENSIP-15, either directly via ``normalize_name_ensip15()`` or via ``ensip15=True`` flag on appropriate ENS utils methods. Add ``ensip15_normalization`` flag to ``ENS`` class to turn on ENSIP-15 for internal class methods.

--- a/newsfragments/3000.internal.rst
+++ b/newsfragments/3000.internal.rst
@@ -1,0 +1,1 @@
+Introduced the logic for ENSIP-15 ENS name normalization. Originally this was done via a flag in this PR but changed to the default behavior in #3024 before release.

--- a/newsfragments/3005.docs.rst
+++ b/newsfragments/3005.docs.rst
@@ -1,1 +1,0 @@
-Document ENSIP-15 normalization standard usage for web3.py ``v6`` and document that this will be the default normalization in web3.py ``v7``.

--- a/newsfragments/3024.breaking.rst
+++ b/newsfragments/3024.breaking.rst
@@ -1,0 +1,1 @@
+ENS name normalization now uses ENSIP-15 by default. This is technically a breaking change introduced by ENS but, according to ENSIP-15, 99% of existing names should be unaffected.

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,9 +2,6 @@
 addopts= -v --showlocals --durations 10
 xfail_strict=true
 asyncio_mode=strict
-markers =
-    # TODO: remove once ENSIP-15 is default
-    ensip15: Don't silence warnings related to ENSIP-15.
 
 [pytest-watch]
 runner= pytest --failed-first --maxfail=1 --no-success-flaky-report

--- a/tests/ens/conftest.py
+++ b/tests/ens/conftest.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import pytest
-import warnings
 
 from eth_tester import (
     EthereumTester,
@@ -14,11 +13,6 @@ import pytest_asyncio
 from ens import (
     ENS,
     AsyncENS,
-)
-from ens._normalization import (
-    ENSNormalizedName,
-    Label,
-    TextToken,
 )
 from ens.contract_data import (
     extended_resolver_abi,
@@ -55,31 +49,6 @@ from web3.providers.eth_tester import (
     AsyncEthereumTesterProvider,
     EthereumTesterProvider,
 )
-
-ENSIP15_NORMALIZED_TESTER_DOT_ETH = ENSNormalizedName(
-    # "tester.eth"
-    [
-        Label("ascii", [TextToken([ord(c) for c in "tester"])]),
-        Label("ascii", [TextToken([ord(c) for c in "eth"])]),
-    ]
-)
-
-
-@pytest.fixture(autouse=True)
-def silence_ensip15_warnings(request):
-    # TODO: remove once ENSIP-15 is default
-    if "ensip15" in request.keywords:
-        yield
-    else:
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message=(
-                    "It is recommended to `normalize_name\\(\\)` with `ensip15==True`"
-                ),
-                category=FutureWarning,
-            )
-            yield
 
 
 def bytes32(val):

--- a/tests/ens/test_nameprep.py
+++ b/tests/ens/test_nameprep.py
@@ -1,69 +1,37 @@
 import pytest
 
 from ens import (
-    InvalidName,
+    ENS,
+    AsyncENS,
 )
 
 # test content inspired by https://github.com/jcranmer/idna-uts46/blob/9e2ff191a8887c872ad172f2d72f8d4bf353aef8/test/test-uts46.js  # noqa: E501
 
-
-def test_nameprep_basic_unicode(ens):
-    assert ens.nameprep("öbb.at") == "öbb.at"
-    assert ens.nameprep("Öbb.at") == "öbb.at"
-    assert ens.nameprep("O\u0308bb.at") == "öbb.at"
-    assert ens.nameprep("faß.de") == "faß.de"
-    assert ens.nameprep("fass.de") == "fass.de"
-    assert ens.nameprep("🌈rainbow.eth") == "🌈rainbow.eth"
-    assert ens.nameprep("🐔🐔.tk") == "🐔🐔.tk"
-    assert ens.nameprep("√.com") == "√.com"
-    assert ens.nameprep("ԛәлп.com") == "ԛәлп.com"
-    assert ens.nameprep("test\u200btest.com") == "testtest.com"
-    assert ens.nameprep("-test.com") == "-test.com"
-    assert ens.nameprep("1test.com") == "1test.com"
-    assert ens.nameprep("test.1com") == "test.1com"
-
-
-@pytest.mark.parametrize(
-    "url",
-    [
-        ("not=std3"),
-        ("not_std3.eth"),  # underscores not allowed
-    ],
+TEST_CONTENT = (
+    ("öbb.at", "öbb.at"),
+    ("Öbb.at", "öbb.at"),
+    ("O\u0308bb.at", "öbb.at"),
+    ("faß.de", "faß.de"),
+    ("fass.de", "fass.de"),
+    ("🌈rainbow.eth", "🌈rainbow.eth"),
+    ("🐔🐔.tk", "🐔🐔.tk"),
+    ("√.com", "√.com"),
+    ("ԛәлп.com", "ԛәлп.com"),
+    ("test\u200btest.com", "testtest.com"),
+    ("-test.com", "-test.com"),
+    ("1test.com", "1test.com"),
+    ("test.1com", "test.1com"),
 )
-def test_nameprep_std3_rules(ens, url):
-    with pytest.raises(InvalidName, match=f"{url} is an invalid name"):
-        ens.nameprep(url)
+
+
+@pytest.mark.parametrize("name,expected", TEST_CONTENT)
+def test_nameprep_basic_unicode(name, expected):
+    assert ENS.nameprep(name) == expected
 
 
 # -- async -- #
 
-# note: `nameprep` isn't an async method, but rather test that nameprep is
-# available to AsyncENS and passes all tests
 
-
-def test_async_nameprep_basic_unicode(async_ens):
-    assert async_ens.nameprep("öbb.at") == "öbb.at"
-    assert async_ens.nameprep("Öbb.at") == "öbb.at"
-    assert async_ens.nameprep("O\u0308bb.at") == "öbb.at"
-    assert async_ens.nameprep("faß.de") == "faß.de"
-    assert async_ens.nameprep("fass.de") == "fass.de"
-    assert async_ens.nameprep("🌈rainbow.eth") == "🌈rainbow.eth"
-    assert async_ens.nameprep("🐔🐔.tk") == "🐔🐔.tk"
-    assert async_ens.nameprep("√.com") == "√.com"
-    assert async_ens.nameprep("ԛәлп.com") == "ԛәлп.com"
-    assert async_ens.nameprep("test\u200btest.com") == "testtest.com"
-    assert async_ens.nameprep("-test.com") == "-test.com"
-    assert async_ens.nameprep("1test.com") == "1test.com"
-    assert async_ens.nameprep("test.1com") == "test.1com"
-
-
-@pytest.mark.parametrize(
-    "url",
-    [
-        ("not=std3"),
-        ("not_std3.eth"),  # underscores not allowed
-    ],
-)
-def test_async_nameprep_std3_rules(async_ens, url):
-    with pytest.raises(InvalidName, match=f"{url} is an invalid name"):
-        async_ens.nameprep(url)
+@pytest.mark.parametrize("name,expected", TEST_CONTENT)
+def test_async_nameprep_basic_unicode(name, expected):
+    assert AsyncENS.nameprep(name) == expected

--- a/tests/ens/test_setup_address.py
+++ b/tests/ens/test_setup_address.py
@@ -34,19 +34,6 @@ SETUP_ADDRESS_TEST_CASES = (
         "TESTER.eth",
         "0x2a7ac1c833d35677c2ff34a908951de142cc1653de6080ad4e38f4c9cc00aafe",
     ),
-    # handles alternative dot separators
-    (
-        "tester．eth",
-        "0x2a7ac1c833d35677c2ff34a908951de142cc1653de6080ad4e38f4c9cc00aafe",
-    ),
-    (
-        "tester。eth",
-        "0x2a7ac1c833d35677c2ff34a908951de142cc1653de6080ad4e38f4c9cc00aafe",
-    ),
-    (
-        "tester｡eth",
-        "0x2a7ac1c833d35677c2ff34a908951de142cc1653de6080ad4e38f4c9cc00aafe",
-    ),
     # confirm that set-owner works
     (
         "lots.of.subdomains.tester.eth",

--- a/tests/ens/test_setup_name.py
+++ b/tests/ens/test_setup_name.py
@@ -28,21 +28,6 @@ SETUP_NAME_TEST_CASES = (
         "tester.eth",
         "2a7ac1c833d35677c2ff34a908951de142cc1653de6080ad4e38f4c9cc00aafe",
     ),
-    (
-        "tester．eth",
-        "tester.eth",
-        "2a7ac1c833d35677c2ff34a908951de142cc1653de6080ad4e38f4c9cc00aafe",
-    ),
-    (
-        "tester。eth",
-        "tester.eth",
-        "2a7ac1c833d35677c2ff34a908951de142cc1653de6080ad4e38f4c9cc00aafe",
-    ),
-    (
-        "tester｡eth",
-        "tester.eth",
-        "2a7ac1c833d35677c2ff34a908951de142cc1653de6080ad4e38f4c9cc00aafe",
-    ),
     # confirm that set-owner works
     (
         "lots.of.subdomains.tester.eth",


### PR DESCRIPTION
### What was wrong?

- ENSIP-15 is the new standard for normalizing and validating ENS names. If we don't turn this on by default we will be allowing invalid names to be created via web3.py. Though this is technically an upstream breaking change by ENS, it is in the best interest of our users to not be allowed to create invalid names in ENS. According to the standard, 99% of existing names are still valid under this new standard.

closes #3010

### How was it fixed?

- Turn on ENSIP-15 normalization by default, effectively reverting the ENSIP-15 flag changes before any release was made.
- Remove / update newsfragments related to ENSIP-15 flag.
- Keep tests that ensure that appropriate ENS utility methods and ENS / AsyncENS class methods call `normalize_name_ensip15` as this is important to test for.
- Update documentation to alert users of this possibly breaking change.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)
- [x] Update and add appropriate documentation and notices
- [x] Update newsfragments

#### Cute Animal Picture

<img width="306" alt="Screenshot 2023-07-10 at 14 12 14" src="https://github.com/ethereum/web3.py/assets/3532824/594c089c-d77e-4df7-8d43-6d49b37551fe">
