### PR TITLE
docs: add ape-hackathon-kit to resources

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -76,5 +76,6 @@ Applications
 Hackathon Helpers
 -----------------
 
+- `ape-hackathon-kit <https://github.com/wolovim/ape-hackathon-kit>`__ - Ape project template with a web front-end (Next.js, Tailwind, RainbowKit, wagmi)
 - `eth-flogger <https://github.com/wolovim/eth-flogger>`__ - Sample web app utilizing async web3.py, Flask, SQLite, Sourcify
 - `Temo <https://github.com/wolovim/temo>`__ - Sample terminal app utilizing async web3py, Textual, Anvil

--- a/newsfragments/3082.docs.rst
+++ b/newsfragments/3082.docs.rst
@@ -1,0 +1,1 @@
+Add an Ape hackathon kit to Resources documenation page


### PR DESCRIPTION
### What does it do?

- Adds a hackathon starter kit repo to the Resources docs page. 
   - Repo combines Ape for contract development and a Next.js web app on the front end.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://backyardbirdnerd.files.wordpress.com/2016/05/bb21.jpg)
