### PR TITLE
Properly JSON encode AttributeDict & bytes types for RPC requests

### DIFF
--- a/newsfragments/3101.feature.rst
+++ b/newsfragments/3101.feature.rst
@@ -1,0 +1,1 @@
+Properly JSON encode ``AttributeDict``, ``bytes``, and ``HexBytes`` when sending a JSON-RPC request by utilizing the in-house ``Web3JsonEncoder`` class.

--- a/tests/core/utilities/test_encoding.py
+++ b/tests/core/utilities/test_encoding.py
@@ -157,38 +157,44 @@ def test_text_if_str_on_text(val):
         (
             AttributeDict(
                 {
-                    "hash": HexBytes(
-                        "0x142ab034696c09dcfb2a8b086b494f3f4c419e67b6c04d95882f87156a3b6f35"  # noqa: E501
-                    ),
-                    "nonce": 3,
-                    "blockHash": HexBytes(
-                        "0xe14a0029f8ae6f41ab2287871d7f2f0658696ce0a842883147629cc1b300fc89"  # noqa: E501
-                    ),
-                    "blockNumber": 4322026,
-                    "transactionIndex": 2,
-                    "from": "0xb17473E95Cc2c37f88C56593Ff8767e10c972359",
-                    "to": "0x8daF62dF221D11b470Ca4531305470DaE4A65784",
-                    "value": 0,
-                    "gasPrice": 3459216019,
-                    "maxPriorityFeePerGas": 2500000000,
-                    "maxFeePerGas": 4421310622,
-                    "gas": 26856,
-                    "input": HexBytes("0x3857"),
-                    "chainId": 1337,
-                    "type": 2,
-                    "accessList": [],
-                    "v": 1,
-                    "s": HexBytes(
-                        "0x6f5216fc207221a11efe2e4c3e3a881a0b5ca286ede538fc9dbc403b2009ea76"  # noqa: E501
-                    ),
-                    "r": HexBytes(
-                        "0xd148ae70c8cbef3a038e70e6d1639f0951e60a2965820f33bad19d0a6c2b8116"  # noqa: E501
-                    ),
-                    "yParity": 1,
+                    "transactions": [
+                        AttributeDict(
+                            {
+                                "hash": HexBytes(
+                                    "0x142ab034696c09dcfb2a8b086b494f3f4c419e67b6c04d95882f87156a3b6f35"  # noqa: E501
+                                ),
+                                "nonce": 3,
+                                "blockHash": HexBytes(
+                                    "0xe14a0029f8ae6f41ab2287871d7f2f0658696ce0a842883147629cc1b300fc89"  # noqa: E501
+                                ),
+                                "blockNumber": 4322026,
+                                "transactionIndex": 2,
+                                "from": "0xb17473E95Cc2c37f88C56593Ff8767e10c972359",
+                                "to": "0x8daF62dF221D11b470Ca4531305470DaE4A65784",
+                                "value": 0,
+                                "gasPrice": 3459216019,
+                                "maxPriorityFeePerGas": 2500000000,
+                                "maxFeePerGas": 4421310622,
+                                "gas": 26856,
+                                "input": HexBytes("0x3857"),
+                                "chainId": 1337,
+                                "type": 2,
+                                "accessList": [],
+                                "v": 1,
+                                "s": HexBytes(
+                                    "0x6f5216fc207221a11efe2e4c3e3a881a0b5ca286ede538fc9dbc403b2009ea76"  # noqa: E501
+                                ),
+                                "r": HexBytes(
+                                    "0xd148ae70c8cbef3a038e70e6d1639f0951e60a2965820f33bad19d0a6c2b8116"  # noqa: E501
+                                ),
+                                "yParity": 1,
+                            },
+                        )
+                    ]
                 }
             ),
             None,
-            """{
+            """{"transactions": [{
                 "hash": "0x142ab034696c09dcfb2a8b086b494f3f4c419e67b6c04d95882f87156a3b6f35",  # noqa: E501
                 "nonce": 3,
                 "blockHash": "0xe14a0029f8ae6f41ab2287871d7f2f0658696ce0a842883147629cc1b300fc89",  # noqa: E501
@@ -209,10 +215,10 @@ def test_text_if_str_on_text(val):
                 "s": "0x6f5216fc207221a11efe2e4c3e3a881a0b5ca286ede538fc9dbc403b2009ea76",  # noqa: E501
                 "r": "0xd148ae70c8cbef3a038e70e6d1639f0951e60a2965820f33bad19d0a6c2b8116",  # noqa: E501
                 "yParity": 1,
-            }""",
+            }]}""",
         ),
     ),
-    ids=("datetime", "datetime_error", "bytes types", "attrdict with hexbytes"),
+    ids=("datetime", "datetime_error", "bytes types", "nested attrdict with hexbytes"),
 )
 def test_friendly_json_encode_with_web3_json_encoder(py_obj, exc_type, expected):
     if exc_type is None:

--- a/web3/_utils/encoding.py
+++ b/web3/_utils/encoding.py
@@ -290,9 +290,11 @@ def encode_single_packed(_type: TypeStr, value: Any) -> bytes:
 class Web3JsonEncoder(json.JSONEncoder):
     def default(self, obj: Any) -> Union[Dict[Any, Any], HexStr]:
         if isinstance(obj, AttributeDict):
-            return {k: v for k, v in obj.items()}
-        if isinstance(obj, HexBytes):
+            return obj.__dict__
+        elif isinstance(obj, HexBytes):
             return HexStr(obj.hex())
+        elif isinstance(obj, bytes):
+            return to_hex(obj)
         return json.JSONEncoder.default(self, obj)
 
 

--- a/web3/providers/async_base.py
+++ b/web3/providers/async_base.py
@@ -17,6 +17,7 @@ from eth_utils import (
 
 from web3._utils.encoding import (
     FriendlyJsonSerde,
+    Web3JsonEncoder,
 )
 from web3.exceptions import (
     ProviderConnectionError,
@@ -106,7 +107,7 @@ class AsyncJSONBaseProvider(AsyncBaseProvider):
             "params": params or [],
             "id": request_id,
         }
-        encoded = FriendlyJsonSerde().json_encode(rpc_dict)
+        encoded = FriendlyJsonSerde().json_encode(rpc_dict, cls=Web3JsonEncoder)
         return to_bytes(text=encoded)
 
     def decode_rpc_response(self, raw_response: bytes) -> RPCResponse:

--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -15,6 +15,7 @@ from eth_utils import (
 
 from web3._utils.encoding import (
     FriendlyJsonSerde,
+    Web3JsonEncoder,
 )
 from web3.exceptions import (
     ProviderConnectionError,
@@ -106,7 +107,7 @@ class JSONBaseProvider(BaseProvider):
             "params": params or [],
             "id": next(self.request_counter),
         }
-        encoded = FriendlyJsonSerde().json_encode(rpc_dict)
+        encoded = FriendlyJsonSerde().json_encode(rpc_dict, Web3JsonEncoder)
         return to_bytes(text=encoded)
 
     def is_connected(self, show_traceback: bool = False) -> bool:


### PR DESCRIPTION
### What was wrong?

closes #2584

### How was it fixed?

- Properly JSON encode ``AttributeDict``, ``bytes``, and ``HexBytes`` types. This can be useful for using responses that have been formatted by *web3.py* as inputs to another request after some cleaning up.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20230917_120119](https://github.com/ethereum/web3.py/assets/3532824/c49a3ac2-8478-4671-9563-4b075da83f9c)

