### PR TITLE
bump and pin mypy to latest version that supports py37

### DIFF
--- a/newsfragments/3122.internal.rst
+++ b/newsfragments/3122.internal.rst
@@ -1,0 +1,1 @@
+Pin mypy to v1.4.1, the last to support py37

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extras_require = {
         "black>=22.1.0",
         "flake8==3.8.3",
         "isort>=5.11.0",
-        "mypy>=1.0.0",
+        "mypy==1.4.1",
         "types-setuptools>=57.4.4",
         "types-requests>=2.26.1",
         "types-protobuf==3.19.13",


### PR DESCRIPTION
### What was wrong?

`mypy` was mistakenly given only a lower-bound, should have been pinned, and its new 1.6.0 release introduced a change that breaks CI.

### How was it fixed?
Pinned to latest version that still supports py37, 1.4.1

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/9f9e8fcd-60c8-4476-b266-1457e0b16842)
