### PR TITLE
chore(docs): fix POA URL anchor

### DIFF
--- a/newsfragments/3037.misc.rst
+++ b/newsfragments/3037.misc.rst
@@ -1,0 +1,1 @@
+Update link to Proof of Authority section of the middleware documentation for the message in the ``ExtraDataLengthError`` raised within the validation middleware.

--- a/web3/middleware/validation.py
+++ b/web3/middleware/validation.py
@@ -77,7 +77,7 @@ def _check_extradata_length(val: Any) -> Any:
             f"The field extraData is {len(result)} bytes, but should be "
             f"{MAX_EXTRADATA_LENGTH}. It is quite likely that you are "
             "connected to a POA chain. Refer to "
-            "http://web3py.readthedocs.io/en/stable/middleware.html#geth-style-proof-of-authority "  # noqa: E501
+            "http://web3py.readthedocs.io/en/stable/middleware.html#proof-of-authority "
             f"for more details. The full extraData is: {result!r}"
         )
     return val


### PR DESCRIPTION
### What was wrong?

The achor linking to the POA middleware is obsolete.

### How was it fixed?

Adapted the anchor.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.enwallpaper.com/wp-content/uploads/2021/03/crop-26.jpg)
