### PR TITLE
Async sign and send raw middleware

### DIFF
--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -537,6 +537,7 @@ Signing
 ~~~~~~~
 
 .. py:method:: web3.middleware.construct_sign_and_send_raw_middleware(private_key_or_account)
+               web3.middleware.async_construct_sign_and_send_raw_middleware(private_key_or_account)
 
 This middleware automatically captures transactions, signs them, and sends them as raw transactions.
 The ``from`` field on the transaction, or ``w3.eth.default_account`` must be set to the address of the private key for
@@ -572,6 +573,27 @@ this middleware to have any effect.
     >>> acct = w3.eth.account.from_key(os.environ.get('PRIVATE_KEY'))
     >>> w3.middleware_onion.add(construct_sign_and_send_raw_middleware(acct))
     >>> w3.eth.default_account = acct.address
+
+    >>> # use `eth_sendTransaction` to automatically sign and send the raw transaction
+    >>> w3.eth.send_transaction(tx_dict)
+    HexBytes('0x09511acf75918fd03de58141d2fd409af4fd6d3dce48eb3aa1656c8f3c2c5c21')
+
+Similarly, with AsyncWeb3:
+
+.. code-block:: python
+
+    >>> from web3 import AsyncWeb3
+    >>> async_w3 = AsyncWeb3(AsyncHTTPProvider('HTTP_ENDPOINT'))
+    >>> from web3.middleware import async_construct_sign_and_send_raw_middleware
+    >>> from eth_account import Account
+    >>> import os
+    >>> acct = async_w3.eth.account.from_key(os.environ.get('PRIVATE_KEY'))
+    >>> async_w3.middleware_onion.add(await async_construct_sign_and_send_raw_middleware(acct))
+    >>> async_w3.eth.default_account = acct.address
+
+    >>> # use `eth_sendTransaction` to automatically sign and send the raw transaction
+    >>> await async_w3.eth.send_transaction(tx_dict)
+    HexBytes('0x09511acf75918fd03de58141d2fd409af4fd6d3dce48eb3aa1656c8f3c2c5c21')
 
 Now you can send a transaction from acct.address without having to build and sign each raw transaction.
 

--- a/newsfragments/2936.bugfix.rst
+++ b/newsfragments/2936.bugfix.rst
@@ -1,0 +1,1 @@
+Fix for a possible bug in ``construct_sign_and_send_raw_middleware`` where the signed transaction was sent as bytes and expected to be converted to hex by formatting later on. It is now explicitly sent as the hex string hash within the middleware.

--- a/newsfragments/3025.feature.rst
+++ b/newsfragments/3025.feature.rst
@@ -1,0 +1,1 @@
+Add async support for the sign-and-send raw transaction middleware via ``construct_async_sign_and_send_raw_middleware()``.

--- a/tests/core/middleware/test_transaction_signing.py
+++ b/tests/core/middleware/test_transaction_signing.py
@@ -12,6 +12,7 @@ from eth_tester.exceptions import (
 )
 from eth_utils import (
     ValidationError as EthUtilsValidationError,
+    is_hexstr,
     to_bytes,
     to_hex,
 )
@@ -310,7 +311,7 @@ def assert_method_and_txn_signed(actual, expected):
     raw_txn = actual[1][0]
     actual_method = actual[0]
     assert actual_method == expected
-    assert isinstance(raw_txn, bytes)
+    assert is_hexstr(raw_txn)
 
 
 @pytest.fixture()
@@ -417,7 +418,7 @@ def test_sign_and_send_raw_middleware_with_byte_addresses(
     raw_txn = actual[1][0]
     actual_method = actual[0]
     assert actual_method == "eth_sendRawTransaction"
-    assert isinstance(raw_txn, bytes)
+    assert is_hexstr(raw_txn)
 
 
 # -- async -- #
@@ -613,4 +614,4 @@ async def test_async_sign_and_send_raw_middleware_with_byte_addresses(
     raw_txn = actual[1][0]
     actual_method = actual[0]
     assert actual_method == "eth_sendRawTransaction"
-    assert isinstance(raw_txn, bytes)
+    assert is_hexstr(raw_txn)

--- a/tests/core/utilities/test_async_transaction.py
+++ b/tests/core/utilities/test_async_transaction.py
@@ -5,7 +5,7 @@ from eth_typing import (
 )
 
 from web3._utils.async_transactions import (
-    fill_transaction_defaults,
+    async_fill_transaction_defaults,
     get_block_gas_limit,
     get_buffered_gas_estimate,
 )
@@ -52,7 +52,7 @@ async def test_get_buffered_gas_estimate(async_w3):
 
 @pytest.mark.asyncio()
 async def test_fill_transaction_defaults_for_all_params(async_w3):
-    default_transaction = await fill_transaction_defaults(async_w3, {})
+    default_transaction = await async_fill_transaction_defaults(async_w3, {})
 
     block = await async_w3.eth.get_block("latest")
     assert default_transaction == {
@@ -72,7 +72,7 @@ async def test_fill_transaction_defaults_nondynamic_tranaction_fee(async_w3):
     gasPrice_transaction = {
         "gasPrice": 10,
     }
-    default_transaction = await fill_transaction_defaults(
+    default_transaction = await async_fill_transaction_defaults(
         async_w3, gasPrice_transaction
     )
 
@@ -86,7 +86,7 @@ async def test_fill_transaction_defaults_for_zero_gas_price(async_w3):
 
     async_w3.eth.set_gas_price_strategy(gas_price_strategy)
 
-    default_transaction = await fill_transaction_defaults(async_w3, {})
+    default_transaction = await async_fill_transaction_defaults(async_w3, {})
 
     assert default_transaction == {
         "chainId": await async_w3.eth.chain_id,

--- a/web3/contract/async_contract.py
+++ b/web3/contract/async_contract.py
@@ -32,7 +32,7 @@ from web3._utils.abi import (
     receive_func_abi_exists,
 )
 from web3._utils.async_transactions import (
-    fill_transaction_defaults as async_fill_transaction_defaults,
+    async_fill_transaction_defaults,
 )
 from web3._utils.compat import (
     Self,

--- a/web3/contract/utils.py
+++ b/web3/contract/utils.py
@@ -29,7 +29,7 @@ from web3._utils.abi import (
     recursive_dict_to_namedtuple,
 )
 from web3._utils.async_transactions import (
-    fill_transaction_defaults as async_fill_transaction_defaults,
+    async_fill_transaction_defaults,
 )
 from web3._utils.contracts import (
     find_matching_fn_abi,

--- a/web3/middleware/signing.py
+++ b/web3/middleware/signing.py
@@ -178,7 +178,7 @@ def construct_sign_and_send_raw_middleware(
             account = accounts[transaction["from"]]
             raw_tx = account.sign_transaction(transaction).rawTransaction
 
-            return make_request(RPCEndpoint("eth_sendRawTransaction"), [raw_tx])
+            return make_request(RPCEndpoint("eth_sendRawTransaction"), [raw_tx.hex()])
 
         return middleware
 
@@ -229,7 +229,10 @@ async def async_construct_sign_and_send_raw_middleware(
             account = accounts[to_checksum_address(tx_from)]
             raw_tx = account.sign_transaction(filled_transaction).rawTransaction
 
-            return await make_request(RPCEndpoint("eth_sendRawTransaction"), [raw_tx])
+            return await make_request(
+                RPCEndpoint("eth_sendRawTransaction"),
+                [raw_tx.hex()],
+            )
 
         return middleware
 


### PR DESCRIPTION
### What was wrong?

closes #2773
closes #2936
closes #2937 

### How was it fixed?

- Add async support for sign-and-send raw transaction middleware
- Use the hex value directly, instead of relying on formatters, since the JSON-RPC specs expect the hex
- Add tests

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20230705_082223](https://github.com/ethereum/web3.py/assets/3532824/1fa94bf7-1162-4c30-8688-3aa1fd50257e)
