### PR TITLE
Fix rpc gas strategy

### DIFF
--- a/newsfragments/3065.bugfix.rst
+++ b/newsfragments/3065.bugfix.rst
@@ -1,0 +1,1 @@
+Fix return type for ``rpc_gas_price_strategy`` to ``int`` but also only convert the ``strategy_based_gas_price`` to ``hex`` if it is an ``int`` in the ``gas_price_strategy_middleware``.

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -689,6 +689,29 @@ class AsyncEthModuleTest:
         async_w3.eth.set_gas_price_strategy(None)  # reset strategy
 
     @pytest.mark.asyncio
+    async def test_gas_price_strategy_middleware_hex_value(
+        self, async_w3: "AsyncWeb3", async_unlocked_account_dual_type: ChecksumAddress
+    ) -> None:
+        txn_params: TxParams = {
+            "from": async_unlocked_account_dual_type,
+            "to": async_unlocked_account_dual_type,
+            "value": Wei(1),
+            "gas": 21000,
+        }
+        two_gwei_in_wei = async_w3.to_wei(2, "gwei")
+
+        def gas_price_strategy(_w3: "Web3", _txn: TxParams) -> str:
+            return hex(two_gwei_in_wei)
+
+        async_w3.eth.set_gas_price_strategy(gas_price_strategy)  # type: ignore
+
+        txn_hash = await async_w3.eth.send_transaction(txn_params)
+        txn = await async_w3.eth.get_transaction(txn_hash)
+
+        assert txn["gasPrice"] == two_gwei_in_wei
+        async_w3.eth.set_gas_price_strategy(None)  # reset strategy
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "max_fee", (1000000000, None), ids=["with_max_fee", "without_max_fee"]
     )
@@ -3197,6 +3220,28 @@ class EthModuleTest:
         ):
             w3.eth.send_transaction(txn_params)
 
+        w3.eth.set_gas_price_strategy(None)  # reset strategy
+
+    def test_gas_price_strategy_middleware_hex_value(
+        self, w3: "Web3", unlocked_account_dual_type: ChecksumAddress
+    ) -> None:
+        txn_params: TxParams = {
+            "from": unlocked_account_dual_type,
+            "to": unlocked_account_dual_type,
+            "value": Wei(1),
+            "gas": 21000,
+        }
+        two_gwei_in_wei = w3.to_wei(2, "gwei")
+
+        def gas_price_strategy(_w3: "Web3", _txn: TxParams) -> str:
+            return hex(two_gwei_in_wei)
+
+        w3.eth.set_gas_price_strategy(gas_price_strategy)  # type: ignore
+
+        txn_hash = w3.eth.send_transaction(txn_params)
+        txn = w3.eth.get_transaction(txn_hash)
+
+        assert txn["gasPrice"] == two_gwei_in_wei
         w3.eth.set_gas_price_strategy(None)  # reset strategy
 
     def test_eth_replace_transaction_legacy(

--- a/web3/gas_strategies/rpc.py
+++ b/web3/gas_strategies/rpc.py
@@ -5,9 +5,6 @@ from typing import (
 from web3 import (
     Web3,
 )
-from web3._utils.rpc_abi import (
-    RPC,
-)
 from web3.types import (
     TxParams,
     Wei,
@@ -20,4 +17,4 @@ def rpc_gas_price_strategy(
     """
     A simple gas price strategy deriving it's value from the eth_gasPrice JSON-RPC call.
     """
-    return w3.manager.request_blocking(RPC.eth_gasPrice, [])
+    return w3.eth.gas_price

--- a/web3/middleware/gas_price_strategy.py
+++ b/web3/middleware/gas_price_strategy.py
@@ -7,6 +7,9 @@ from typing import (
 from eth_utils.toolz import (
     assoc,
 )
+from web3._utils.method_formatters import (
+    to_integer_if_hex,
+)
 
 from web3._utils.utility_methods import (
     all_in_dict,
@@ -45,7 +48,9 @@ def validate_transaction_params(
         and "gasPrice" not in transaction
         and none_in_dict(DYNAMIC_FEE_TXN_PARAMS, transaction)
     ):
-        transaction = assoc(transaction, "gasPrice", hex(strategy_based_gas_price))
+        transaction = assoc(
+            transaction, "gasPrice", to_integer_if_hex(strategy_based_gas_price)
+        )
 
     # legacy and dynamic fee tx variables used:
     if "gasPrice" in transaction and any_in_dict(DYNAMIC_FEE_TXN_PARAMS, transaction):

--- a/web3/middleware/gas_price_strategy.py
+++ b/web3/middleware/gas_price_strategy.py
@@ -7,10 +7,10 @@ from typing import (
 from eth_utils.toolz import (
     assoc,
 )
-from web3._utils.method_formatters import (
-    to_integer_if_hex,
-)
 
+from web3._utils.method_formatters import (
+    to_hex_if_integer,
+)
 from web3._utils.utility_methods import (
     all_in_dict,
     any_in_dict,
@@ -49,7 +49,7 @@ def validate_transaction_params(
         and none_in_dict(DYNAMIC_FEE_TXN_PARAMS, transaction)
     ):
         transaction = assoc(
-            transaction, "gasPrice", to_integer_if_hex(strategy_based_gas_price)
+            transaction, "gasPrice", to_hex_if_integer(strategy_based_gas_price)
         )
 
     # legacy and dynamic fee tx variables used:


### PR DESCRIPTION
### What was wrong?

- `rpc_gas_price_strategy` incorrectly returns the hex value without convesion to `int` even though the defined return type is `Wei`.
- We don't have tests to catch this
- bonus: Let's also not assume the value will always be an `int` and only convert to `hex` if it is an `int` in the `gas_price_strategy_middleware`.

### How was it fixed?

- In the `rpc_gas_price_strategy`, use the `eth` module `gas_price` call which always returns an `int`, rather than `request_blocking` which can be variable depending on the provider.
- Convert `gasPrice` value from strategy to `hex` only if it's an `int`
- Add tests that would've failed before this change. The reason here is we only test on EthereumTesterProvider (core test suite)... but eth-tester already returns an `int`, even though most providers return the `hex` value.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.arrowexterminators.com/assets/istock-594051380_Pg8DZzX.jpg)
