### PR TITLE
ignore flake8 F401 qa in all __init__.py files

### DIFF
--- a/newsfragments/3097.internal.rst
+++ b/newsfragments/3097.internal.rst
@@ -1,0 +1,1 @@
+Ignore flake8 rule F401 (unused import) in all ``__init__.py`` files

--- a/tox.ini
+++ b/tox.ini
@@ -10,9 +10,10 @@ envlist=
     benchmark
 
 [flake8]
-max-line-length=88
 exclude= venv*,.tox,docs,build
 extend-ignore=E203,W503
+max-line-length=88
+per-file-ignores=__init__.py:F401
 
 [testenv]
 allowlist_externals=/usr/bin/make

--- a/web3/_utils/compat/__init__.py
+++ b/web3/_utils/compat/__init__.py
@@ -8,7 +8,7 @@
 # Once web3 supports >= the noted python version, the type may be directly
 # imported from `typing`
 
-from typing_extensions import (  # noqa: F401
+from typing_extensions import (
     Literal,  # py38
     NotRequired,  # py311
     Protocol,  # py38

--- a/web3/_utils/module_testing/__init__.py
+++ b/web3/_utils/module_testing/__init__.py
@@ -1,21 +1,21 @@
-from .eth_module import (  # noqa: F401
+from .eth_module import (
     AsyncEthModuleTest,
     EthModuleTest,
 )
-from .go_ethereum_admin_module import (  # noqa: F401
+from .go_ethereum_admin_module import (
     GoEthereumAdminModuleTest,
 )
-from .go_ethereum_personal_module import (  # noqa: F401
+from .go_ethereum_personal_module import (
     GoEthereumPersonalModuleTest,
 )
-from .go_ethereum_txpool_module import (  # noqa: F401
+from .go_ethereum_txpool_module import (
     GoEthereumAsyncTxPoolModuleTest,
     GoEthereumTxPoolModuleTest,
 )
-from .net_module import (  # noqa: F401
+from .net_module import (
     AsyncNetModuleTest,
     NetModuleTest,
 )
-from .web3_module import (  # noqa: F401
+from .web3_module import (
     Web3ModuleTest,
 )

--- a/web3/beacon/__init__.py
+++ b/web3/beacon/__init__.py
@@ -1,2 +1,2 @@
-from .async_beacon import AsyncBeacon  # noqa: F401
-from .main import Beacon  # noqa: F401
+from .async_beacon import AsyncBeacon
+from .main import Beacon

--- a/web3/contract/__init__.py
+++ b/web3/contract/__init__.py
@@ -1,8 +1,8 @@
-from web3.contract.async_contract import (  # noqa: F401
+from web3.contract.async_contract import (
     AsyncContract,
     AsyncContractCaller,
 )
-from web3.contract.contract import (  # noqa: F401
+from web3.contract.contract import (
     Contract,
     ContractCaller,
     ContractConstructor,

--- a/web3/eth/__init__.py
+++ b/web3/eth/__init__.py
@@ -1,10 +1,10 @@
-from .async_eth import (  # noqa: F401
+from .async_eth import (
     AsyncEth,
 )
-from .base_eth import (  # noqa: F401
+from .base_eth import (
     BaseEth,
 )
-from .eth import (  # noqa: F401
+from .eth import (
     Contract,
     Eth,
 )

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -14,22 +14,22 @@ from web3.types import (
     RPCResponse,
 )
 
-from .abi import (  # noqa: F401
+from .abi import (
     abi_middleware,
 )
-from .async_cache import (  # noqa: F401
+from .async_cache import (
     _async_simple_cache_middleware as async_simple_cache_middleware,
     async_construct_simple_cache_middleware,
 )
-from .attrdict import (  # noqa: F401
+from .attrdict import (
     async_attrdict_middleware,
     attrdict_middleware,
 )
-from .buffered_gas_estimate import (  # noqa: F401
+from .buffered_gas_estimate import (
     async_buffered_gas_estimate_middleware,
     buffered_gas_estimate_middleware,
 )
-from .cache import (  # noqa: F401
+from .cache import (
     _latest_block_based_cache_middleware as latest_block_based_cache_middleware,
     _simple_cache_middleware as simple_cache_middleware,
     _time_based_cache_middleware as time_based_cache_middleware,
@@ -37,59 +37,59 @@ from .cache import (  # noqa: F401
     construct_simple_cache_middleware,
     construct_time_based_cache_middleware,
 )
-from .exception_handling import (  # noqa: F401
+from .exception_handling import (
     construct_exception_handler_middleware,
 )
-from .exception_retry_request import (  # noqa: F401
+from .exception_retry_request import (
     async_http_retry_request_middleware,
     http_retry_request_middleware,
 )
-from .filter import (  # noqa: F401
+from .filter import (
     async_local_filter_middleware,
     local_filter_middleware,
 )
-from .fixture import (  # noqa: F401
+from .fixture import (
     async_construct_error_generator_middleware,
     async_construct_result_generator_middleware,
     construct_error_generator_middleware,
     construct_fixture_middleware,
     construct_result_generator_middleware,
 )
-from .formatting import (  # noqa: F401
+from .formatting import (
     construct_formatting_middleware,
 )
-from .gas_price_strategy import (  # noqa: F401
+from .gas_price_strategy import (
     async_gas_price_strategy_middleware,
     gas_price_strategy_middleware,
 )
-from .geth_poa import (  # noqa: F401
+from .geth_poa import (
     async_geth_poa_middleware,
     geth_poa_middleware,
 )
-from .names import (  # noqa: F401
+from .names import (
     async_name_to_address_middleware,
     name_to_address_middleware,
 )
-from .normalize_request_parameters import (  # noqa: F401
+from .normalize_request_parameters import (
     request_parameter_normalizer,
 )
-from .pythonic import (  # noqa: F401
+from .pythonic import (
     pythonic_middleware,
 )
-from .signing import (  # noqa: F401
+from .signing import (
     construct_sign_and_send_raw_middleware,
 )
-from .stalecheck import (  # noqa: F401
+from .stalecheck import (
     async_make_stalecheck_middleware,
     make_stalecheck_middleware,
 )
-from .validation import (  # noqa: F401
+from .validation import (
     async_validation_middleware,
     validation_middleware,
 )
 
 if TYPE_CHECKING:
-    from web3 import AsyncWeb3, Web3  # noqa: F401
+    from web3 import AsyncWeb3, Web3
 
 
 def combine_middlewares(

--- a/web3/providers/__init__.py
+++ b/web3/providers/__init__.py
@@ -1,26 +1,26 @@
-from .async_base import (  # noqa: F401
+from .async_base import (
     AsyncBaseProvider,
 )
-from .async_rpc import (  # noqa: F401
+from .async_rpc import (
     AsyncHTTPProvider,
 )
-from .base import (  # noqa: F401
+from .base import (
     BaseProvider,
     JSONBaseProvider,
 )
-from .ipc import (  # noqa: F401
+from .ipc import (
     IPCProvider,
 )
-from .persistent import (  # noqa: F401
+from .persistent import (
     PersistentConnectionProvider,
 )
-from .rpc import (  # noqa: F401
+from .rpc import (
     HTTPProvider,
 )
-from .websocket import (  # noqa: F401
+from .websocket import (
     WebsocketProvider,
     WebsocketProviderV2,
 )
-from .auto import (  # noqa: F401
+from .auto import (
     AutoProvider,
 )

--- a/web3/providers/eth_tester/__init__.py
+++ b/web3/providers/eth_tester/__init__.py
@@ -1,4 +1,4 @@
-from .main import (  # noqa: F401
+from .main import (
     AsyncEthereumTesterProvider,
     EthereumTesterProvider,
 )

--- a/web3/providers/websocket/__init__.py
+++ b/web3/providers/websocket/__init__.py
@@ -1,8 +1,8 @@
-from .websocket import (  # noqa: F401
+from .websocket import (
     DEFAULT_WEBSOCKET_TIMEOUT,
     RESTRICTED_WEBSOCKET_KWARGS,
     WebsocketProvider,
 )
-from .websocket_v2 import (  # noqa: F401
+from .websocket_v2 import (
     WebsocketProviderV2,
 )

--- a/web3/tools/__init__.py
+++ b/web3/tools/__init__.py
@@ -1,4 +1,4 @@
-from .pytest_ethereum import (  # noqa: F401
+from .pytest_ethereum import (
     deployer,
     linker,
 )


### PR DESCRIPTION
### What was wrong?

Flake8 rule F401 requires that an import be used, but `__init__.py` files are specifically for importing various functions to then be imported elsewhere

### How was it fixed?

Tell flake8 to ignore F401 qa errors in all `__init__.py` files.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/05ca2409-132c-4d83-aa67-51e389854a03)