### PR TITLE
Handle edge case for initialized chain

### DIFF
--- a/newsfragments/1149.bugfix.rst
+++ b/newsfragments/1149.bugfix.rst
@@ -1,0 +1,1 @@
+Return `w3.eth.gas_price` when calculating time based gas price strategy for an empty chain.

--- a/tests/core/gas-strategies/test_time_based_gas_price_strategy.py
+++ b/tests/core/gas-strategies/test_time_based_gas_price_strategy.py
@@ -171,6 +171,46 @@ def test_time_based_gas_price_strategy(strategy_params, expected):
     assert actual == expected
 
 
+def _get_initial_block(method, params):
+    return {
+        "hash": constants.HASH_ZERO,
+        "number": 0,
+        "parentHash": None,
+        "transactions": [],
+        "miner": "0x" + "Aa" * 20,
+        "timestamp": 0,
+    }
+
+
+def _get_gas_price(method, params):
+    return 4321
+
+
+def test_time_based_gas_price_strategy_without_transactions():
+    fixture_middleware = construct_result_generator_middleware(
+        {
+            "eth_getBlockByHash": _get_initial_block,
+            "eth_getBlockByNumber": _get_initial_block,
+            "eth_gasPrice": _get_gas_price,
+        }
+    )
+
+    w3 = Web3(
+        provider=BaseProvider(),
+        middlewares=[fixture_middleware],
+    )
+
+    time_based_gas_price_strategy = construct_time_based_gas_price_strategy(
+        max_wait_seconds=80,
+        sample_size=5,
+        probability=50,
+        weighted=True,
+    )
+    w3.eth.set_gas_price_strategy(time_based_gas_price_strategy)
+    actual = w3.eth.generate_gas_price()
+    assert actual == w3.eth.gas_price
+
+
 @pytest.mark.parametrize(
     "strategy_params_zero,expected_exception_message",
     (

--- a/web3/gas_strategies/time_based.py
+++ b/web3/gas_strategies/time_based.py
@@ -216,6 +216,10 @@ def construct_time_based_gas_price_strategy(
     """
 
     def time_based_gas_price_strategy(w3: Web3, transaction_params: TxParams) -> Wei:
+        # return gas price when no transactions available to sample
+        if w3.eth.get_block("latest")["number"] == 0:
+            return w3.eth.gas_price
+
         if weighted:
             avg_block_time = _get_weighted_avg_block_time(w3, sample_size=sample_size)
         else:


### PR DESCRIPTION
### What was wrong?

Closes #1149

The time based gas price strategy assumes there are many blocks to sample from. In cases where test chains are spun up and no blocks have been mined, this can throw exceptions for folks who are running tests.

### How was it fixed?

Check the latest block prior to attempting to sample so it can fallback to the gas price in `w3.eth.gas_price`.

### Todo:
- [X] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/id/1359382329/photo/a-chihuahua-dog-in-a-tuxedo-at-a-wedding.jpg?s=612x612&w=0&k=20&c=962fPVcvJUFcmgpeWdjGDPQ-EtNt6CfbFNnYfY00kuE=)
