### PR TITLE
Fix type for Optional BlockIdentifier

### DIFF
--- a/newsfragments/3114.misc.rst
+++ b/newsfragments/3114.misc.rst
@@ -1,0 +1,1 @@
+Fix optional ``BlockIdentifier`` argument type in synchronous ``get_storage_at`` method.

--- a/web3/eth/eth.py
+++ b/web3/eth/eth.py
@@ -482,12 +482,23 @@ class Eth(BaseEth):
 
     # eth_getStorageAt
 
-    get_storage_at: Method[
-        Callable[[Union[Address, ChecksumAddress, ENS], int], HexBytes]
+    _get_storage_at: Method[
+        Callable[
+            [Union[Address, ChecksumAddress, ENS], int, Optional[BlockIdentifier]],
+            HexBytes,
+        ]
     ] = Method(
         RPC.eth_getStorageAt,
         mungers=[BaseEth.get_storage_at_munger],
     )
+
+    def get_storage_at(
+        self,
+        account: Union[Address, ChecksumAddress, ENS],
+        position: int,
+        block_identifier: Optional[BlockIdentifier] = None,
+    ) -> HexBytes:
+        return self._get_storage_at(account, position, block_identifier)
 
     # eth_getProof
 


### PR DESCRIPTION
### What was wrong?

Closes #3114 

### How was it fixed?
* Added the BlockIdentifier type as optional
* Created a private method to specify `None` as the default for the optional argument

### Todo:
- [X] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.shemazing.net/wp-content/uploads/2018/10/fuzzapichu-656x431.jpg)
