### PR TITLE
fix type of `input` in `TxData`

### DIFF
--- a/newsfragments/3074.bugfix.rst
+++ b/newsfragments/3074.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the type for ``input`` in ``TxData`` from ``HexStr`` -> ``HexBytes``.

--- a/web3/types.py
+++ b/web3/types.py
@@ -148,7 +148,7 @@ TxData = TypedDict(
         "maxFeePerGas": Wei,
         "maxPriorityFeePerGas": Wei,
         "hash": HexBytes,
-        "input": HexStr,
+        "input": HexBytes,
         "nonce": Nonce,
         "r": HexBytes,
         "s": HexBytes,


### PR DESCRIPTION
The type of `input` in `TxData` is actually `HexBytes`(`bytes`), not `HexStr`(`str`).

```
>>> type(tx["input"])
<class 'hexbytes.main.HexBytes'>
```