### PR TITLE
Catch if data is None in revert error

### DIFF
--- a/newsfragments/3054.bugfix.rst
+++ b/newsfragments/3054.bugfix.rst
@@ -1,0 +1,1 @@
+Handle case where data gets returned as ``None`` in a JSON-RPC error response

--- a/tests/core/utilities/test_method_formatters.py
+++ b/tests/core/utilities/test_method_formatters.py
@@ -101,6 +101,42 @@ SPACENETH_RESPONSE = RPCResponse(
     }
 )
 
+NONE_DATA_RESPONSE = RPCResponse(
+    {
+        "id": 24,
+        "jsonrpc": "2.0",
+        "error": {
+            "message": "execution reverted",
+            "code": -32000,
+            "data": None,
+        },
+    }
+)
+
+NONE_MESSAGE_RESPONSE = RPCResponse(
+    {
+        "id": 24,
+        "jsonrpc": "2.0",
+        "error": {
+            "message": None,
+            "code": -32000,
+            "data": "execution reverted",
+        },
+    }
+)
+
+NO_DATA_NO_MESSAGE_RESPONSE = RPCResponse(
+    {
+        "id": 24,
+        "jsonrpc": "2.0",
+        "error": {
+            "message": None,
+            "code": -32000,
+            "data": None,
+        },
+    }
+)
+
 
 @pytest.mark.parametrize(
     "response,expected",
@@ -116,6 +152,18 @@ SPACENETH_RESPONSE = RPCResponse(
             SPACENETH_RESPONSE,
             "execution reverted: OwnerId does not exist in registry",
         ),
+        (
+            NONE_DATA_RESPONSE,
+            "execution reverted",
+        ),
+        (
+            NONE_MESSAGE_RESPONSE,
+            "execution reverted",
+        ),
+        (
+            NO_DATA_NO_MESSAGE_RESPONSE,
+            "execution reverted",
+        ),
     ),
     ids=[
         "test-get-revert-reason-with-msg",
@@ -123,6 +171,9 @@ SPACENETH_RESPONSE = RPCResponse(
         "test-get-geth-revert-reason",
         "test_get-ganache-revert-reason",
         "test_get-spaceneth-revert-reason",
+        "test_none-data-response",
+        "test_none-message-response",
+        "test_no-data-no-message-response",
     ],
 )
 def test_get_revert_reason(response, expected) -> None:


### PR DESCRIPTION
### What was wrong?
Needed to handle the case when the data key in the JSON-RPC error response was `None`.

Related to Issue #3051 

### How was it fixed?
Added a check.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://assets.slice.ca/wp-content/uploads/2019/03/funny-animals-caught-on-camera-right-time-squirrel-stretch.jpg)
