### PR TITLE
Upgrade eth-tester

### DIFF
--- a/newsfragments/3064.internal.rst
+++ b/newsfragments/3064.internal.rst
@@ -1,0 +1,1 @@
+Upgrade eth-tester requirement to v0.9.0-b.1

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import (
 
 extras_require = {
     "tester": [
-        "eth-tester[py-evm]==v0.9.0-b.2",
+        "eth-tester[py-evm]==v0.9.1-b.1",
         "py-geth>=3.11.0",
     ],
     "linter": [


### PR DESCRIPTION
### What was wrong?

eth-tester needed to be upgraded in web3


### How was it fixed?

upgraded!

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://paradepets.com/.image/c_limit%2Ccs_srgb%2Cq_auto:good%2Cw_724/MTkxMzY1Nzg3ODY4NDA3Mzk0/short-eared-elephant-shrew-macroscelides-proboscideus.webp)
