### PR TITLE
fix default windows ipc provider path

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -173,7 +173,7 @@ IPCProvider
 
     - On Linux and FreeBSD: ``~/.ethereum/geth.ipc``
     - On Mac OS: ``~/Library/Ethereum/geth.ipc``
-    - On Windows: ``\\\.\pipe\geth.ipc``
+    - On Windows: ``\\.\pipe\geth.ipc``
 
 
 WebsocketProvider

--- a/newsfragments/3058.bugfix.rst
+++ b/newsfragments/3058.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed default windows IPC provider path to work with python 3.11

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -102,7 +102,7 @@ def get_default_ipc_path() -> Optional[str]:
         return None
 
     elif sys.platform == "win32":
-        ipc_path = os.path.join("\\\\", ".", "pipe", "geth.ipc")
+        ipc_path = r"\\.\pipe\geth.ipc"
         if os.path.exists(ipc_path):
             return ipc_path
         return None


### PR DESCRIPTION
### What was wrong?

`os.path.join` seems to add additional backslashes in py3.11 on windows. I couldn't find a reason/changelog explanation, but at least found someone with the same problem: https://stackoverflow.com/questions/76107858/python-3-10-3-11-changes-on-os-path-join

Closes #3058 

### How was it fixed?

Changed the default path to `r"\\.\pipe\geth.ipc"`. Tested against py3.9, 10, and 11 on Windows 10.

Updated docs to match [geth](https://geth.ethereum.org/docs/interacting-with-geth/rpc#ipc-server).

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/1643a6a7-a3a0-4073-b42c-5e49ad78c939)
