### PR TITLE
Add custom list and backoff factor to http_retry_middleware

### DIFF
--- a/newsfragments/3120.feature.rst
+++ b/newsfragments/3120.feature.rst
@@ -1,0 +1,1 @@
+Add ``allow_list`` kwarg for ``exception_retry_middleware`` to allow for a custom list of RPC endpoints. Add a sleep between retries and a customizable ``backoff_factor`` to control the sleep time between retry attempts.


### PR DESCRIPTION
### What was wrong?

closes #958 
closes #1911 

### How was it fixed?

- Add kwarg for importing custom list of RPC methods to retry on
- Add kwarg, as in the async version, for a backoff factor to prevent timeout issues and provide flexibility

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20231006_081808](https://github.com/ethereum/web3.py/assets/3532824/d51c5819-41f5-4f93-b7c7-5bb8bc88ac66)

