### PR TITLE
Use `hash` to compare equality in `AttributeDict`s

### DIFF
--- a/newsfragments/3104.bugfix.rst
+++ b/newsfragments/3104.bugfix.rst
@@ -1,0 +1,1 @@
+Use hashes to compare equality of two ``AttributeDict``s

--- a/tests/core/datastructures/test_datastructures.py
+++ b/tests/core/datastructures/test_datastructures.py
@@ -1,10 +1,88 @@
 import pytest
+import random
 import re
 
 from web3.datastructures import (
     AttributeDict,
     tupleize_lists_nested,
 )
+
+
+def generate_random_value(depth=0, max_depth=3, key_type=None):
+    if depth > max_depth:
+        return None
+
+    choice = random.choice(["str", "int", "bool", "list", "tuple", "dict"])
+
+    if choice == "str":
+        return "".join(random.choices("abcdefghijklmnopqrstuvwxyz", k=5))
+    elif choice == "int":
+        return random.randint(0, 100)
+    elif choice == "bool":
+        return random.choice([True, False])
+    elif choice == "list":
+        return [
+            generate_random_value(depth + 1, key_type=key_type)
+            for _ in range(random.randint(1, 5))
+        ]
+    elif choice == "tuple":
+        return tuple(
+            generate_random_value(depth + 1, key_type=key_type)
+            for _ in range(random.randint(1, 5))
+        )
+    elif choice == "dict":
+        return generate_random_dict(depth + 1, key_type=key_type)
+
+
+def generate_random_dict(depth=0, max_depth=3, max_keys=5, key_type=None):
+    if not key_type:
+        key_type = random.choice(["str", "int", "float"])
+
+    if depth > max_depth:
+        return {}
+
+    result = {}
+    for _ in range(random.randint(1, max_keys)):
+        if key_type == "str":
+            key = "".join(random.choices("abcdefghijklmnopqrstuvwxyz", k=5))
+        elif key_type == "int":
+            key = random.randint(0, 100)
+        elif key_type == "float":
+            key = round(random.uniform(0, 100), 2)
+
+        value = generate_random_value(depth, max_depth, key_type)
+        result[key] = value
+
+    return AttributeDict.recursive(result)
+
+
+def test_attribute_dict_raises_when_mutated():
+    test_attr_dict = AttributeDict(
+        {"address": "0x4CB06C43fcdABeA22541fcF1F856A6a296448B6c"}
+    )
+    with pytest.raises(TypeError):
+        # should raise when trying to edit an attribute with dict syntax
+        test_attr_dict["address"] = "0x6C8f2A135f6ed072DE4503Bd7C4999a1a17F824B"
+
+    with pytest.raises(TypeError):
+        # should raise when trying to edit an attribute with dot syntax
+        test_attr_dict.address = "0x6C8f2A135f6ed072DE4503Bd7C4999a1a17F824B"
+
+    with pytest.raises(TypeError):
+        # should raise when trying to add an attribute with dict syntax
+        test_attr_dict["cats"] = "0x6C8f2A135f6ed072DE4503Bd7C4999a1a17F824B"
+
+    with pytest.raises(TypeError):
+        # should raise when trying to add an attribute with dot syntax
+        test_attr_dict.cats = "0x6C8f2A135f6ed072DE4503Bd7C4999a1a17F824B"
+
+    with pytest.raises(TypeError):
+        # should raise when trying to delete an attribute with dict syntax
+        del test_attr_dict["address"]
+
+    with pytest.raises(TypeError):
+        # should raise when trying to delete an attribute with dot syntax
+        del test_attr_dict.address
 
 
 @pytest.mark.parametrize(
@@ -50,9 +128,18 @@ from web3.datastructures import (
         ),
     ),
 )
-def test_tupleization_and_hashing(input, expected):
+def test_tupleization_and_hashing_passing_defined(input, expected):
     assert tupleize_lists_nested(input) == expected
     assert hash(AttributeDict(input)) == hash(expected)
+    assert AttributeDict(input) == expected
+
+
+def test_tupleization_and_hashing_passing_random():
+    for _ in range(1000):
+        random_dict = generate_random_dict()
+        tupleized_random_dict = tupleize_lists_nested(random_dict)
+        assert hash(random_dict) == hash(tupleized_random_dict)
+        assert random_dict == tupleized_random_dict
 
 
 @pytest.mark.parametrize(

--- a/web3/datastructures.py
+++ b/web3/datastructures.py
@@ -14,6 +14,7 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     Type,
     TypeVar,
     Union,
@@ -117,7 +118,9 @@ class AttributeDict(ReadableAttributeDict[TKey, TValue], Hashable):
         return hash(tuple(sorted(tupleize_lists_nested(self).items())))
 
     def __eq__(self, other: Any) -> bool:
-        if isinstance(other, Mapping):
+        if isinstance(other, AttributeDict):
+            return hash(self) == hash(other)
+        elif isinstance(other, Mapping):
             return self.__dict__ == dict(other)
         else:
             return False
@@ -130,12 +133,12 @@ def tupleize_lists_nested(d: Mapping[TKey, TValue]) -> AttributeDict[TKey, TValu
     Other unhashable types found will raise a TypeError
     """
 
-    def _to_tuple(lst: List[Any]) -> Any:
-        return tuple(_to_tuple(i) if isinstance(i, list) else i for i in lst)
+    def _to_tuple(value: Union[List[Any], Tuple[Any, ...]]) -> Any:
+        return tuple(_to_tuple(i) if isinstance(i, (list, tuple)) else i for i in value)
 
     ret = dict()
     for k, v in d.items():
-        if isinstance(v, List):
+        if isinstance(v, (list, tuple)):
             ret[k] = _to_tuple(v)
         elif isinstance(v, Mapping):
             ret[k] = tupleize_lists_nested(v)


### PR DESCRIPTION
### What was wrong?

Two `AttributeDicts` could have the same hash, but not compare as equal. 
Also found a bug in `tupleize_lists_nested` where it wouldn't find lists if they were inside a tuple.

Related to Issue #2572 

### How was it fixed?

Updated `AttributeDict.__eq__` to compare hashes if one is being compared to another. It still uses the previous method of converting to dicts for comparison if the `other` is another type of `Mapping`.

In `tupleize_lists_nested`, added tuples to things that need to be recursively tupleized, in case they have unhashable objects within them.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/9e9194e8-064f-4c6b-8574-f1d1ef0d943a)
