### PR TITLE
recursive typing for ABIFunctionComponents

### DIFF
--- a/newsfragments/3063.internal.rst
+++ b/newsfragments/3063.internal.rst
@@ -1,0 +1,1 @@
+Added recursive typing to ``ABIFunctionComponents`` type

--- a/web3/types.py
+++ b/web3/types.py
@@ -90,9 +90,7 @@ class ABIEvent(TypedDict, total=False):
 
 
 class ABIFunctionComponents(TypedDict, total=False):
-    # better typed as Sequence['ABIFunctionComponents'], but recursion not possible yet
-    # https://github.com/python/mypy/issues/731
-    components: Sequence[Any]
+    components: Sequence["ABIFunctionComponents"]
     name: str
     type: str
 


### PR DESCRIPTION
### What was wrong?

The `ABIFunctionComponents` type is better typed recursively, but mypy did not allow it previously. It does now.

### How was it fixed?

Added recursive type  and removed note.

I looked through the lib for other places this kind of change might be appropriate but couldn't identify any.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/b31403b5-a6f9-4a79-b289-f0bfc85fb3e6)

