### PR TITLE
Fix issue 929

### DIFF
--- a/newsfragments/929.internal.rst
+++ b/newsfragments/929.internal.rst
@@ -1,0 +1,1 @@
+Fix an issue with an IPC test present only on MacOSX.

--- a/tests/core/providers/test_ipc_provider.py
+++ b/tests/core/providers/test_ipc_provider.py
@@ -7,7 +7,6 @@ from threading import (
     Thread,
 )
 import time
-import uuid
 
 from web3.auto.gethdev import (
     w3,
@@ -26,7 +25,7 @@ from web3.providers.ipc import (
 @pytest.fixture
 def jsonrpc_ipc_pipe_path():
     with tempfile.TemporaryDirectory() as temp_dir:
-        ipc_path = os.path.join(temp_dir, f"{uuid.uuid4()}.ipc")
+        ipc_path = os.path.join(temp_dir, "temp.ipc")
         try:
             yield ipc_path
         finally:


### PR DESCRIPTION
### What was wrong?

closes #929 

### How was it fixed?

- Use a short hard-coded name for the temp file, as suggested in the issue.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

```
   
< `)        /
  /\ ------/\
   ```