### PR TITLE
Add ens/specs to the Manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,8 @@ include requirements.txt
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
+recursive-include ens/specs *
+
 recursive-include ethpm/assets/ *
 recursive-include ethpm/ethpm-spec/examples *
 recursive-include ethpm/ethpm-spec/spec *

--- a/newsfragments/3039.bugfix.rst
+++ b/newsfragments/3039.bugfix.rst
@@ -1,0 +1,1 @@
+Add ``ens/specs`` to MANIFEST.in


### PR DESCRIPTION
### What was wrong?

The new ens/specs directory wasn't getting packaged up, leading to user issues. 

Closes #3038 

### How was it fixed?

Added `ens/specs` to the Manifest

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.theconversation.com/files/438138/original/file-20211216-25-1hu3e65.jpg?ixlib=rb-1.1.0&q=45&auto=format&w=1200&h=1200.0&fit=crop)
