### PR TITLE
Speed up core tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,6 +247,13 @@ jobs:
     environment:
       TOXENV: py37-core
 
+  py37-core_async:
+    <<: *common
+    docker:
+      - image: cimg/python:3.7
+    environment:
+      TOXENV: py37-core_async
+
   py37-ens:
     <<: *common
     docker:
@@ -364,6 +371,13 @@ jobs:
       - image: cimg/python:3.8
     environment:
       TOXENV: py38-core
+
+  py38-core_async:
+    <<: *common
+    docker:
+      - image: cimg/python:3.8
+    environment:
+        TOXENV: py38-core_async
 
   py38-ens:
     <<: *common
@@ -483,6 +497,13 @@ jobs:
     environment:
       TOXENV: py39-core
 
+  py39-core_async:
+    <<: *common
+    docker:
+      - image: cimg/python:3.9
+    environment:
+        TOXENV: py39-core_async
+
   py39-ens:
     <<: *common
     docker:
@@ -599,6 +620,13 @@ jobs:
       - image: cimg/python:3.10
     environment:
       TOXENV: py310-core
+
+  py310-core_async:
+    <<: *common
+    docker:
+      - image: cimg/python:3.10
+    environment:
+      TOXENV: py310-core_async
 
   py310-ens:
     <<: *common
@@ -722,6 +750,13 @@ jobs:
     environment:
       TOXENV: py311-core
 
+  py311-core_async:
+    <<: *common
+    docker:
+      - image: cimg/python:3.11
+    environment:
+      TOXENV: py311-core_async
+
   py311-ens:
     <<: *common
     docker:
@@ -840,6 +875,11 @@ workflows:
       - py39-core
       - py310-core
       - py311-core
+      - py37-core_async
+      - py38-core_async
+      - py39-core_async
+      - py310-core_async
+      - py311-core_async
       - docs
       - benchmark
       - py37-ens

--- a/newsfragments/3111.internal.rst
+++ b/newsfragments/3111.internal.rst
@@ -1,0 +1,1 @@
+Speed up the core test suite by splitting up sync and async tests. This reduces the CI build times to ~8min from ~12min.

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,8 @@ allowlist_externals=/usr/bin/make
 install_command=python -m pip install {opts} {packages}
 usedevelop=True
 commands=
-    core: pytest {posargs:tests/core}
+    core: pytest {posargs:tests/core -k "not async"}
+    core_async: pytest {posargs:tests/core -k async}
     ens: pytest {posargs:tests/ens --ignore=tests/ens/normalization/test_normalize_name_ensip15.py}
     ensip15: pytest {posargs:tests/ens/normalization/test_normalize_name_ensip15.py -q}
     ethpm: pytest {posargs:tests/ethpm}


### PR DESCRIPTION
### What was wrong?

Core tests take ~12 min on average to run. We should try to speed this up.

- use `pytest-xdist`
- split sync / async into separate runs
- ???

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/3532824/136ad480-8e5c-4278-a1a3-b6088faa92f1)
