### PR TITLE
Minor internal fixes

### DIFF
--- a/newsfragments/3069.internal.rst
+++ b/newsfragments/3069.internal.rst
@@ -1,0 +1,1 @@
+Minor fixes to type hinting in the core tests setup fixtures.

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -3,10 +3,7 @@ import pytest
 import pytest_asyncio
 
 from web3 import (
-    Web3,
-)
-from web3.eth import (
-    AsyncEth,
+    AsyncWeb3,
 )
 from web3.module import (
     Module,
@@ -119,18 +116,16 @@ def module_many_init_args():
     return ModuleManyArgs
 
 
-@pytest_asyncio.fixture()
+@pytest_asyncio.fixture
 async def async_w3():
-    provider = AsyncEthereumTesterProvider()
-    w3 = Web3(provider, modules={"eth": [AsyncEth]}, middlewares=provider.middlewares)
+    w3 = AsyncWeb3(AsyncEthereumTesterProvider())
     w3.eth.default_account = await w3.eth.coinbase
     return w3
 
 
-@pytest_asyncio.fixture()
+@pytest_asyncio.fixture
 async def async_w3_non_strict_abi():
-    provider = AsyncEthereumTesterProvider()
-    w3 = Web3(provider, modules={"eth": [AsyncEth]}, middlewares=provider.middlewares)
+    w3 = AsyncWeb3(AsyncEthereumTesterProvider())
     w3.strict_bytes_type_checking = False
     w3.eth.default_account = await w3.eth.coinbase
     return w3

--- a/tests/core/eth-module/test_accounts.py
+++ b/tests/core/eth-module/test_accounts.py
@@ -26,10 +26,10 @@ from hexbytes import (
 
 from web3 import (
     Account,
+    AsyncWeb3,
     Web3,
 )
 from web3.eth import (
-    AsyncEth,
     BaseEth,
 )
 from web3.providers.eth_tester import (
@@ -557,7 +557,7 @@ def test_eth_account_sign_and_send_EIP155_transaction_to_eth_tester(
 
 @pytest.fixture()
 def async_w3():
-    return Web3(AsyncEthereumTesterProvider(), modules={"eth": [AsyncEth]})
+    return AsyncWeb3(AsyncEthereumTesterProvider())
 
 
 @patch("web3.eth.BaseEth.account", "wired via BaseEth")

--- a/tests/core/middleware/test_attrdict_middleware.py
+++ b/tests/core/middleware/test_attrdict_middleware.py
@@ -1,6 +1,7 @@
 import pytest
 
 from web3 import (
+    AsyncWeb3,
     EthereumTesterProvider,
     Web3,
 )
@@ -98,7 +99,7 @@ def test_no_attrdict_middleware_does_not_convert_dicts_to_attrdict():
 
 @pytest.mark.asyncio
 async def test_async_attrdict_middleware_default_for_async_ethereum_tester_provider():
-    async_w3 = Web3(AsyncEthereumTesterProvider())
+    async_w3 = AsyncWeb3(AsyncEthereumTesterProvider())
     assert async_w3.middleware_onion.get("attrdict") == async_attrdict_middleware
 
 
@@ -132,7 +133,7 @@ async def test_async_attrdict_middleware_is_recursive(async_w3):
 
 @pytest.mark.asyncio
 async def test_no_async_attrdict_middleware_does_not_convert_dicts_to_attrdict():
-    async_w3 = Web3(AsyncEthereumTesterProvider())
+    async_w3 = AsyncWeb3(AsyncEthereumTesterProvider())
 
     async_w3.middleware_onion.inject(
         await async_construct_result_generator_middleware(


### PR DESCRIPTION
### What was wrong?

- Some of our tests were still using the `Web3` class with async providers in the setup. Use `AsyncWeb3`. I don't believe this should have much of an effect other than the type hinting being corrected.

### How was it fixed?

- `Web3(async_provider)` -> `AsyncWeb3(async_provider)`

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://ih1.redbubble.net/image.5012305793.1528/st,small,507x507-pad,600x600,f8f8f8.jpg)
