### PR TITLE
bugfix: release async lock only if locked

### DIFF
--- a/newsfragments/3083.bugfix.rst
+++ b/newsfragments/3083.bugfix.rst
@@ -1,0 +1,1 @@
+Only release ``async_lock`` if it's locked to begin with.

--- a/web3/_utils/async_caching.py
+++ b/web3/_utils/async_caching.py
@@ -18,4 +18,5 @@ async def async_lock(
         await loop.run_in_executor(thread_pool, lock.acquire)
         yield
     finally:
-        lock.release()
+        if lock.locked():
+            lock.release()


### PR DESCRIPTION
### What was wrong?

- closes #3081

### How was it fixed?

- Only release ``async_lock`` if it is locked.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fi.ebayimg.com%2Fimages%2Fg%2FbHIAAOSwy3JcAIzl%2Fs-l300.jpg&f=1&nofb=1&ipt=70c12dceb897721904b776e00a2f3ac1334d0bda5af98d24c3fb58069c556f54&ipo=images)
