### PR TITLE
add eth_maxPriorityFeePerGas to http-retry middleware whitelist

### DIFF
--- a/newsfragments/3090.feature.rst
+++ b/newsfragments/3090.feature.rst
@@ -1,0 +1,1 @@
+Add ``eth_maxPriorityFeePerGas`` to ``exception_retry_middleware`` whitelist

--- a/tests/core/middleware/test_http_request_retry.py
+++ b/tests/core/middleware/test_http_request_retry.py
@@ -43,7 +43,7 @@ def test_check_if_retry_on_failure_false():
     methods = [
         "eth_sendTransaction",
         "personal_signAndSendTransaction",
-        "personal_sendTRansaction",
+        "personal_sendTransaction",
     ]
 
     for method in methods:

--- a/web3/middleware/exception_retry_request.py
+++ b/web3/middleware/exception_retry_request.py
@@ -62,6 +62,7 @@ whitelist = [
     "eth_getRawTransactionByHash",
     "eth_call",
     "eth_estimateGas",
+    "eth_maxPriorityFeePerGas",
     "eth_newBlockFilter",
     "eth_newPendingTransactionFilter",
     "eth_newFilter",


### PR DESCRIPTION
### What was wrong?
`eth_maxPriorityFeePerGas` was requested to be added to the `http_retry_request_middleware` whitelist.

Closes #2993

### How was it fixed?

Added. I looked into whether this would interfere with `eth_maxPriorityFeePerGas` falling back to `eth_feeHistory`, but that fallback depends on getting a completed HTTP request through first. 

Found a typo in tests too.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/aa966335-5a27-42b6-8ac6-6696845e24bf)
