### PR TITLE
Use AsyncHTTPProvider for logger

### DIFF
--- a/newsfragments/3026.bugfix.rst
+++ b/newsfragments/3026.bugfix.rst
@@ -1,0 +1,1 @@
+Properly initialize logger in ``AsyncHTTPProvider``.

--- a/web3/providers/__init__.py
+++ b/web3/providers/__init__.py
@@ -1,6 +1,9 @@
 from .async_base import (  # noqa: F401
     AsyncBaseProvider,
 )
+from .async_rpc import (  # noqa: F401
+    AsyncHTTPProvider,
+)
 from .base import (  # noqa: F401
     BaseProvider,
     JSONBaseProvider,

--- a/web3/providers/async_rpc.py
+++ b/web3/providers/async_rpc.py
@@ -44,7 +44,7 @@ from .async_base import (
 
 
 class AsyncHTTPProvider(AsyncJSONBaseProvider):
-    logger = logging.getLogger("web3.providers.HTTPProvider")
+    logger = logging.getLogger("web3.providers.AsyncHTTPProvider")
     endpoint_uri = None
     _request_kwargs = None
     # type ignored b/c conflict with _middlewares attr on AsyncBaseProvider


### PR DESCRIPTION
### What was wrong?

Closes #3026 

### How was it fixed?

Initialize logger with `AsyncHTTPProvider` rather than `HTTPProvider`.

### Todo:
- [X] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://static.pupperish.com/images/KbWpjJhBRTya_8165_700.jpg)
