### PR TITLE
docs: resources page hackathon helpers

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -71,3 +71,10 @@ Applications
 ------------
 
 - `StakeWise Oracle <https://github.com/stakewise/oracle/>`__
+
+
+Hackathon Helpers
+-----------------
+
+- `eth-flogger <https://github.com/wolovim/eth-flogger>`__ - Sample web app utilizing async web3.py, Flask, SQLite, Sourcify
+- `Temo <https://github.com/wolovim/temo>`__ - Sample terminal app utilizing async web3py, Textual, Anvil

--- a/newsfragments/3035.docs.rst
+++ b/newsfragments/3035.docs.rst
@@ -1,0 +1,1 @@
+Adds "Hackathon Helpers" section to Resources page


### PR DESCRIPTION
### What does it do?

Adds a couple sample repos to a new "Hackathon Helpers" section in the Resources page. Hopeful that this grows with more helpful reference projects, tips, and other types of support, e.g., presentation slide templates.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![](https://www.arthayantra.com/blogs/wp-content/uploads/2017/05/Valuable-Money-Lessons-from-Animal-e1495460688515.jpg)
