### PR TITLE
fix bug in websocketProviderV2 docs

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -313,6 +313,7 @@ and reconnect automatically if the connection is lost. A similar example, using 
     ...         WebsocketProviderV2(f"ws://127.0.0.1:8546")
     ...     ):
     ...         try:
+    ...             await w3.provider.connect()
     ...             ...
     ...         except websockets.ConnectionClosed:
     ...             continue


### PR DESCRIPTION
### What was wrong?
The documentation example doesn't work. 

### How was it fixed?
Changed the documentation. 
### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](http://www.pixelstalk.net/wp-content/uploads/2016/03/Free-cute-animal-wallpaper-HD.jpg)
