### PR TITLE
Fixed improper method call in `datastructures.py`

### DIFF
--- a/newsfragments/3080.bugfix.rst
+++ b/newsfragments/3080.bugfix.rst
@@ -1,0 +1,1 @@
+Return ``NotImplemented`` constant, rather than raising ``NotImplementedError`` for ``NamedElementOnion.__add__()``, based on Python standards.

--- a/web3/datastructures.py
+++ b/web3/datastructures.py
@@ -261,9 +261,8 @@ class NamedElementOnion(Mapping[TKey, TValue]):
 
     def __add__(self, other: Any) -> "NamedElementOnion[TKey, TValue]":
         if not isinstance(other, NamedElementOnion):
-            raise NotImplementedError(
-                "You can only combine with another NamedElementOnion"
-            )
+            # you can only combine with another ``NamedElementOnion``
+            return NotImplemented
         combined = self._queue.copy()
         combined.update(other._queue)
         return NamedElementOnion(cast(List[Any], combined.items()))


### PR DESCRIPTION
### What was wrong?
In Python, `NotImplementedError` exception should be raised by abstract classes/methods when they require the derived classes to override the method. And `NotImplemented` is a constant which should be returned by "special binary methods" such as- `__add__`, `__eq__`, `__lt__`, etc. to indicate that **the operation is not implemented with respect to other type.**

Since `NamedElementOnion` isn't derived from any classes, it's recommended and considered a good practice to use `NotImplemented` instead of `NotImplementedError`. [Here's](https://docs.python.org/3/library/numbers.html#implementing-the-arithmetic-operations) an example of how to implement binary operations for complex classes.

You can find more references here:
- https://docs.python.org/3/library/exceptions.html#NotImplementedError
- https://docs.python.org/3/library/constants.html#NotImplemented

### How was it fixed?
It was fixed by just replacing `NotImplementedError` exception with the constant `NotImplemented`

***

### CLA Requirements:
This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.

All contributed commits are already automatically signed off.

The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
- [Git Commit SignOff documentation](https://developercertificate.org/)

### Sponsorship and Support:
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed - to improve global software supply chain security.

The bug is found by running the iCR tool by [OpenRefactory, Inc.](https://openrefactory.com/) and then manually triaging the results.
