### PR TITLE
Update async http docs

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -359,11 +359,6 @@ AsyncHTTPProvider
     `aiohttp <https://docs.aiohttp.org/en/stable/>`_ library for making requests.
 
 
-    The ``AsyncHTTPProvider`` has almost all the same functionality available as the ``HTTPProvider``.
-    The only documented exceptions to this are:
-
-
-    - **ENS Address Lookup** - It can't resolve :class:`ENS` addresses yet. 
     - **Available Middleware** - These middlewares have async versions available:
 
         - :meth:`Attribute Dict Middleware <web3.middleware.async_attrdict_middleware>`
@@ -373,7 +368,9 @@ AsyncHTTPProvider
         - :meth:`Local Filter Middleware <web3.middleware.async_local_filter_middleware>`
         - :meth:`Simple Cache Middleware <web3.middleware.async_construct_simple_cache_middleware>`
         - :meth:`Stalecheck Middleware <web3.middleware.async_make_stalecheck_middleware>`
-        - :meth:`Validation Middleware <web3.middleware.async_validation>`
+        - :meth:`Validation Middleware <web3.middleware.async_validation_middleware>`
+        - :meth:`Name to Address Middleware <web3.middleware.async_name_to_address_middleware>`
+
 
 
 .. py:currentmodule:: web3.providers.eth_tester

--- a/newsfragments/3070.docs.rst
+++ b/newsfragments/3070.docs.rst
@@ -1,0 +1,1 @@
+Change docs to reflect AsyncHTTPProvider does accept ENS names now

--- a/web3/_utils/compat/__init__.py
+++ b/web3/_utils/compat/__init__.py
@@ -10,6 +10,7 @@
 
 from typing_extensions import (  # noqa: F401
     Literal,  # py38
+    NotRequired,  # py311
     Protocol,  # py38
     TypedDict,  # py38
     Self,  # py311

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -142,7 +142,7 @@ def _make_response(result: Any, message: str = "") -> RPCResponse:
             {
                 "id": 1,
                 "jsonrpc": "2.0",
-                "error": RPCError({"code": -32601, "message": message, "data": None}),
+                "error": RPCError({"code": -32601, "message": message}),
             }
         )
 

--- a/web3/types.py
+++ b/web3/types.py
@@ -26,6 +26,7 @@ from hexbytes import (
 
 from web3._utils.compat import (
     Literal,
+    NotRequired,
     TypedDict,
 )
 from web3._utils.function_identifiers import (
@@ -129,7 +130,7 @@ class EventData(TypedDict):
 class RPCError(TypedDict):
     code: int
     message: str
-    data: Optional[str]
+    data: NotRequired[str]
 
 
 # syntax b/c "from" keyword not allowed w/ class construction


### PR DESCRIPTION
### What was wrong?

- The AsyncHTTPProvider docs still said that you couldn't use the ENS middleware, but you can. 
- Also removed the `data` key from the Eth-tester RPCError response to standardize with other clients. 

### How was it fixed?
Updated docs, and eth-tester error response. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/e/e9/Persian_sand_CAT.jpg)
