### PR TITLE
Bugfix: AsyncWeb3.solidity_keccak no longer throws

### DIFF
--- a/newsfragments/3034.bugfix.rst
+++ b/newsfragments/3034.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``AsyncWeb3.solidity_keccak`` to match ``Web3.solidity_keccak``.

--- a/web3/_utils/module_testing/web3_module.py
+++ b/web3/_utils/module_testing/web3_module.py
@@ -3,6 +3,7 @@ from typing import (
     Any,
     NoReturn,
     Sequence,
+    Union,
 )
 
 from eth_typing import (
@@ -231,7 +232,7 @@ class Web3ModuleTest:
     )
     def test_solidity_keccak(
         self,
-        w3: "Web3",
+        w3: Union["Web3", "AsyncWeb3"],
         types: Sequence[TypeStr],
         values: Sequence[Any],
         expected: HexBytes,
@@ -263,9 +264,16 @@ class Web3ModuleTest:
             ),
         ),
     )
+    @pytest.mark.parametrize(
+        "w3",
+        (
+            Web3(),
+            AsyncWeb3(),
+        ),
+    )
     def test_solidity_keccak_ens(
         self,
-        w3: "Web3",
+        w3: Union["Web3", "AsyncWeb3"],
         types: Sequence[TypeStr],
         values: Sequence[str],
         expected: HexBytes,

--- a/web3/_utils/module_testing/web3_module.py
+++ b/web3/_utils/module_testing/web3_module.py
@@ -16,6 +16,7 @@ from hexbytes import (
 )
 
 from web3 import (
+    AsyncWeb3,
     Web3,
 )
 from web3._utils.ens import (
@@ -219,6 +220,13 @@ class Web3ModuleTest:
                 ],
                 InvalidAddress,
             ),
+        ),
+    )
+    @pytest.mark.parametrize(
+        "w3",
+        (
+            Web3,
+            AsyncWeb3,
         ),
     )
     def test_solidity_keccak(

--- a/web3/main.py
+++ b/web3/main.py
@@ -286,9 +286,9 @@ class BaseWeb3:
 
     @classmethod
     def normalize_values(
-        cls, _w3: "BaseWeb3", abi_types: List[TypeStr], values: List[Any]
+        cls, w3: "BaseWeb3", abi_types: List[TypeStr], values: List[Any]
     ) -> List[Any]:
-        return map_abi_data(zip(abi_types, values))
+        return map_abi_data([abi_ens_resolver(w3)], abi_types, values)
 
     @combomethod
     def solidity_keccak(cls, abi_types: List[TypeStr], values: List[Any]) -> bytes:
@@ -449,12 +449,6 @@ class Web3(BaseWeb3):
 
     def is_connected(self, show_traceback: bool = False) -> bool:
         return self.provider.is_connected(show_traceback)
-
-    @classmethod
-    def normalize_values(
-        cls, w3: "BaseWeb3", abi_types: List[TypeStr], values: List[Any]
-    ) -> List[Any]:
-        return map_abi_data([abi_ens_resolver(w3)], abi_types, values)
 
     @property
     def middleware_onion(self) -> MiddlewareOnion:


### PR DESCRIPTION
### What was wrong?

`AsyncWeb3.solidity_keccak` was raising `TypeError: 'cytoolz.functoolz.curry' object is not iterable`. The root was the `normalize_values` function on the `BaseWeb3` class.

Closes #3006 

### How was it fixed?

Took the `normalize_values` function from the `Web3` class and moved it up to the `BaseWeb3` class so that both `AsyncWeb3` and `Web3` use the same function now. Also added a test to 


### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.rd.com/wp-content/uploads/2021/03/GettyImages-927813644.jpg?resize=696,464)
