### PR TITLE
Add ens name-to-address support for eth_subscribe method

### DIFF
--- a/newsfragments/3066.feature.rst
+++ b/newsfragments/3066.feature.rst
@@ -1,0 +1,1 @@
+ENS name-to-address support for ``eth_subscribe``.


### PR DESCRIPTION
### What was wrong?

- `eth_subscribe` request for "logs" takes an optional dict arg that can include an address param. This case isn't supported by the usual flow for the rpc-abi request formatters because those parse *either* sequence args to methods *or* dict args, but not dict args within list sequences... e.g. `("logs", {"address": "0x...", "topics": ["0x...", "0x..."]})`

### How was it fixed?

- Parse this special case differently in the middleware for async ENS name-to-address.

Note: It isn't ideal to not add a test here. However, we don't yet have a good test flow for `eth_subscribe`. Since this is still in beta, via WebsocketProviderV2, I suggest to test this locally and we can work on `eth_subscribe` tests separately.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

MidJourney's interpretation of "a websocket as an animal":

<img width="349" alt="Screenshot 2023-08-01 at 15 52 38" src="https://github.com/ethereum/web3.py/assets/3532824/346712b4-e213-4bae-adbe-7989ef16870d">
