### PR TITLE
Test to catch if files are missing from a release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,13 +1,11 @@
-include LICENSE
 include VERSION
 include README.md
-include requirements.txt
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
 recursive-include ens/specs *
 
-recursive-include ethpm/assets/ *
+recursive-include ethpm/assets *
 recursive-include ethpm/ethpm-spec/examples *
 recursive-include ethpm/ethpm-spec/spec *

--- a/newsfragments/3046.bugfix.rst
+++ b/newsfragments/3046.bugfix.rst
@@ -1,0 +1,1 @@
+Test wheel build in separate directory and virtualenv

--- a/tox.ini
+++ b/tox.ini
@@ -79,12 +79,9 @@ deps=
 allowlist_externals=
     /bin/rm
     /bin/bash
+    /bin/mktemp
 commands=
-    pip install --upgrade pip
-    /bin/rm -rf build dist
-    python -m build
-    /bin/bash -c 'pip install --upgrade "$(ls dist/web3-*-py3-none-any.whl)" --progress-bar off'
-    python -c "from web3 import Web3"
+    /bin/bash {toxinidir}/web3/scripts/release/test_wheel_install.sh
 skip_install=true
 
 [testenv:py311-wheel-cli-windows]
@@ -94,8 +91,5 @@ deps=
 allowlist_externals=
     bash.exe
 commands=
-    bash.exe -c "rm -rf build dist"
-    python -m build
-    bash.exe -c 'pip install --upgrade "$(ls dist/web3-*-py3-none-any.whl)" --progress-bar off'
-    python -c "from web3 import Web3"
+    bash.exe {toxinidir}/web3/scripts/release/test_windows_wheel_install.sh
 skip_install=true

--- a/web3/scripts/release/test_wheel_install.sh
+++ b/web3/scripts/release/test_wheel_install.sh
@@ -1,0 +1,7 @@
+rm -rf build dist
+python -m build
+cd $(mktemp -d)
+python -m venv venv-test
+source venv-test/bin/activate
+pip install --upgrade "$(ls ~/repo/dist/web3-*-py3-none-any.whl)"
+python -c "import web3"

--- a/web3/scripts/release/test_wheel_install.sh
+++ b/web3/scripts/release/test_wheel_install.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+
+set -e
 rm -rf build dist
 python -m build
 cd $(mktemp -d)

--- a/web3/scripts/release/test_windows_wheel_install.sh
+++ b/web3/scripts/release/test_windows_wheel_install.sh
@@ -1,0 +1,8 @@
+bash.exe -c "rm -rf build dist"
+python -m build
+bash.exe -c "export temp_dir=$(mktemp -d)"
+cd $temp_dir
+python -m venv venv-test
+bash.exe -c "source venv-test/Scripts/activate"
+bash.exe -c 'pip install --upgrade "$(ls /c/Users/circleci/project/web3py/dist/web3-*-py3-none-any.whl)" --progress-bar off'
+python -c "from web3 import Web3"

--- a/web3/scripts/release/test_windows_wheel_install.sh
+++ b/web3/scripts/release/test_windows_wheel_install.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+
+bash.exe -c "set -e"
 bash.exe -c "rm -rf build dist"
 python -m build
 bash.exe -c "export temp_dir=$(mktemp -d)"


### PR DESCRIPTION
### What was wrong?

`v6.6.0` was missing a few new, required, files in the release. The wheel tests should catch this, but they didn't this time. 

### How was it fixed?

Now the built files get installed in a new temporary directory and a separate virtualenv so that the dist files don't pick up the files that were present after the circleci code check out. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.natgeofe.com/n/c0e0a134-3e97-4b8f-9f7b-9d11f5e1bf02/comedy-wildlife-awards-squirel-stop.jpg)
