### PR TITLE
Fix AsyncEth.max_priority_fee

### DIFF
--- a/newsfragments/3084.bugfix.rst
+++ b/newsfragments/3084.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes ``AsyncEth.max_priority_fee_per_gas``. It wasn't falling back to ``eth_feeHistory`` since the ``MethodUnavailable`` error was introduced.

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -189,7 +189,7 @@ class AsyncEth(BaseEth):
         """
         try:
             return await self._max_priority_fee()
-        except ValueError:
+        except (ValueError, MethodUnavailable):
             warnings.warn(
                 "There was an issue with the method eth_maxPriorityFeePerGas. "
                 "Calculating using eth_feeHistory."


### PR DESCRIPTION
### What was wrong?

Related to Issue https://github.com/ethereum/web3.py/pull/3002

### How was it fixed?

The issue https://github.com/ethereum/web3.py/pull/3002 was fixed for `Eth` class, not for `AsyncEth`. I have copied the fix to `AsyncEth`.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.ibb.co/FBpbyfw/snegir.jpg)
