### PR TITLE
Add basic support of batch requests to `AsyncHTTPProvider`

### DIFF
--- a/web3/providers/async_base.py
+++ b/web3/providers/async_base.py
@@ -6,6 +6,7 @@ from typing import (
     Callable,
     Coroutine,
     Iterable,
+    List,
     Sequence,
     Tuple,
     cast,
@@ -92,8 +93,8 @@ class AsyncBaseProvider:
         raise NotImplementedError("Providers must implement this method")
 
     async def make_batch_request(
-        self, requests: Iterable[tuple[RPCEndpoint, Any]]
-    ) -> list[RPCResponse]:
+        self, requests: Iterable[Tuple[RPCEndpoint, Any]]
+    ) -> List[RPCResponse]:
         raise NotImplementedError("Only AsyncHTTPProvider supports this method")
 
     async def is_connected(self, show_traceback: bool = False) -> bool:
@@ -117,7 +118,7 @@ class AsyncJSONBaseProvider(AsyncBaseProvider):
         return to_bytes(text=encoded)
 
     def encode_batch_rpc_request(
-        self, requests: Iterable[tuple[RPCEndpoint, Any]]
+        self, requests: Iterable[Tuple[RPCEndpoint, Any]]
     ) -> bytes:
         return (
             b"["
@@ -133,7 +134,7 @@ class AsyncJSONBaseProvider(AsyncBaseProvider):
         )
         return cast(RPCResponse, FriendlyJsonSerde().json_decode(text_response))
 
-    def decode_batch_rpc_response(self, raw_response: bytes) -> list[RPCResponse]:
+    def decode_batch_rpc_response(self, raw_response: bytes) -> List[RPCResponse]:
         text_response = str(
             to_text(raw_response) if not is_text(raw_response) else raw_response
         )

--- a/web3/providers/async_base.py
+++ b/web3/providers/async_base.py
@@ -1,9 +1,11 @@
 import itertools
+import json
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
     Coroutine,
+    Iterable,
     Sequence,
     Tuple,
     cast,
@@ -89,6 +91,11 @@ class AsyncBaseProvider:
     async def make_request(self, method: RPCEndpoint, params: Any) -> RPCResponse:
         raise NotImplementedError("Providers must implement this method")
 
+    async def make_batch_request(
+        self, requests: Iterable[tuple[RPCEndpoint, Any]]
+    ) -> list[RPCResponse]:
+        raise NotImplementedError("Only AsyncHTTPProvider supports this method")
+
     async def is_connected(self, show_traceback: bool = False) -> bool:
         raise NotImplementedError("Providers must implement this method")
 
@@ -109,11 +116,28 @@ class AsyncJSONBaseProvider(AsyncBaseProvider):
         encoded = FriendlyJsonSerde().json_encode(rpc_dict)
         return to_bytes(text=encoded)
 
+    def encode_batch_rpc_request(
+        self, requests: Iterable[tuple[RPCEndpoint, Any]]
+    ) -> bytes:
+        return (
+            b"["
+            + b", ".join(
+                self.encode_rpc_request(method, params) for method, params in requests
+            )
+            + b"]"
+        )
+
     def decode_rpc_response(self, raw_response: bytes) -> RPCResponse:
         text_response = str(
             to_text(raw_response) if not is_text(raw_response) else raw_response
         )
         return cast(RPCResponse, FriendlyJsonSerde().json_decode(text_response))
+
+    def decode_batch_rpc_response(self, raw_response: bytes) -> list[RPCResponse]:
+        text_response = str(
+            to_text(raw_response) if not is_text(raw_response) else raw_response
+        )
+        return json.loads(text_response)
 
     async def is_connected(self, show_traceback: bool = False) -> bool:
         try:

--- a/web3/providers/async_rpc.py
+++ b/web3/providers/async_rpc.py
@@ -3,6 +3,7 @@ from typing import (
     Any,
     Dict,
     Iterable,
+    List,
     Optional,
     Tuple,
     Union,
@@ -99,13 +100,13 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
         return response
 
     async def make_batch_request(
-        self, requests: Iterable[tuple[RPCEndpoint, Any]]
-    ) -> list[RPCResponse]:
+        self, requests: Iterable[Tuple[RPCEndpoint, Any]]
+    ) -> List[RPCResponse]:
         self.logger.debug(f"Making batch request HTTP. URI: {self.endpoint_uri}")
         request_data: bytes = self.encode_batch_rpc_request(requests)
         raw_response: bytes = await async_make_post_request(
             self.endpoint_uri, request_data, **self.get_request_kwargs()
         )
-        response = self.decode_batch_rpc_response(raw_response)
+        response: List[RPCResponse] = self.decode_batch_rpc_response(raw_response)
         self.logger.debug(f"Getting batch response HTTP. URI: {self.endpoint_uri}")
         return response

--- a/web3/providers/async_rpc.py
+++ b/web3/providers/async_rpc.py
@@ -97,3 +97,15 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
             f"Method: {method}, Response: {response}"
         )
         return response
+
+    async def make_batch_request(
+        self, requests: Iterable[tuple[RPCEndpoint, Any]]
+    ) -> list[RPCResponse]:
+        self.logger.debug(f"Making batch request HTTP. URI: {self.endpoint_uri}")
+        request_data: bytes = self.encode_batch_rpc_request(requests)
+        raw_response: bytes = await async_make_post_request(
+            self.endpoint_uri, request_data, **self.get_request_kwargs()
+        )
+        response = self.decode_batch_rpc_response(raw_response)
+        self.logger.debug(f"Getting batch response HTTP. URI: {self.endpoint_uri}")
+        return response


### PR DESCRIPTION
Related to Issue #832 

This PR contains basic/limited support of batch requests for `AsyncHTTPProvider`.

-----

Problem with batch requests is living there for years... and to be honest, there is a lot of things to do to add support of batch requests :cry:.  With this PR I just want to add stuff that is critical for me... and praying that it will motivate someone to finally resolve #832.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://a-z-animals.com/media/2022/06/shutterstock_1772205443-1.jpg)
