### PR TITLE
Web3 on pyodide

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,8 @@ setup(
     url="https://github.com/ethereum/web3.py",
     include_package_data=True,
     install_requires=[
-        "aiohttp>=3.7.4.post0",
+        "aiohttp>=3.7.4.post0;sys_platform!='emscripten'",
+        "micropip;sys_platform=='emscripten'",
         "eth-abi>=4.0.0",
         "eth-account>=0.8.0",
         "eth-hash[pycryptodome]>=0.5.1",
@@ -81,7 +82,7 @@ setup(
         "pywin32>=223;platform_system=='Windows'",
         "requests>=2.16.0",
         "typing-extensions>=4.0.1",
-        "websockets>=10.0.0",
+        "websockets>=10.0.0;sys_platform!='emscripten'",
         "pyunormalize>=15.0.0",
     ],
     python_requires=">=3.7.2",

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ setup(
     include_package_data=True,
     install_requires=[
         "aiohttp>=3.7.4.post0;sys_platform!='emscripten'",
-        "micropip;sys_platform=='emscripten'",
         "eth-abi>=4.0.0",
         "eth-account>=0.8.0",
         "eth-hash[pycryptodome]>=0.5.1",
@@ -84,6 +83,9 @@ setup(
         "typing-extensions>=4.0.1",
         "websockets>=10.0.0;sys_platform!='emscripten'",
         "pyunormalize>=15.0.0",
+        # pyodide includes - unversioned to use the one from pyodide distribution
+        "micropip;sys_platform=='emscripten'",
+        "pyodide-http;sys_platform=='emscripten'"
     ],
     python_requires=">=3.7.2",
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,8 @@
 #!/usr/bin/env python
-from setuptools import (
-    find_packages,
-    setup,
-)
+from setuptools import find_packages, setup
 
 extras_require = {
-    "tester": [
-        "eth-tester[py-evm]==v0.9.1-b.1",
-        "py-geth>=3.11.0",
-    ],
+    "tester": ["eth-tester[py-evm]==v0.9.1-b.1", "py-geth>=3.11.0"],
     "linter": [
         "black>=22.1.0",
         "flake8==3.8.3",
@@ -18,11 +12,7 @@ extras_require = {
         "types-requests>=2.26.1",
         "types-protobuf==3.19.13",
     ],
-    "docs": [
-        "sphinx>=5.3.0",
-        "sphinx_rtd_theme>=1.0.0",
-        "towncrier>=21,<22",
-    ],
+    "docs": ["sphinx>=5.3.0", "sphinx_rtd_theme>=1.0.0", "towncrier>=21,<22"],
     "dev": [
         "bumpversion",
         "flaky>=3.7.0",
@@ -40,9 +30,7 @@ extras_require = {
         "when-changed>=0.3.0",
         "build>=0.9.0",
     ],
-    "ipfs": [
-        "ipfshttpclient==0.8.0a2",
-    ],
+    "ipfs": ["ipfshttpclient==0.8.0a2"],
 }
 
 extras_require["dev"] = (
@@ -85,7 +73,7 @@ setup(
         "pyunormalize>=15.0.0",
         # pyodide includes - unversioned to use the one from pyodide distribution
         "micropip;sys_platform=='emscripten'",
-        "pyodide-http;sys_platform=='emscripten'"
+        "pyodide-http;sys_platform=='emscripten'",
     ],
     python_requires=">=3.7.2",
     extras_require=extras_require,

--- a/web3/__init__.py
+++ b/web3/__init__.py
@@ -1,6 +1,42 @@
 from eth_account import Account  # noqa: E402,
 import pkg_resources
 
+if sys.platform=="emscripten":
+    # asynchronous connections and websockets aren't supported on
+    # emscripten yet. 
+    # We mock the aiohttp and websockets module so that things import okay
+    import micropip
+    micropip.add_mock_package("aiohttp","1.0.0",modules={
+        "aiohttp":'''
+class ClientSession:
+    def __init__(self,*args,**argv):
+        raise NotImplementedError("Async web3 functions aren't supported on pyodide yet")
+class ClientResponse:
+    def __init__(self,*args,**argv):
+        raise NotImplementedError("Async web3 functions aren't supported on pyodide yet")
+class ClientTimeout:
+    def __init__(self,*args,**argv):
+        raise NotImplementedError("Async web3 functions aren't supported on pyodide yet")
+'''} )
+    # mock websockets
+    micropip.add_mock_package("websockets","1.0.0",modules={"websockets":'',"websockets.legacy":'',
+        "websockets.legacy.client":'''
+class WebSocketClientProtocol:
+    def __init__(self,*args,**argv):
+        raise NotImplementedError("Websockets aren't supported on pyodide yet")
+''',"websockets.client":'''
+def connect(*args,**argv):
+        raise NotImplementedError("Websockets aren't supported on pyodide yet")
+''',"websockets.exceptions":'''
+class WebSocketException:
+    def __init__(self,*args,**argv):
+        raise NotImplementedError("Websockets aren't supported on pyodide yet")
+class ConnectionClosedOK:
+    def __init__(self,*args,**argv):
+        raise NotImplementedError("Websockets aren't supported on pyodide yet")
+'''} )
+
+
 from web3.main import (
     AsyncWeb3,
     Web3,

--- a/web3/__init__.py
+++ b/web3/__init__.py
@@ -36,14 +36,18 @@ class ClientTimeout(__NotImplemented):
         "websockets",
         "1.0.0",
         modules={
-            "websockets": "",
-            "websockets.legacy": "",
-            "websockets.legacy.client": """
-class WebSocketClientProtocol
+            "websockets": """
+class __NotImplemented:
     def __init__(self,*args,**argv):
         raise NotImplementedError(
-            "Websockets aren't supported on pyodide yet"
+            "Async web3 functions aren't supported on pyodide yet"
         )
+""",
+            "websockets.legacy": "",
+            "websockets.legacy.client": """
+from websockets import __NotImplemented
+class WebSocketClientProtocol(__NotImplemented):
+    pass
 """,
             "websockets.client": """
 def connect(*args,**argv):
@@ -52,37 +56,21 @@ def connect(*args,**argv):
         )
 """,
             "websockets.exceptions": """
-class WebSocketException:
-    def __init__(self,*args,**argv):
-        raise NotImplementedError(
-            "Websockets aren't supported on pyodide yet"
-        )
-class ConnectionClosedOK:
-    def __init__(self,*args,**argv):
-        raise NotImplementedError(
-            "Websockets aren't supported on pyodide yet"
-        )
+from websockets import __NotImplemented
+class WebSocketException(__NotImplemented):
+    pass
+class ConnectionClosedOK(__NotImplemented):
+    pass
 """,
         },
     )
 
 
-from web3.main import (  # noqa: E402
-    AsyncWeb3,
-    Web3,
-)
-from web3.providers.async_rpc import (  # noqa: E402
-    AsyncHTTPProvider,
-)
-from web3.providers.eth_tester import (  # noqa: E402
-    EthereumTesterProvider,
-)
-from web3.providers.ipc import (  # noqa: E402
-    IPCProvider,
-)
-from web3.providers.rpc import (  # noqa: E402
-    HTTPProvider,
-)
+from web3.main import AsyncWeb3, Web3  # noqa: E402
+from web3.providers.async_rpc import AsyncHTTPProvider  # noqa: E402
+from web3.providers.eth_tester import EthereumTesterProvider  # noqa: E402
+from web3.providers.ipc import IPCProvider  # noqa: E402
+from web3.providers.rpc import HTTPProvider  # noqa: E402
 from web3.providers.websocket import (  # noqa: E402
     WebsocketProvider,
     WebsocketProviderV2,

--- a/web3/__init__.py
+++ b/web3/__init__.py
@@ -4,60 +4,70 @@ import sys
 
 if sys.platform == "emscripten":
     # pyodide has a built in patcher which makes the requests module work
-    import pyodide_http
+    from pyodide_http import patch_all
 
-    pyodide_http.patch_all()
+    patch_all()
     # asynchronous connections and websockets aren't supported on
     # emscripten yet.
     # We mock the aiohttp and websockets module so that things import okay
-    import micropip
+    from micropip import add_mock_package
 
-    micropip.add_mock_package(
+    add_mock_package(
         "aiohttp",
         "1.0.0",
         modules={
             "aiohttp": """
-class ClientSession:
+class __NotImplemented:
     def __init__(self,*args,**argv):
-        raise NotImplementedError("Async web3 functions aren't supported on pyodide yet")
-class ClientResponse:
-    def __init__(self,*args,**argv):
-        raise NotImplementedError("Async web3 functions aren't supported on pyodide yet")
-class ClientTimeout:
-    def __init__(self,*args,**argv):
-        raise NotImplementedError("Async web3 functions aren't supported on pyodide yet")
+        raise NotImplementedError(
+            "Async web3 functions aren't supported on pyodide yet"
+        )
+class ClientSession(__NotImplemented):
+    pass
+class ClientResponse(__NotImplemented):
+    pass
+class ClientTimeout(__NotImplemented):
+    pass
 """
         },
     )
     # mock websockets
-    micropip.add_mock_package(
+    add_mock_package(
         "websockets",
         "1.0.0",
         modules={
             "websockets": "",
             "websockets.legacy": "",
             "websockets.legacy.client": """
-class WebSocketClientProtocol:
+class WebSocketClientProtocol
     def __init__(self,*args,**argv):
-        raise NotImplementedError("Websockets aren't supported on pyodide yet")
+        raise NotImplementedError(
+            "Websockets aren't supported on pyodide yet"
+        )
 """,
             "websockets.client": """
 def connect(*args,**argv):
-        raise NotImplementedError("Websockets aren't supported on pyodide yet")
+        raise NotImplementedError(
+            "Websockets aren't supported on pyodide yet"
+        )
 """,
             "websockets.exceptions": """
 class WebSocketException:
     def __init__(self,*args,**argv):
-        raise NotImplementedError("Websockets aren't supported on pyodide yet")
+        raise NotImplementedError(
+            "Websockets aren't supported on pyodide yet"
+        )
 class ConnectionClosedOK:
     def __init__(self,*args,**argv):
-        raise NotImplementedError("Websockets aren't supported on pyodide yet")
+        raise NotImplementedError(
+            "Websockets aren't supported on pyodide yet"
+        )
 """,
         },
     )
 
 
-from web3.main import (
+from web3.main import (  # noqa: E402
     AsyncWeb3,
     Web3,
 )

--- a/web3/__init__.py
+++ b/web3/__init__.py
@@ -1,7 +1,11 @@
 from eth_account import Account  # noqa: E402,
 import pkg_resources
+import sys
 
 if sys.platform=="emscripten":
+    # pyodide has a built in patcher which makes the requests module work 
+    import pyodide_http
+    pyodide_http.patch_all()
     # asynchronous connections and websockets aren't supported on
     # emscripten yet. 
     # We mock the aiohttp and websockets module so that things import okay

--- a/web3/__init__.py
+++ b/web3/__init__.py
@@ -2,16 +2,21 @@ from eth_account import Account  # noqa: E402,
 import pkg_resources
 import sys
 
-if sys.platform=="emscripten":
-    # pyodide has a built in patcher which makes the requests module work 
+if sys.platform == "emscripten":
+    # pyodide has a built in patcher which makes the requests module work
     import pyodide_http
+
     pyodide_http.patch_all()
     # asynchronous connections and websockets aren't supported on
-    # emscripten yet. 
+    # emscripten yet.
     # We mock the aiohttp and websockets module so that things import okay
     import micropip
-    micropip.add_mock_package("aiohttp","1.0.0",modules={
-        "aiohttp":'''
+
+    micropip.add_mock_package(
+        "aiohttp",
+        "1.0.0",
+        modules={
+            "aiohttp": """
 class ClientSession:
     def __init__(self,*args,**argv):
         raise NotImplementedError("Async web3 functions aren't supported on pyodide yet")
@@ -21,24 +26,35 @@ class ClientResponse:
 class ClientTimeout:
     def __init__(self,*args,**argv):
         raise NotImplementedError("Async web3 functions aren't supported on pyodide yet")
-'''} )
+"""
+        },
+    )
     # mock websockets
-    micropip.add_mock_package("websockets","1.0.0",modules={"websockets":'',"websockets.legacy":'',
-        "websockets.legacy.client":'''
+    micropip.add_mock_package(
+        "websockets",
+        "1.0.0",
+        modules={
+            "websockets": "",
+            "websockets.legacy": "",
+            "websockets.legacy.client": """
 class WebSocketClientProtocol:
     def __init__(self,*args,**argv):
         raise NotImplementedError("Websockets aren't supported on pyodide yet")
-''',"websockets.client":'''
+""",
+            "websockets.client": """
 def connect(*args,**argv):
         raise NotImplementedError("Websockets aren't supported on pyodide yet")
-''',"websockets.exceptions":'''
+""",
+            "websockets.exceptions": """
 class WebSocketException:
     def __init__(self,*args,**argv):
         raise NotImplementedError("Websockets aren't supported on pyodide yet")
 class ConnectionClosedOK:
     def __init__(self,*args,**argv):
         raise NotImplementedError("Websockets aren't supported on pyodide yet")
-'''} )
+""",
+        },
+    )
 
 
 from web3.main import (


### PR DESCRIPTION
This is the basic patch for it to be possible to build and run web3.py on webassembly using pyodide.

It works for synchronous http only right now. Calls to async or websockets functions will raise exceptions,

Right now it is at the point where:

```
from web3 import Web3, HTTPProvider

w3 = Web3(HTTPProvider('https://goerli.infura.io/v3/<apikey>'))
w3.is_connected()
w3.eth.get_block("latest")
```
should work 

I built a pyodide distribution with it in here:

https://joemarshall.github.io/web3_py_on_web/dist/console.html

Still todo on this is bits that are outside web3.py itself:
1) Figure out how to package this easily (I had a load of hassle running micropip.freeze to make the pyodide lock file that I use so that it loads nicely on import)
2) Build in a jupyterlite based notebook environment so that one can store private keys etc.

#3056 