### PR TITLE
Remove Docs for Oboslete Methods

### DIFF
--- a/docs/web3.contract.rst
+++ b/docs/web3.contract.rst
@@ -293,30 +293,6 @@ Each Contract Factory exposes the following methods.
         filter_builder.fromBlock = 0  # raises a ValueError
 
 
-.. py:classmethod:: Contract.deploy(transaction=None, args=None)
-
-    .. warning:: Deprecated: this method is deprecated in favor of
-      :meth:`~Contract.constructor`, which provides more flexibility.
-
-    Construct and send a transaction to deploy the contract.
-
-    If provided ``transaction`` should be a dictionary conforming to the
-    ``web3.eth.send_transaction(transaction)`` method.  This value may not
-    contain the keys ``data`` or ``to``.
-
-    If the contract takes constructor arguments they should be provided as a
-    list via the ``args`` parameter.
-
-    If any of the ``args`` specified in the ABI are an ``address`` type, they
-    will accept ENS names.
-
-    If a ``gas`` value is not provided, then the ``gas`` value for the
-    deployment transaction will be created using the ``web3.eth.estimate_gas()``
-    method.
-
-    Returns the transaction hash for the deploy transaction.
-
-
 .. py:classmethod:: Contract.encodeABI(fn_name, args=None, kwargs=None, data=None)
 
    Encodes the arguments using the Ethereum ABI for the contract function that

--- a/docs/web3.miner.rst
+++ b/docs/web3.miner.rst
@@ -24,12 +24,6 @@ The following methods are available on the ``web3.geth.miner`` namespace.
         >>> web3.geth.miner.make_dag(10000)
 
 
-.. py:method:: GethMiner.makeDAG(number)
-
-   .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~GethMiner.make_dag`
-
-
 .. py:method:: GethMiner.set_extra(extra)
 
     * Delegates to ``miner_setExtra`` RPC Method
@@ -40,12 +34,6 @@ The following methods are available on the ``web3.geth.miner`` namespace.
     .. code-block:: python
 
         >>> web3.geth.miner.set_extra('abcdefghijklmnopqrstuvwxyzABCDEF')
-
-.. py:method:: GethMiner.setExtra(extra)
-
-   .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~GethMiner.set_extra`
-
 
 .. py:method:: GethMiner.set_gas_price(gas_price)
 
@@ -58,12 +46,6 @@ The following methods are available on the ``web3.geth.miner`` namespace.
     .. code-block:: python
 
         >>> web3.geth.miner.set_gas_price(19999999999)
-
-
-.. py:method:: GethMiner.setGasPrice(gas_price)
-
-   .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~GethMiner.set_gas_price`
 
 
 .. py:method:: GethMiner.start(num_threads)
@@ -98,12 +80,6 @@ The following methods are available on the ``web3.geth.miner`` namespace.
 
         >>> web3.geth.miner.start_auto_dag()
 
-.. py:method:: GethMiner.startAutoDag()
-
-   .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~GethMiner.start_auto_dag`
-
-
 .. py:method:: GethMiner.stop_auto_dag()
 
     * Delegates to ``miner_stopAutoDag`` RPC Method
@@ -114,7 +90,3 @@ The following methods are available on the ``web3.geth.miner`` namespace.
 
         >>> web3.geth.miner.stop_auto_dag()
 
-.. py:method:: GethMiner.stopAutoDag()
-
-   .. warning:: Deprecated: This method is deprecated in favor of
-      :meth:`~GethMiner.stop_auto_dag`

--- a/docs/web3.miner.rst
+++ b/docs/web3.miner.rst
@@ -89,4 +89,3 @@ The following methods are available on the ``web3.geth.miner`` namespace.
     .. code-block:: python
 
         >>> web3.geth.miner.stop_auto_dag()
-

--- a/newsfragments/2039.docs.rst
+++ b/newsfragments/2039.docs.rst
@@ -1,0 +1,1 @@
+Removed obsolete docs for camelCase miner methods and ``deploy``

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -411,12 +411,6 @@ API_ENDPOINTS = {
         "stop": not_implemented,
         "start_auto_dag": not_implemented,
         "stop_auto_dag": not_implemented,
-        # deprecated
-        "makeDAG": not_implemented,
-        "setExtra": not_implemented,
-        "setGasPrice": not_implemented,
-        "startAutoDAG": not_implemented,
-        "stopAutoDAG": not_implemented,
     },
     "personal": {
         "ec_recover": not_implemented,


### PR DESCRIPTION
### What was wrong?
I noticed that we still had deprecated method docs still hanging around in the miner section. Also had docs on `deploy` that needed to be removed from the contract.

### How was it fixed?
Removed them!

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/id/1154370446/photo/funny-raccoon-in-green-sunglasses-showing-a-rock-gesture-isolated-on-white-background.jpg?s=612x612&w=0&k=20&c=kkZiaB9Q-GbY5gjf6WWURzEpLzNrpjZp_tn09GB21bI=)
