### PR TITLE
WebsocketProviderV2 updates + formatting middleware bugfix

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -277,7 +277,7 @@ asynchronous context manager, can be found in the `websockets connection`_ docs.
         ...             if some_condition:
         ...                 # unsubscribe from new block headers and break out of
         ...                 # iterator
-        ...                 unsubscribed = await w3.eth.unsubscribe(subscription_id)
+        ...                 await w3.eth.unsubscribe(subscription_id)
         ...                 break
         ...
         ...         # still an open connection, make any other requests and get

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -270,16 +270,15 @@ asynchronous context manager, can be found in the `websockets connection`_ docs.
         ...         # subscribe to new block headers
         ...         subscription_id = await w3.eth.subscribe("newHeads")
         ...
-        ...         unsubscribed = False
-        ...         while not unsubscribed:
-        ...             async for response in w3.ws.listen_to_websocket():
-        ...                 print(f"{response}\n")
-        ...                 # handle responses here
+        ...         async for response in w3.ws.listen_to_websocket():
+        ...             print(f"{response}\n")
+        ...             # handle responses here
         ...
-        ...                 if some_condition:
-        ...                     # unsubscribe from new block headers
-        ...                     unsubscribed = await w3.eth.unsubscribe(subscription_id)
-        ...                     break
+        ...             if some_condition:
+        ...                 # unsubscribe from new block headers and break out of
+        ...                 # iterator
+        ...                 unsubscribed = await w3.eth.unsubscribe(subscription_id)
+        ...                 break
         ...
         ...         # still an open connection, make any other requests and get
         ...         # responses via send / receive

--- a/newsfragments/3116.breaking.rst
+++ b/newsfragments/3116.breaking.rst
@@ -1,0 +1,1 @@
+Refactor the async iterator pattern for message streams from the websocket connection for ``WebsocketProviderV2`` to a proper async iterator. This allows for a more natural usage of the iterator pattern and mimics the behavior of the underlying ``websockets`` library.

--- a/newsfragments/3116.bugfix.rst
+++ b/newsfragments/3116.bugfix.rst
@@ -1,0 +1,1 @@
+Fix issues with formatting middleware, such as ``async_geth_poa_middleware`` and subscription responses for ``WebsocketProviderV2``.

--- a/newsfragments/3116.docs.rst
+++ b/newsfragments/3116.docs.rst
@@ -1,0 +1,1 @@
+Updates to the ``WebsocketProviderV2`` documentation async iterator example for iterating over a persistent stream of messages from the websocket connection via ``async for``.

--- a/tests/core/providers/test_wsv2_provider.py
+++ b/tests/core/providers/test_wsv2_provider.py
@@ -1,0 +1,92 @@
+import json
+import pytest
+import sys
+
+from eth_utils import (
+    to_bytes,
+)
+
+from web3.providers.websocket import (
+    WebsocketProviderV2,
+)
+from web3.types import (
+    RPCEndpoint,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    # TODO: remove when python 3.7 is no longer supported in web3.py
+    #  python 3.7 is already sunset so this feels like a reasonable tradeoff
+    sys.version_info < (3, 8),
+    reason="Mock args behave differently in python 3.7 but test should still pass.",
+)
+async def test_async_make_request_caches_all_undesired_responses_and_returns_desired():
+    # move to top of file when python 3.7 is no longer supported in web3.py
+    from unittest.mock import (
+        AsyncMock,
+    )
+
+    provider = WebsocketProviderV2("ws://mocked")
+
+    method_under_test = provider.make_request
+
+    provider._ws = AsyncMock()
+    undesired_responses_count = 10
+    ws_recv_responses = [
+        to_bytes(
+            text=json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "eth_subscription",
+                    "params": {"subscription": "0x1", "result": f"0x{i}"},
+                }
+            )
+        )
+        for i in range(0, undesired_responses_count)
+    ]
+    # The first request we make should have an id of `0`, expect the response to match
+    # that id. Append it as the last response in the list.
+    ws_recv_responses.append(b'{"jsonrpc": "2.0", "id":0, "result": "0x1337"}')
+    provider._ws.recv.side_effect = ws_recv_responses
+
+    response = await method_under_test(RPCEndpoint("some_method"), ["desired_params"])
+    assert response == json.loads(ws_recv_responses.pop())  # pop the expected response
+
+    assert (
+        len(provider._request_processor._raw_response_cache)
+        == len(ws_recv_responses)
+        == undesired_responses_count
+    )
+
+    for (
+        _cache_key,
+        cached_response,
+    ) in provider._request_processor._raw_response_cache.items():
+        # assert all cached responses are in the list of responses we received
+        assert to_bytes(text=json.dumps(cached_response)) in ws_recv_responses
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    # TODO: remove when python 3.7 is no longer supported in web3.py
+    #  python 3.7 is already sunset so this feels like a reasonable tradeoff
+    sys.version_info < (3, 8),
+    reason="Uses AsyncMock, not supported by python 3.7",
+)
+async def test_async_make_request_returns_cached_response_with_no_recv_if_cached():
+    provider = WebsocketProviderV2("ws://mocked")
+
+    method_under_test = provider.make_request
+
+    _mock_ws(provider)
+
+    # cache the response, so we should get it immediately & should never call `recv()`
+    desired_response = {"jsonrpc": "2.0", "id": 0, "result": "0x1337"}
+    await provider._request_processor.cache_raw_response(desired_response)
+
+    response = await method_under_test(RPCEndpoint("some_method"), ["desired_params"])
+    assert response == desired_response
+
+    assert len(provider._request_processor._raw_response_cache) == 0
+    assert not provider._ws.recv.called  # type: ignore

--- a/tests/integration/go_ethereum/test_goethereum_ws_v2/test_async_ctx_manager_w3.py
+++ b/tests/integration/go_ethereum/test_goethereum_ws_v2/test_async_ctx_manager_w3.py
@@ -12,6 +12,9 @@ from web3._utils.module_testing.go_ethereum_admin_module import (
 from web3._utils.module_testing.go_ethereum_personal_module import (
     GoEthereumAsyncPersonalModuleTest,
 )
+from web3._utils.module_testing.persistent_connection_provider import (
+    PersistentConnectionProviderTest,
+)
 
 from ..common import (
     GoEthereumAsyncEthModuleTest,
@@ -25,6 +28,8 @@ from ..utils import (
 @pytest_asyncio.fixture(scope="module")
 async def async_w3(geth_process, endpoint_uri):
     await wait_for_aiohttp(endpoint_uri)
+
+    # async context manager pattern
     async with AsyncWeb3.persistent_websocket(
         WebsocketProviderV2(endpoint_uri, call_timeout=30)
     ) as w3:
@@ -55,6 +60,10 @@ class TestGoEthereumAsyncAdminModuleTest(GoEthereumAsyncAdminModuleTest):
             reason="Only one WebSocket endpoint is allowed to be active at any time"
         )
         await super().test_admin_start_stop_ws(async_w3)
+
+
+class TestPersistentConnectionProviderTest(PersistentConnectionProviderTest):
+    pass
 
 
 class TestGoEthereumAsyncEthModuleTest(GoEthereumAsyncEthModuleTest):

--- a/tests/integration/go_ethereum/test_goethereum_ws_v2/test_async_iterator_w3.py
+++ b/tests/integration/go_ethereum/test_goethereum_ws_v2/test_async_iterator_w3.py
@@ -12,6 +12,9 @@ from web3._utils.module_testing.go_ethereum_admin_module import (
 from web3._utils.module_testing.go_ethereum_personal_module import (
     GoEthereumAsyncPersonalModuleTest,
 )
+from web3._utils.module_testing.persistent_connection_provider import (
+    PersistentConnectionProviderTest,
+)
 
 from ..common import (
     GoEthereumAsyncEthModuleTest,
@@ -25,6 +28,8 @@ from ..utils import (
 @pytest_asyncio.fixture(scope="module")
 async def async_w3(geth_process, endpoint_uri):
     await wait_for_aiohttp(endpoint_uri)
+
+    # async iterator pattern
     async for w3 in AsyncWeb3.persistent_websocket(
         WebsocketProviderV2(endpoint_uri, call_timeout=30)
     ):
@@ -55,6 +60,10 @@ class TestGoEthereumAsyncAdminModuleTest(GoEthereumAsyncAdminModuleTest):
             reason="Only one WebSocket endpoint is allowed to be active at any time"
         )
         await super().test_admin_start_stop_ws(async_w3)
+
+
+class TestPersistentConnectionProviderTest(PersistentConnectionProviderTest):
+    pass
 
 
 class TestGoEthereumAsyncEthModuleTest(GoEthereumAsyncEthModuleTest):

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -643,13 +643,13 @@ def subscription_formatter(value: Any) -> Union[HexBytes, HexStr, Dict[str, Any]
                 result_formatter = block_formatter
 
             elif either_set_is_a_subset(
-                result_key_set, set(LOG_ENTRY_FORMATTERS.keys()), percentage=90
+                result_key_set, set(LOG_ENTRY_FORMATTERS.keys()), percentage=75
             ):
                 # logs
                 result_formatter = log_entry_formatter
 
             elif either_set_is_a_subset(
-                result_key_set, set(TRANSACTION_RESULT_FORMATTERS.keys()), percentage=90
+                result_key_set, set(TRANSACTION_RESULT_FORMATTERS.keys()), percentage=75
             ):
                 # newPendingTransactions, full transactions
                 result_formatter = transaction_result_formatter
@@ -663,7 +663,7 @@ def subscription_formatter(value: Any) -> Union[HexBytes, HexStr, Dict[str, Any]
             elif either_set_is_a_subset(
                 result_key_set,
                 set(SYNCING_FORMATTERS.keys()),
-                percentage=90,
+                percentage=75,
             ):
                 # syncing response object
                 result_formatter = syncing_formatter

--- a/web3/_utils/module_testing/persistent_connection_provider.py
+++ b/web3/_utils/module_testing/persistent_connection_provider.py
@@ -292,7 +292,6 @@ class PersistentConnectionProviderTest:
         expected_formatted_result: Any,
     ) -> None:
         sub_id = await async_w3.eth.subscribe(*subscription_params)
-        assert sub_id is not None
         assert is_hexstr(sub_id)
 
         async def _mocked_recv_coro() -> bytes:

--- a/web3/_utils/module_testing/persistent_connection_provider.py
+++ b/web3/_utils/module_testing/persistent_connection_provider.py
@@ -1,0 +1,272 @@
+import pytest
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Tuple,
+    cast,
+)
+
+from eth_utils import (
+    is_hexstr,
+    to_bytes,
+)
+from hexbytes import (
+    HexBytes,
+)
+
+from web3._utils.encoding import (
+    FriendlyJsonSerde,
+)
+from web3.datastructures import (
+    AttributeDict,
+)
+from web3.types import (
+    FormattedEthSubscriptionResponse,
+)
+
+if TYPE_CHECKING:
+    from web3.main import (
+        _PersistentConnectionWeb3,
+    )
+
+
+class PersistentConnectionProviderTest:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "subscription_params,ws_subscription_response,expected_formatted_result",
+        (
+            (
+                ("newHeads",),
+                {
+                    "jsonrpc": "2.0",
+                    "method": "eth_subscription",
+                    "params": {
+                        "subscription": "THIS_WILL_BE_REPLACED_IN_THE_TEST",
+                        "result": {
+                            "number": "0x539",
+                            "hash": "0xb46b85928f2c2264c2bf7ad5c6d6985664f1527e744193ef990cc0d3da5afc5e",  # noqa: E501
+                            "parentHash": "0xb46b85928f2c2264c2bf7ad5c6d6985664f1527e744193ef990cc0d3da5afc5e",  # noqa: E501
+                            "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",  # noqa: E501
+                            "logsBloom": "0x00",
+                            "transactionsRoot": "0x56260fe8298aff6d360e3a68fa855693f25dcb2708d8a7e509e8519b265d3988",  # noqa: E501
+                            "stateRoot": "0x56260fe8298aff6d360e3a68fa855693f25dcb2708d8a7e509e8519b265d3988",  # noqa: E501
+                            "receiptsRoot": "0x56260fe8298aff6d360e3a68fa855693f25dcb2708d8a7e509e8519b265d3988",  # noqa: E501
+                            "miner": "0x0000000000000000000000000000000000000000",
+                            "difficulty": "0x0",
+                            "extraData": "0x496c6c756d696e61746520446d6f63726174697a6520447374726962757465",  # noqa: E501
+                            "gasLimit": "0x1c9c380",
+                            "gasUsed": "0xd1ce44",
+                            "timestamp": "0x539",
+                            "baseFeePerGas": "0x26f93fef9",
+                            "withdrawalsRoot": "0x56260fe8298aff6d360e3a68fa855693f25dcb2708d8a7e509e8519b265d3988",  # noqa: E501
+                            "nonce": "0x0000000000000000",
+                            "mixHash": "0x73e9e036ec894047f29954571d4b6d9e8717de7304269c263cbf150caa4e0768",  # noqa: E501
+                        },
+                    },
+                },
+                AttributeDict(
+                    {
+                        "number": 1337,
+                        "hash": HexBytes(
+                            "0xb46b85928f2c2264c2bf7ad5c6d6985664f1527e744193ef990cc0d3da5afc5e"  # noqa: E501
+                        ),
+                        "parentHash": HexBytes(
+                            "0xb46b85928f2c2264c2bf7ad5c6d6985664f1527e744193ef990cc0d3da5afc5e"  # noqa: E501
+                        ),
+                        "sha3Uncles": HexBytes(
+                            "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"  # noqa: E501
+                        ),
+                        "logsBloom": HexBytes("0x00"),
+                        "transactionsRoot": HexBytes(
+                            "0x56260fe8298aff6d360e3a68fa855693f25dcb2708d8a7e509e8519b265d3988"  # noqa: E501
+                        ),
+                        "stateRoot": HexBytes(
+                            "0x56260fe8298aff6d360e3a68fa855693f25dcb2708d8a7e509e8519b265d3988"  # noqa: E501
+                        ),
+                        "receiptsRoot": HexBytes(
+                            "0x56260fe8298aff6d360e3a68fa855693f25dcb2708d8a7e509e8519b265d3988"  # noqa: E501
+                        ),
+                        "miner": "0x0000000000000000000000000000000000000000",
+                        "difficulty": 0,
+                        "extraData": HexBytes(
+                            "0x496c6c756d696e61746520446d6f63726174697a6520447374726962757465"  # noqa: E501
+                        ),
+                        "gasLimit": 30000000,
+                        "gasUsed": 13749828,
+                        "timestamp": 1337,
+                        "baseFeePerGas": 10461904633,
+                        "withdrawalsRoot": HexBytes(
+                            "0x56260fe8298aff6d360e3a68fa855693f25dcb2708d8a7e509e8519b265d3988"  # noqa: E501
+                        ),
+                        "nonce": HexBytes("0x0000000000000000"),
+                        "mixHash": HexBytes(
+                            "0x73e9e036ec894047f29954571d4b6d9e8717de7304269c263cbf150caa4e0768"  # noqa: E501
+                        ),
+                    }
+                ),
+            ),
+            (
+                ("newPendingTransactions", True),
+                {
+                    "jsonrpc": "2.0",
+                    "method": "eth_subscription",
+                    "params": {
+                        "subscription": "THIS_WILL_BE_REPLACED_IN_THE_TEST",
+                        "result": {
+                            "blockHash": None,
+                            "blockNumber": None,
+                            "from": "0x0000000000000000000000000000000000000000",
+                            "gas": "0xf2f4",
+                            "gasPrice": "0x29035f36f",
+                            "maxFeePerGas": "0x29035f36f",
+                            "maxPriorityFeePerGas": "0x3b9aca00",
+                            "hash": "0xb46b85928f2c2264c2bf7ad5c6d6985664f1527e744193ef990cc0d3da5afc5e",  # noqa: E501
+                            "input": "0x00",
+                            "nonce": "0x2013",
+                            "to": "0x0000000000000000000000000000000000000000",
+                            "transactionIndex": None,
+                            "value": "0x0",
+                            "type": "0x2",
+                            "accessList": [],
+                            "chainId": "0x1",
+                            "v": "0x1",
+                            "r": "0x3c144a7c00ed3118d55445cd5be2ae4620ca377f7c685e9c5f3687671d4dece1",  # noqa: E501
+                            "s": "0x284de67cbf75fec8a9edb368dee3a37cf6faba87f0af4413b2f869ebfa87d002",  # noqa: E501
+                            "yParity": "0x1",
+                        },
+                    },
+                },
+                AttributeDict(
+                    {
+                        "blockHash": None,
+                        "blockNumber": None,
+                        "from": "0x0000000000000000000000000000000000000000",
+                        "gas": 62196,
+                        "gasPrice": 11009389423,
+                        "maxFeePerGas": 11009389423,
+                        "maxPriorityFeePerGas": 1000000000,
+                        "hash": HexBytes(
+                            "0xb46b85928f2c2264c2bf7ad5c6d6985664f1527e744193ef990cc0d3da5afc5e"  # noqa: E501
+                        ),
+                        "input": HexBytes("0x00"),
+                        "nonce": 8211,
+                        "to": "0x0000000000000000000000000000000000000000",
+                        "transactionIndex": None,
+                        "value": 0,
+                        "type": 2,
+                        "accessList": [],
+                        "chainId": 1,
+                        "v": 1,
+                        "r": HexBytes(
+                            "0x3c144a7c00ed3118d55445cd5be2ae4620ca377f7c685e9c5f3687671d4dece1"  # noqa: E501
+                        ),
+                        "s": HexBytes(
+                            "0x284de67cbf75fec8a9edb368dee3a37cf6faba87f0af4413b2f869ebfa87d002"  # noqa: E501
+                        ),
+                        "yParity": 1,
+                    }
+                ),
+            ),
+            (
+                ("newPendingTransactions", False),
+                {
+                    "jsonrpc": "2.0",
+                    "method": "eth_subscription",
+                    "params": {
+                        "subscription": "THIS_WILL_BE_REPLACED_IN_THE_TEST",
+                        "result": "0xb46b85928f2c2264c2bf7ad5c6d6985664f1527e744193ef990cc0d3da5afc5e",  # noqa: E501
+                    },
+                },
+                HexBytes(
+                    "0xb46b85928f2c2264c2bf7ad5c6d6985664f1527e744193ef990cc0d3da5afc5e"
+                ),
+            ),
+            (
+                ("logs", {"address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"}),
+                {
+                    "jsonrpc": "2.0",
+                    "method": "eth_subscription",
+                    "params": {
+                        "subscription": "THIS_WILL_BE_REPLACED_IN_THE_TEST",
+                        "result": {
+                            "removed": False,
+                            "logIndex": "0x0",
+                            "transactionIndex": "0x0",
+                            "transactionHash": "0x56260fe8298aff6d360e3a68fa855693f25dcb2708d8a7e509e8519b265d3988",  # noqa: E501
+                            "blockHash": "0xb46b85928f2c2264c2bf7ad5c6d6985664f1527e744193ef990cc0d3da5afc5e",  # noqa: E501
+                            "blockNumber": "0x539",
+                            "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                            "data": "0x00",
+                            "topics": [
+                                "0xe1fffdd4923d04f559f4d29e8bfc6cda04eb5b0d3c460751c2402c5c5cc9105c",  # noqa: E501
+                                "0x00000000000000000000000016250d5630b4cf539739df2c5dacb4c659f2482d",  # noqa: E501
+                            ],
+                        },
+                    },
+                },
+                AttributeDict(
+                    {
+                        "removed": False,
+                        "logIndex": 0,
+                        "transactionIndex": 0,
+                        "transactionHash": HexBytes(
+                            "0x56260fe8298aff6d360e3a68fa855693f25dcb2708d8a7e509e8519b265d3988"  # noqa: E501
+                        ),
+                        "blockHash": HexBytes(
+                            "0xb46b85928f2c2264c2bf7ad5c6d6985664f1527e744193ef990cc0d3da5afc5e"  # noqa: E501
+                        ),
+                        "blockNumber": 1337,
+                        "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                        "data": HexBytes("0x00"),
+                        "topics": [
+                            HexBytes(
+                                "0xe1fffdd4923d04f559f4d29e8bfc6cda04eb5b0d3c460751c2402c5c5cc9105c"  # noqa: E501
+                            ),
+                            HexBytes(
+                                "0x00000000000000000000000016250d5630b4cf539739df2c5dacb4c659f2482d"  # noqa: E501
+                            ),
+                        ],
+                    }
+                ),
+            ),
+        ),
+        ids=[
+            "newHeads",
+            "newPendingTransactions-FullTxs",
+            "newPendingTransactions-TxHashes",
+            "logs",
+        ],
+    )
+    async def test_async_eth_subscribe_mocked(
+        self,
+        async_w3: "_PersistentConnectionWeb3",
+        subscription_params: Tuple[Any, ...],
+        ws_subscription_response: Dict[str, Any],
+        expected_formatted_result: Any,
+    ) -> None:
+        sub_id = await async_w3.eth.subscribe(*subscription_params)
+        assert sub_id is not None
+        assert is_hexstr(sub_id)
+
+        # return a coroutine that returns the response
+        async def _mocked_recv() -> bytes:
+            # Must be same subscription id so we can know how to parse the message.
+            # We don't have this information when mocking the response.
+            ws_subscription_response["params"]["subscription"] = sub_id
+            encoded = FriendlyJsonSerde().json_encode(ws_subscription_response)
+            return to_bytes(text=encoded)
+
+        actual_recv_fxn = async_w3.provider._ws.recv
+        async_w3.provider._ws.__setattr__("recv", _mocked_recv)
+
+        async for msg in async_w3.ws.listen_to_websocket():
+            response = cast(FormattedEthSubscriptionResponse, msg)
+            assert response["subscription"] == sub_id
+            assert response["result"] == expected_formatted_result
+
+            # only testing one message, so break here
+            break
+
+        # reset the mocked recv
+        async_w3.provider._ws.__setattr__("recv", actual_recv_fxn)

--- a/web3/_utils/module_testing/persistent_connection_provider.py
+++ b/web3/_utils/module_testing/persistent_connection_provider.py
@@ -238,12 +238,50 @@ class PersistentConnectionProviderTest:
                     }
                 ),
             ),
+            (
+                ("syncing",),
+                {
+                    "jsonrpc": "2.0",
+                    "method": "eth_subscription",
+                    "params": {
+                        "subscription": "THIS_WILL_BE_REPLACED_IN_THE_TEST",
+                        "result": False,
+                    },
+                },
+                False,
+            ),
+            (
+                ("syncing",),
+                {
+                    "jsonrpc": "2.0",
+                    "method": "eth_subscription",
+                    "params": {
+                        "subscription": "THIS_WILL_BE_REPLACED_IN_THE_TEST",
+                        "result": {
+                            "isSyncing": True,
+                            "startingBlock": "0x0",
+                            "currentBlock": "0x4346fe",
+                            "highestBlock": "0x434806",
+                        },
+                    },
+                },
+                AttributeDict(
+                    {
+                        "isSyncing": True,
+                        "startingBlock": 0,
+                        "currentBlock": 4409086,
+                        "highestBlock": 4409350,
+                    }
+                ),
+            ),
         ),
         ids=[
             "newHeads",
             "newPendingTransactions-FullTxs",
             "newPendingTransactions-TxHashes",
             "logs",
+            "syncing-False",
+            "syncing-True",
         ],
     )
     async def test_async_eth_subscribe_mocked(

--- a/web3/_utils/module_testing/persistent_connection_provider.py
+++ b/web3/_utils/module_testing/persistent_connection_provider.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 from typing import (
     TYPE_CHECKING,
@@ -15,9 +16,6 @@ from hexbytes import (
     HexBytes,
 )
 
-from web3._utils.encoding import (
-    FriendlyJsonSerde,
-)
 from web3.datastructures import (
     AttributeDict,
 )
@@ -38,8 +36,7 @@ def _mocked_recv(sub_id: str, ws_subscription_response: Dict[str, Any]) -> bytes
     # Must be same subscription id so we can know how to parse the message.
     # We don't have this information when mocking the response.
     ws_subscription_response["params"]["subscription"] = sub_id
-    encoded = FriendlyJsonSerde().json_encode(ws_subscription_response)
-    return to_bytes(text=encoded)
+    return to_bytes(text=json.dumps(ws_subscription_response))
 
 
 class PersistentConnectionProviderTest:

--- a/web3/main.py
+++ b/web3/main.py
@@ -543,6 +543,9 @@ class _PersistentConnectionWeb3(AsyncWeb3):
 
     # async for w3 in w3.persistent_websocket(provider)
     async def __aiter__(self) -> AsyncIterator[Self]:
+        if not await self.provider.is_connected():
+            await self.provider.connect()
+
         while True:
             try:
                 yield self

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -1,6 +1,5 @@
 import logging
 from typing import (
-    AsyncIterator,
     TYPE_CHECKING,
     Any,
     AsyncGenerator,
@@ -28,6 +27,9 @@ from web3._utils.async_caching import (
 )
 from web3._utils.caching import (
     generate_cache_key,
+)
+from web3._utils.compat import (
+    Self,
 )
 from web3.datastructures import (
     NamedElementOnion,
@@ -441,7 +443,7 @@ class _AsyncPersistentRecvStream:
         self.manager = manager
         super().__init__(*args, **kwargs)
 
-    def __aiter__(self) -> AsyncIterator[RPCResponse]:
+    def __aiter__(self) -> Self:
         return self
 
     async def __anext__(self) -> RPCResponse:

--- a/web3/middleware/formatting.py
+++ b/web3/middleware/formatting.py
@@ -16,6 +16,7 @@ from eth_utils.toolz import (
 from web3.types import (
     AsyncMiddleware,
     AsyncMiddlewareCoroutine,
+    EthSubscriptionParams,
     Formatters,
     FormattersDict,
     Literal,
@@ -52,7 +53,9 @@ def _apply_response_formatters(
         method_response_formatter: Callable[..., Any],
     ) -> RPCResponse:
         appropriate_response = response[response_type]
+
         if response_type == "params":
+            appropriate_response = cast(EthSubscriptionParams, response[response_type])
             return assoc(
                 response,
                 response_type,

--- a/web3/middleware/geth_poa.py
+++ b/web3/middleware/geth_poa.py
@@ -4,6 +4,7 @@ from typing import (
     Callable,
 )
 
+from eth_utils import is_dict
 from eth_utils.curried import (
     apply_formatter_if,
     apply_formatters_to_dict,
@@ -68,6 +69,11 @@ async def async_geth_poa_middleware(
         result_formatters={
             RPC.eth_getBlockByHash: apply_formatter_if(is_not_null, geth_poa_cleanup),
             RPC.eth_getBlockByNumber: apply_formatter_if(is_not_null, geth_poa_cleanup),
+            RPC.eth_subscribe: apply_formatter_if(
+                is_not_null,
+                # original call to eth_subscribe returns a string, needs a dict check
+                apply_formatter_if(is_dict, geth_poa_cleanup),
+            ),
         },
     )
     return await middleware(make_request, w3)

--- a/web3/middleware/geth_poa.py
+++ b/web3/middleware/geth_poa.py
@@ -4,7 +4,9 @@ from typing import (
     Callable,
 )
 
-from eth_utils import is_dict
+from eth_utils import (
+    is_dict,
+)
 from eth_utils.curried import (
     apply_formatter_if,
     apply_formatters_to_dict,

--- a/web3/providers/persistent.py
+++ b/web3/providers/persistent.py
@@ -1,11 +1,7 @@
 from abc import (
     ABC,
 )
-from concurrent.futures import (
-    ThreadPoolExecutor,
-)
 import logging
-import threading
 from typing import (
     Optional,
 )
@@ -33,8 +29,6 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
 
     _ws: Optional[WebSocketClientProtocol] = None
     _request_processor: RequestProcessor
-    _thread_pool: ThreadPoolExecutor = ThreadPoolExecutor()
-    _lock: threading.Lock = threading.Lock()
 
     def __init__(
         self,

--- a/web3/providers/persistent.py
+++ b/web3/providers/persistent.py
@@ -34,7 +34,7 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
         self,
         endpoint_uri: str,
         request_cache_size: int = 100,
-        call_timeout: int = DEFAULT_PERSISTENT_CONNECTION_TIMEOUT,
+        call_timeout: float = DEFAULT_PERSISTENT_CONNECTION_TIMEOUT,
     ) -> None:
         super().__init__()
         self.endpoint_uri = endpoint_uri

--- a/web3/providers/websocket/request_processor.py
+++ b/web3/providers/websocket/request_processor.py
@@ -183,11 +183,12 @@ class RequestProcessor:
     async def pop_raw_response(self, cache_key: str) -> Any:
         async with self._raw_response_cache_lock:
             raw_response = self._raw_response_cache.pop(cache_key)
-            self._provider.logger.debug(
-                f"Cached response processed and popped from cache:\n"
-                f"    cache_key={cache_key},\n"
-                f"    raw_response={raw_response}"
-            )
+        self._provider.logger.debug(
+            f"Cached response processed and popped from cache:\n"
+            f"    cache_key={cache_key},\n"
+            f"    raw_response={raw_response}"
+        )
+        return raw_response
 
     # request processor class methods
 

--- a/web3/providers/websocket/websocket_connection.py
+++ b/web3/providers/websocket/websocket_connection.py
@@ -33,4 +33,4 @@ class WebsocketConnection:
         return await self._w3.manager.ws_recv()
 
     def listen_to_websocket(self) -> "_AsyncPersistentRecvStream":
-        return self._w3.manager.persistent_recv_stream()
+        return self._w3.manager._persistent_recv_stream()

--- a/web3/types.py
+++ b/web3/types.py
@@ -281,6 +281,14 @@ class GethSyncingSubscriptionResponse(SubscriptionResponse):
     result: GethSyncingSubscriptionResult
 
 
+EthSubscriptionParams = Union[
+    BlockTypeSubscriptionResponse,
+    TransactionTypeSubscriptionResponse,
+    LogsSubscriptionResponse,
+    SyncingSubscriptionResponse,
+    GethSyncingSubscriptionResponse,
+]
+
 RPCId = Optional[Union[int, str]]
 
 
@@ -292,12 +300,13 @@ class RPCResponse(TypedDict, total=False):
 
     # eth_subscribe
     method: Literal["eth_subscription"]
-    params: Union[
-        BlockTypeSubscriptionResponse,
-        TransactionTypeSubscriptionResponse,
-        LogsSubscriptionResponse,
-        SyncingSubscriptionResponse,
-        GethSyncingSubscriptionResponse,
+    params: EthSubscriptionParams
+
+
+class FormattedEthSubscriptionResponse(TypedDict):
+    subscription: HexStr
+    result: Union[
+        BlockData, TxData, LogReceipt, SyncProgress, GethSyncingSubscriptionResult
     ]
 
 


### PR DESCRIPTION
### What was wrong?

- Closes #3093
- `WebsocketProviderV2` needed tests for subscriptions. While we revamp the test suite and try to get some actual integration tests for `eth_subscribe`, introduce some static tests to make sure our formatters and middleware work appropriately for subscriptions.
- Adds a timeout around trying to match the response `id` to the request `id` for a request. Also improves on the logic around matching the ids, simplifying it.
- Add unit tests for the raw response cache process. 
  - Ensure we are caching any undesired responses before returning the desired response.
  - Ensure we return the desired cached response, if cached, and that we never call recv() in that case. 
  - Test the timeout if a response with matching `id` never comes (see above bullet point for test case).
- **(breaking change for beta provider)** Refactor to a proper AsyncIterator pattern for receiving a persistent message stream from the socket.
- Update docs based on the above

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20231004_181437](https://github.com/ethereum/web3.py/assets/3532824/a7369729-ecc7-4db7-98f5-87c77d5c042f)
