### PR TITLE
docs(contributing.rst): use `docker compose` instead of `docker-compose` in the examples

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -67,7 +67,7 @@ To start up the test environment, run:
 
 .. code:: sh
 
-    $ docker-compose up -d
+    $ docker compose up -d
 
 
 This will build a Docker container set up with an environment to run the
@@ -82,7 +82,7 @@ To run the Python tests from your local machine:
 
 .. code:: sh
 
-    $ docker-compose exec sandbox bash -c 'pytest -n 4 -f -k "not goethereum"'
+    $ docker compose exec sandbox bash -c 'pytest -n 4 -f -k "not goethereum"'
 
 
 You can run arbitrary commands inside the Docker container by using the
@@ -90,14 +90,14 @@ You can run arbitrary commands inside the Docker container by using the
 
 .. code:: sh
 
-    $ docker-compose exec sandbox bash -c ''
+    $ docker compose exec sandbox bash -c ''
 
 
 Or, if you would like to open a session to the container, run:
 
 .. code:: sh
 
-    $ docker-compose exec sandbox bash
+    $ docker compose exec sandbox bash
 
 
 Code Style

--- a/newsfragments/3107.docs.rst
+++ b/newsfragments/3107.docs.rst
@@ -1,0 +1,1 @@
+Change ``docker-compose`` to ``docker compose`` in the Contributing docs examples.


### PR DESCRIPTION
Since from July 2023 Docker Compose V1 stopped receiving updates and is no longer available in new releases of Docker Desktop, it's recommended to rather use the `docker compose` syntax instead of `docker-compose`.

### What was wrong?

Related to Issue #

### How was it fixed?

Used `docker compose` instead of `docker-compose` in examples on Contributing docs page.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://newverest.com/cdn/shop/articles/Create_Photos_for_Article_1920x1080_6.jpg?v=1567779872)
