### PR TITLE
Websockets bugfixes

### DIFF
--- a/newsfragments/3075.bugfix.rst
+++ b/newsfragments/3075.bugfix.rst
@@ -1,0 +1,1 @@
+Fix an issue with ``WebsocketProviderV2`` when responses to a request aren't found in the cache (``None`` values).

--- a/newsfragments/3076.bugfix.rst
+++ b/newsfragments/3076.bugfix.rst
@@ -1,0 +1,1 @@
+Re-expose some websockets constants found in ``web3.providers.websocket.websocket`` via ``web3.providers.websocket``.

--- a/web3/providers/websocket/__init__.py
+++ b/web3/providers/websocket/__init__.py
@@ -1,4 +1,6 @@
 from .websocket import (  # noqa: F401
+    DEFAULT_WEBSOCKET_TIMEOUT,
+    RESTRICTED_WEBSOCKET_KWARGS,
     WebsocketProvider,
 )
 from .websocket_v2 import (  # noqa: F401


### PR DESCRIPTION
### What was wrong?

- fixes one issue in #3075
- closes #3076

### How was it fixed?

- Put the `yield` in question in an isolated code block by moving the rest of the code into an `else` as the issue suggests.
- Re-expose some previously exposed constants related to websockets

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=http%3A%2F%2Fi.huffpost.com%2Fgen%2F911965%2Fimages%2Fo-CUTEST-BABY-ANIMAL-facebook.jpg&f=1&nofb=1&ipt=0ee5ac231fd0ed2f0d343ab688c9c583427ed216ccac0bdea8e782eb3ead8764&ipo=images)
