### PR TITLE
Add JSON-RPC fallback and MEV blocking tutorial

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -41,6 +41,10 @@ Frameworks and Tooling
   Brownie lacks active maintenance. 
   `See migration guide to ApeWorX <https://academy.apeworx.io/articles/porting-brownie-to-ape>`__.
 
+Tutorials
+---------
+
+- `Configuring Web3 for JSON-RPC fallback and MEV blocker providers <https://web3-ethereum-defi.readthedocs.io/tutorials/multi-rpc-configuration.html>`__
 
 Smart Contract Programming Languages
 ------------------------------------

--- a/newsfragments/3072.docs.rst
+++ b/newsfragments/3072.docs.rst
@@ -1,0 +1,1 @@
+Add MEV blocking tutorial to Resources docs page


### PR DESCRIPTION
### What was wrong?

Flaky JSON-RPC and frontrunning are harming the users of Web3.py library.

### How was it fixed?

Adding a tutorial on advanced MEV protection and JSON-RPC fallback configuration for `Web3`.
This tutorial uses a special `MultiProviderWeb3` class from [web3-ethereum-defi](https://github.com/tradingstrategy-ai/web3-ethereum-defi#make) package which allows complex JSON-RPC configurations.

The tutorial is linked in the external resources documentation section.

#### Cute Animal Picture

```
Art by Joan Stark

                   _ |\_
                   \` ..\
              __,.-" =__Y=
            ."        )
      _    /   ,    \/\_
     ((____|    )_-\ \_-`
jgs  `-----'`-----` `--`

```