### PR TITLE
Websockets v2 iterator

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -233,7 +233,24 @@ WebsocketProviderV2 (beta)
     * ``call_timeout`` is the timeout in seconds, used when receiving or sending data
       over the connection. Defaults to ``None`` (no timeout).
 
-    .. code-block:: python
+    Under the hood, the ``WebsocketProviderV2`` uses the python websockets library for
+    making requests.  If you would like to modify how requests are made, you can
+    use the ``websocket_kwargs`` to do so.  See the `websockets documentation`_ for
+    available arguments.
+
+    The timeout for each call to send or receive is controlled by a ``call_timeout``
+    argument. This is set to ``None`` by default, which means no timeout.
+
+Usage
+~~~~~
+
+The ``AsyncWeb3`` class may be used as a context manager, utilizing the ``async with``
+syntax, when connecting via ``persistent_connection()`` using the
+``WebsocketProviderV2``. This will automatically close the connection when the context
+manager exits. A similar example, using the ``websockets`` connection as an
+asynchronous context manager, can be found in the `websockets connection`_ docs.
+
+.. code-block:: python
 
         >>> import asyncio
         >>> from web3 import AsyncWeb3
@@ -246,7 +263,7 @@ WebsocketProviderV2 (beta)
         ...     logger.setLevel(logging.DEBUG)
         ...     logger.addHandler(logging.StreamHandler())
 
-        >>> async def ws_v2_subscription_example():
+        >>> async def ws_v2_subscription_context_manager_example():
         ...     async with AsyncWeb3.persistent_websocket(
         ...         WebsocketProviderV2(f"ws://127.0.0.1:8546")
         ...     ) as w3:
@@ -272,16 +289,36 @@ WebsocketProviderV2 (beta)
         ...         # the connection closes automatically when exiting the context
         ...         # manager (the `async with` block)
 
-        >>> asyncio.run(ws_v2_subscription_example())
+        >>> asyncio.run(ws_v2_subscription_context_manager_example())
 
 
-    Under the hood, the ``WebsocketProviderV2`` uses the python websockets library for
-    making requests.  If you would like to modify how requests are made, you can
-    use the ``websocket_kwargs`` to do so.  See the `websockets documentation`_ for
-    available arguments.
+The ``AsyncWeb3`` class may also be used as an asynchronous iterator, utilizing the
+``async for`` syntax, when connecting via ``persistent_connection()`` using the
+``WebsocketProviderV2``. This may be used to set up an indefinite websocket connection
+and reconnect automatically if the connection is lost. A similar example, using the
+``websockets`` connection as an asynchronous iterator, can be found in the
+`websockets connection`_ docs.
 
-    The timeout for each call to send or receive is controlled by a ``call_timeout``
-    argument. This is set to ``None`` by default, which means no timeout.
+.. _`websockets connection`: https://websockets.readthedocs.io/en/stable/reference/asyncio/client.html#websockets.client.connect
+
+.. code-block:: python
+
+    >>> import asyncio
+    >>> from web3 import AsyncWeb3
+    >>> from web3.providers import WebsocketProviderV2
+    >>> import websockets
+
+    >>> async def ws_v2_subscription_iterator_example():
+    ...     async for w3 in AsyncWeb3.persistent_websocket(
+    ...         WebsocketProviderV2(f"ws://127.0.0.1:8546")
+    ...     ):
+    ...         try:
+    ...             ...
+    ...         except websockets.ConnectionClosed:
+    ...             continue
+
+    >>> asyncio.run(ws_v2_subscription_iterator_example())
+
 
 
 AutoProvider

--- a/newsfragments/3067.bugfix.rst
+++ b/newsfragments/3067.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the type for the optional param asking for "full transactions" when subscribing to ``newPendingTransactions`` via ``eth_subscribe`` to ``bool``.

--- a/newsfragments/3067.feature.rst
+++ b/newsfragments/3067.feature.rst
@@ -1,0 +1,1 @@
+Asynchronous iterator support for ``AsyncWeb3`` with ``WebsocketProviderV2`` using ``async for`` syntax.

--- a/tests/integration/go_ethereum/test_goethereum_ws_v2/conftest.py
+++ b/tests/integration/go_ethereum/test_goethereum_ws_v2/conftest.py
@@ -1,0 +1,49 @@
+import pytest
+
+from tests.integration.common import (
+    COINBASE,
+)
+from tests.utils import (
+    get_open_port,
+)
+
+
+@pytest.fixture(scope="module")
+def ws_port():
+    return get_open_port()
+
+
+@pytest.fixture(scope="module")
+def endpoint_uri(ws_port):
+    return f"ws://localhost:{ws_port}"
+
+
+def _geth_command_arguments(ws_port, base_geth_command_arguments, geth_version):
+    yield from base_geth_command_arguments
+    if geth_version.major == 1:
+        yield from (
+            "--miner.etherbase",
+            COINBASE[2:],
+            "--ws",
+            "--ws.port",
+            ws_port,
+            "--ws.api",
+            "admin,eth,net,web3,personal,miner",
+            "--ws.origins",
+            "*",
+            "--ipcdisable",
+            "--allow-insecure-unlock",
+        )
+        if geth_version.minor not in [10, 11]:
+            raise AssertionError("Unsupported Geth version")
+    else:
+        raise AssertionError("Unsupported Geth version")
+
+
+@pytest.fixture(scope="module")
+def geth_command_arguments(
+    geth_binary, get_geth_version, datadir, ws_port, base_geth_command_arguments
+):
+    return _geth_command_arguments(
+        ws_port, base_geth_command_arguments, get_geth_version
+    )

--- a/tests/integration/go_ethereum/test_goethereum_ws_v2/test_async_generator_w3.py
+++ b/tests/integration/go_ethereum/test_goethereum_ws_v2/test_async_generator_w3.py
@@ -2,12 +2,6 @@ import pytest
 
 import pytest_asyncio
 
-from tests.integration.common import (
-    COINBASE,
-)
-from tests.utils import (
-    get_open_port,
-)
 from web3 import (
     AsyncWeb3,
     WebsocketProviderV2,
@@ -19,54 +13,13 @@ from web3._utils.module_testing.go_ethereum_personal_module import (
     GoEthereumAsyncPersonalModuleTest,
 )
 
-from .common import (
+from ..common import (
     GoEthereumAsyncEthModuleTest,
     GoEthereumAsyncNetModuleTest,
 )
-from .utils import (
+from ..utils import (
     wait_for_aiohttp,
 )
-
-
-@pytest.fixture(scope="module")
-def ws_port():
-    return get_open_port()
-
-
-@pytest.fixture(scope="module")
-def endpoint_uri(ws_port):
-    return f"ws://localhost:{ws_port}"
-
-
-def _geth_command_arguments(ws_port, base_geth_command_arguments, geth_version):
-    yield from base_geth_command_arguments
-    if geth_version.major == 1:
-        yield from (
-            "--miner.etherbase",
-            COINBASE[2:],
-            "--ws",
-            "--ws.port",
-            ws_port,
-            "--ws.api",
-            "admin,eth,net,web3,personal,miner",
-            "--ws.origins",
-            "*",
-            "--ipcdisable",
-            "--allow-insecure-unlock",
-        )
-        if geth_version.minor not in [10, 11]:
-            raise AssertionError("Unsupported Geth version")
-    else:
-        raise AssertionError("Unsupported Geth version")
-
-
-@pytest.fixture(scope="module")
-def geth_command_arguments(
-    geth_binary, get_geth_version, datadir, ws_port, base_geth_command_arguments
-):
-    return _geth_command_arguments(
-        ws_port, base_geth_command_arguments, get_geth_version
-    )
 
 
 @pytest_asyncio.fixture(scope="module")
@@ -79,12 +32,14 @@ async def async_w3(geth_process, endpoint_uri):
 
 
 class TestGoEthereumAsyncAdminModuleTest(GoEthereumAsyncAdminModuleTest):
+    @pytest.mark.asyncio
     @pytest.mark.xfail(
         reason="running geth with the --nodiscover flag doesn't allow peer addition"
     )
     async def test_admin_peers(self, async_w3: "AsyncWeb3") -> None:
         await super().test_admin_peers(async_w3)
 
+    @pytest.mark.asyncio
     async def test_admin_start_stop_http(self, async_w3: "AsyncWeb3") -> None:
         # This test causes all tests after it to fail on CI if it's allowed to run
         pytest.xfail(
@@ -92,6 +47,7 @@ class TestGoEthereumAsyncAdminModuleTest(GoEthereumAsyncAdminModuleTest):
         )
         await super().test_admin_start_stop_http(async_w3)
 
+    @pytest.mark.asyncio
     async def test_admin_start_stop_ws(self, async_w3: "AsyncWeb3") -> None:
         # This test inconsistently causes all tests after it to
         # fail on CI if it's allowed to run

--- a/tests/integration/go_ethereum/test_goethereum_ws_v2/test_async_iterator_w3.py
+++ b/tests/integration/go_ethereum/test_goethereum_ws_v2/test_async_iterator_w3.py
@@ -1,0 +1,69 @@
+import pytest
+
+import pytest_asyncio
+
+from web3 import (
+    AsyncWeb3,
+    WebsocketProviderV2,
+)
+from web3._utils.module_testing.go_ethereum_admin_module import (
+    GoEthereumAsyncAdminModuleTest,
+)
+from web3._utils.module_testing.go_ethereum_personal_module import (
+    GoEthereumAsyncPersonalModuleTest,
+)
+
+from ..common import (
+    GoEthereumAsyncEthModuleTest,
+    GoEthereumAsyncNetModuleTest,
+)
+from ..utils import (
+    wait_for_aiohttp,
+)
+
+
+@pytest_asyncio.fixture(scope="module")
+async def async_w3(geth_process, endpoint_uri):
+    await wait_for_aiohttp(endpoint_uri)
+    async for w3 in AsyncWeb3.persistent_websocket(
+        WebsocketProviderV2(endpoint_uri, call_timeout=30)
+    ):
+        return w3
+
+
+class TestGoEthereumAsyncAdminModuleTest(GoEthereumAsyncAdminModuleTest):
+    @pytest.mark.asyncio
+    @pytest.mark.xfail(
+        reason="running geth with the --nodiscover flag doesn't allow peer addition"
+    )
+    async def test_admin_peers(self, async_w3: "AsyncWeb3") -> None:
+        await super().test_admin_peers(async_w3)
+
+    @pytest.mark.asyncio
+    async def test_admin_start_stop_http(self, async_w3: "AsyncWeb3") -> None:
+        # This test causes all tests after it to fail on CI if it's allowed to run
+        pytest.xfail(
+            reason="Only one HTTP endpoint is allowed to be active at any time"
+        )
+        await super().test_admin_start_stop_http(async_w3)
+
+    @pytest.mark.asyncio
+    async def test_admin_start_stop_ws(self, async_w3: "AsyncWeb3") -> None:
+        # This test inconsistently causes all tests after it to
+        # fail on CI if it's allowed to run
+        pytest.xfail(
+            reason="Only one WebSocket endpoint is allowed to be active at any time"
+        )
+        await super().test_admin_start_stop_ws(async_w3)
+
+
+class TestGoEthereumAsyncEthModuleTest(GoEthereumAsyncEthModuleTest):
+    pass
+
+
+class TestGoEthereumAsyncNetModuleTest(GoEthereumAsyncNetModuleTest):
+    pass
+
+
+class TestGoEthereumAsyncPersonalModuleTest(GoEthereumAsyncPersonalModuleTest):
+    pass

--- a/tox.ini
+++ b/tox.ini
@@ -30,8 +30,8 @@ commands=
     integration-goethereum-http_flaky: pytest {posargs:tests/integration/go_ethereum/test_goethereum_http.py --flaky}
     integration-goethereum-ws: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ws.py}
     integration-goethereum-ws_flaky: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ws.py --flaky}
-    integration-goethereum-ws-v2: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ws_v2.py}
-    integration-goethereum-ws-v2_flaky: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ws_v2.py --flaky}
+    integration-goethereum-ws-v2: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ws_v2}
+    integration-goethereum-ws-v2_flaky: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ws_v2 --flaky}
     integration-ethtester: pytest {posargs:tests/integration/test_ethereum_tester.py}
     docs: make -C {toxinidir} validate-docs
 deps =

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -86,7 +86,6 @@ from web3.types import (
     TxData,
     TxParams,
     TxReceipt,
-    TxTypeSubscriptionArg,
     Wei,
     _Hash32,
 )
@@ -669,7 +668,7 @@ class AsyncEth(BaseEth):
         Callable[
             [
                 SubscriptionType,
-                Optional[Union[LogsSubscriptionArg, TxTypeSubscriptionArg]],
+                Optional[Union[LogsSubscriptionArg, bool]],
             ],
             Awaitable[HexStr],
         ]
@@ -682,7 +681,10 @@ class AsyncEth(BaseEth):
         self,
         subscription_type: SubscriptionType,
         subscription_arg: Optional[
-            Union[LogsSubscriptionArg, TxTypeSubscriptionArg]
+            Union[
+                LogsSubscriptionArg,  # logs, optional filter params
+                bool,  # newPendingTransactions, full_transactions
+            ]
         ] = None,
     ) -> HexStr:
         if not isinstance(self.w3.provider, PersistentConnectionProvider):

--- a/web3/main.py
+++ b/web3/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import decimal
 import warnings
 from types import (
@@ -33,6 +34,7 @@ from hexbytes import (
 )
 from typing import (
     Any,
+    AsyncIterator,
     Dict,
     List,
     Optional,
@@ -538,6 +540,16 @@ class _PersistentConnectionWeb3(AsyncWeb3):
             )
         AsyncWeb3.__init__(self, provider, middlewares, modules, external_modules, ens)
 
+    # async for w3 in w3.persistent_websocket(provider)
+    async def __aiter__(self) -> AsyncIterator["_PersistentConnectionWeb3"]:
+        while True:
+            try:
+                yield self
+            except Exception:
+                # provider should handle connection / reconnection
+                continue
+
+    # async with w3.persistent_websocket(provider) as w3
     async def __aenter__(self) -> "_PersistentConnectionWeb3":
         await self.provider.connect()
         return self

--- a/web3/main.py
+++ b/web3/main.py
@@ -1,4 +1,3 @@
-import asyncio
 import decimal
 import warnings
 from types import (

--- a/web3/providers/websocket/websocket_v2.py
+++ b/web3/providers/websocket/websocket_v2.py
@@ -136,6 +136,7 @@ class WebsocketProviderV2(PersistentConnectionProvider):
 
     async def disconnect(self) -> None:
         await self.ws.close()
+        self.ws = None
 
         # clear the provider request cache after disconnecting
         self._async_response_processing_cache.clear()

--- a/web3/types.py
+++ b/web3/types.py
@@ -546,7 +546,3 @@ class LogsSubscriptionArg(TypedDict, total=False):
         Sequence[Union[Address, ChecksumAddress, ENS]],
     ]
     topics: Sequence[Union[HexStr, Sequence[HexStr]]]
-
-
-class TxTypeSubscriptionArg(TypedDict, total=False):
-    full_transactions: bool


### PR DESCRIPTION
PR Summary:

- Add asynchronous iterator functionality to the ``AsyncWeb3`` with ``WebsocketProviderV2`` via ``persistent_connection()``
- (bugfix) Fix typing for the optional "full_transactions" boolean param when subscribing to "newPendingTransactions"
- Split ``WebsocketProviderV2`` tests into asynchronous generator / context manager (async with) and asynchronous iterator (async for) tests
- Add docs for async iterator setup

Peripheral changes:

- Add a bit more connection debugging with exponential backoff when connecting via ``WebsocketProviderV2``. Keep re-connection attempts reasonable at ``5`` for now.
- Use a better system for the heartbeat / ``is_connected()`` method for wsV2, as recommended by the ``websockets`` library, use the unsolicited pong call.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="347" alt="Screenshot 2023-07-28 at 16 29 51" src="https://github.com/ethereum/web3.py/assets/3532824/601c101a-1b98-42de-8531-519d94281045">

