### PR TITLE
WebsocketProviderV2 `recv()` lock + other multi-tasking support

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -201,13 +201,13 @@ message and receive a response to that particular request,
 response *id* values coming back from the websocket connection. Any provider that does
 not adhere to the `JSON-RPC 2.0 specification <https://www.jsonrpc.org/specification>`_
 in this way will not work with ``PersistentConnectionProvider`` instances. The specifics
-of how the request processor handles this is outlined below.
+of how the request processor handles this are outlined below.
 
 One-To-One Requests
 ~~~~~~~~~~~~~~~~~~~
 
-One-to-one requests can be summarized as any request that expects one response back.
-An example is using the ``eth`` module API to request the latest block number.
+One-to-one requests can be summarized as any request that expects only one response
+back. An example is using the ``eth`` module API to request the latest block number.
 
 .. code-block:: python
 
@@ -220,13 +220,13 @@ An example is using the ``eth`` module API to request the latest block number.
 
     >>> asyncio.run(wsV2_one_to_one_example())
 
-With websockets we have to call ``ws_send()`` and asynchronously receive responses via
-``ws.recv()``. In order to make the one-to-one request-to-response call work, we
-have to save the request information somewhere so that, when the response is received,
-we can match it to the original request that was made (the request with a matching *id*
-to the response that was received), and use that request information to process the
-response. Processing the response, in this case, means running it through the
-formatters and middlewares internal to the *web3.py* library.
+With websockets we have to call ``send()`` and asynchronously receive responses via
+``recv()``. In order to make the one-to-one request-to-response call work, we
+have to save the request information somewhere so that when the response is received
+we can match it to the original request that was made i.e. the request with a matching
+*id* to the response that was received). The stored request information is then used to
+process the response when it is received, piping it through the response formatters and
+middlewares internal to the *web3.py* library.
 
 In order to store the request information, the ``RequestProcessor`` class has an
 internal ``RequestInformation`` cache. The ``RequestInformation`` class saves important
@@ -279,7 +279,7 @@ successful. For this reason, the original request is considered a one-to-one req
 so that a subscription *id* can be returned to the user on the same line, but the
 ``listen_to_websocket()`` method on the
 :class:`~web3.providers.websocket.WebsocketConnection` class, the public API for
-interacting with the active websocket connection, is set up to receive many-to-one
+interacting with the active websocket connection, is set up to receive
 ``eth_subscription`` responses over an asynchronous interator pattern.
 
 .. code-block:: python

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -185,3 +185,138 @@ Managers
 The Manager acts as a gatekeeper for the request/response lifecycle.  It is
 unlikely that you will need to change the Manager as most functionality can be
 implemented in the Middleware layer.
+
+
+Request Processing for Persistent Connection Providers
+------------------------------------------------------
+
+.. py:class:: web3.providers.websocket.request_processor.RequestProcessor
+
+The ``RequestProcessor`` class is responsible for the storing and syncing up of
+asynchronous requests to responses for a ``PersistentConnectionProvider``. The best
+example of one such provider is the
+:class:`~web3.providers.websocket.WebsocketProviderV2`. In order to send a websocket
+message and receive a response to that particular request,
+``PersistentConnectionProvider`` instances have to match request *id* values to
+response *id* values coming back from the websocket connection. Any provider that does
+not adhere to the `JSON-RPC 2.0 specification <https://www.jsonrpc.org/specification>`_
+in this way will not work with ``PersistentConnectionProvider`` instances. The specifics
+of how the request processor handles this is outlined below.
+
+One-To-One Requests
+~~~~~~~~~~~~~~~~~~~
+
+One-to-one requests can be summarized as any request that expects one response back.
+An example is using the ``eth`` module API to request the latest block number.
+
+.. code-block:: python
+
+    >>> async def wsV2_one_to_one_example():
+    ...     async with AsyncWeb3.persistent_websocket(
+    ...         WebsocketProviderV2(f"ws://127.0.0.1:8546")
+    ...     ) as w3:
+    ...         # make a request and expect a single response returned on the same line
+    ...         latest_block_num = await w3.eth.block_number
+
+    >>> asyncio.run(wsV2_one_to_one_example())
+
+With websockets we have to call ``ws_send()`` and asynchronously receive responses via
+``ws.recv()``. In order to make the one-to-one request-to-response call work, we
+have to save the request information somewhere so that, when the response is received,
+we can match it to the original request that was made (the request with a matching *id*
+to the response that was received), and use that request information to process the
+response. Processing the response, in this case, means running it through the
+formatters and middlewares internal to the *web3.py* library.
+
+In order to store the request information, the ``RequestProcessor`` class has an
+internal ``RequestInformation`` cache. The ``RequestInformation`` class saves important
+information about a request.
+
+.. py:class:: web3._utils.caching.RequestInformation
+
+    .. py:attribute:: method
+
+        The name of the method - e.g. "eth_subscribe".
+
+    .. py:attribute:: params
+
+        The params used when the call was made - e.g. ("newPendingTransactions", True).
+
+    .. py:attribute:: response_formatters
+
+        The formatters that will be used to process the response.
+
+    .. py:attribute:: middleware_response_processors
+
+        Any middleware that processes responses that is present on the instance at the
+        time of the request is appended here, in order, so the response may be piped
+        through that logic when it comes in.
+
+    .. py:attribute:: subscription_id
+
+        If the request is an ``eth_subscribe`` request, rather than
+        popping this information from the cache when the response to the subscription call
+        comes in (i.e. the subscription *id*), we save the subscription id with the
+        request information so that we can correctly process all subscription messages
+        that come in with that subscription *id*. For one-to-one request-to-response
+        calls, this value is always ``None``.
+
+One-to-one responses, those that include a JSON-RPC *id* in the response object, are
+stored in an internal ``SimpleCache`` class, isolated from any one-to-many responses.
+When the ``PersistentConnectionProvider`` is looking for a response internally, it will
+cycle within a ``while`` loop, alternating between checking this cache (in case
+somewhere else in the code our desired response was cached by another call) and calling
+``recv()`` on the websocket connection to see if it is yet to come.
+
+One-To-Many Requests
+~~~~~~~~~~~~~~~~~~~~
+
+One-to-many requests can be summarized by any request that expects many responses as a
+result of the initial request. An example is the ``eth_subscribe`` request. The initial
+``eth_subscribe`` request expects only one response, the subscription *id* value, but
+it also expects to receive many ``eth_subscription`` messages if and when the request is
+successful. For this reason, the original request is considered a one-to-one request
+so that a subscription *id* can be returned to the user on the same line, but the
+``listen_to_websocket()`` method on the
+:class:`~web3.providers.websocket.WebsocketConnection` class, the public API for
+interacting with the active websocket connection, is set up to receive many-to-one
+``eth_subscription`` responses over an asynchronous interator pattern.
+
+.. code-block:: python
+
+    >>> async def ws_v2_subscription_example():
+    ...     async with AsyncWeb3.persistent_websocket(
+    ...         WebsocketProviderV2(f"ws://127.0.0.1:8546")
+    ...     ) as w3:
+    ...         # Subscribe to new block headers and receive the subscription_id.
+    ...         # A one-to-one call with a trigger for many responses
+    ...         subscription_id = await w3.eth.subscribe("newHeads")
+    ...
+    ...         # Listen to the websocket for the many responses utilizing the ``w3.ws``
+    ...         # ``WebsocketConnection`` public API method ``listen_to_websocket()``
+    ...         async for response in w3.ws.listen_to_websocket():
+    ...             # Receive only one-to-many responses here so that we don't
+    ...             # accidentally return the response for a one-to-one request in this
+    ...             # block
+    ...
+    ...             print(f"{response}\n")
+    ...
+    ...             if some_condition:
+    ...                 # unsubscribe from new block headers, another one-to-one request
+    ...                 is_unsubscribed = await w3.eth.unsubscribe(subscription_id)
+    ...                 if is_unsubscribed:
+    ...                     break
+
+    >>> asyncio.run(ws_v2_subscription_example())
+
+One-to-many responses, those that do not include a JSON-RPC *id* in the response object,
+are stored in an internal ``collections.deque`` instance, isolated from any one-to-one
+responses. When the ``PersistentConnectionProvider`` is looking for a one-to-many
+response internally, it will cycle within a ``while`` loop, alternating between
+checking this deque (in case somewhere else in the code, subscriptions responses were
+put in the deque by another call looking for another response type) and calling
+``recv()`` on the websocket connection to see if the response is yet to be received.
+With each iteration on this iterator, if the ``deque`` is non-empty, it will yield
+messages from the ``deque`` as FIFO order until the deque is empty before receiving any
+new messages from the websocket connection, guaranteeing the messages are yielded in the
+order they were received.

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -397,8 +397,8 @@ Interacting with the Websocket Connection
 
         This method is available for listening to websocket responses indefinitely.
         It is an asynchronous iterator that yields strictly one-to-many
-        (e.g. eth_subscription responses) request-to-response responses from the
-        websocket connection. To receive responses for 1-to-1 request-to-response
+        (e.g. ``eth_subscription`` responses) request-to-response responses from the
+        websocket connection. To receive responses for one-to-one request-to-response
         calls, use the standard API for making requests via the appropriate module
         (e.g. ``block_num = await w3.eth.block_number``)
 

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -222,6 +222,10 @@ WebsocketProvider
 WebsocketProviderV2 (beta)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. warning:: This provider is still in beta. However, it is being actively developed
+    and supported and is expected to be stable in the next major version of *web3.py*
+    (v7).
+
 .. py:class:: web3.providers.websocket.WebsocketProviderV2(endpoint_uri, websocket_kwargs, call_timeout)
 
     This provider handles interactions with an WS or WSS based JSON-RPC server.
@@ -348,6 +352,13 @@ provider in separate lines. Both of these examples are shown below.
     >>> asyncio.run(ws_v2_alternate_init_example_1)
     >>> asyncio.run(ws_v2_alternate_init_example_2)
 
+The ``WebsocketProviderV2`` class uses the
+:class:`~web3.providers.websocket.request_processor.RequestProcessor` class under the
+hood to sync up the receiving of responses and response processing for one-to-one and
+one-to-many request-to-response requests. Refer to the
+:class:`~web3.providers.websocket.request_processor.RequestProcessor`
+documentation for details.
+
 _PersistentConnectionWeb3 via AsyncWeb3.persistent_websocket()
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -356,54 +367,61 @@ When an ``AsyncWeb3`` class is connected to a persistent websocket connection, v
 ``_PersistentConnectionWeb3`` class. This class has a few additional methods and
 attributes that are not available on the ``AsyncWeb3`` class.
 
-.. py:attribute:: _PersistentConnectionWeb3.ws
+.. py:class:: web3.main._PersistentConnectionWeb3
 
-    Listening to websocket responses, and sending raw requests, can be done using the
-    ``ws`` attribute of the ``_PersistentConnectionWeb3`` class. The ``ws`` attribute
-    houses a public API, a :class:`~web3.providers.websocket.WebsocketConnection` class,
-    for sending and receiving websocket messages.
+    .. py:attribute:: ws
 
-    .. py:class:: web3.providers.websocket.WebsocketConnection()
+        The public API for interacting with the websocket connection is available via
+        the ``ws`` attribute of the ``_PersistentConnectionWeb3`` class. This attribute
+        is an instance of the
+        :class:`~web3.providers.websocket.WebsocketConnection` class and is the main
+        interface for interacting with the websocket connection.
 
-        This class handles interactions with a websocket connection. It is available
-        via the ``ws`` attribute of the ``_PersistentConnectionWeb3`` class. The
-        ``WebsocketConnection`` class has the following methods and attributes:
 
-        .. py:attribute:: subscriptions
+Interacting with the Websocket Connection
++++++++++++++++++++++++++++++++++++++++++
 
-            This attribute returns the current active subscriptions as a dict mapping
-            the subscription ``id`` to a dict of metadata about the subscription
-            request.
+.. py:class:: web3.providers.websocket.WebsocketConnection
 
-        .. py:method:: listen_to_websocket()
+    This class handles interactions with a websocket connection. It is available
+    via the ``ws`` attribute of the ``_PersistentConnectionWeb3`` class. The
+    ``WebsocketConnection`` class has the following methods and attributes:
 
-            This method is available for listening to websocket responses indefinitely.
-            It is an asynchronous iterator that yields strictly one-to-many
-            (e.g. eth_subscription responses) request-to-response responses from the
-            websocket connection. To receive responses for 1-to-1 request-to-response
-            calls, use the standard API for making requests via the appropriate module
-            (e.g. ``block_num = await w3.eth.block_number``)
+    .. py:attribute:: subscriptions
 
-            The responses from this method are formatted by web3.py formatters and run
-            through the middlewares that were present at the time of subscription.
-            An example of its use can be seen above in the `Usage`_ section.
+        This attribute returns the current active subscriptions as a dict mapping
+        the subscription ``id`` to a dict of metadata about the subscription
+        request.
 
-        .. py:method:: recv()
+    .. py:method:: listen_to_websocket()
 
-            The ``recv()`` method can be used to receive the next message from the
-            websocket. The response from this method is formatted by web3.py formatters
-            and run through the middlewares before being returned. This is useful for
-            receiving singled responses for one-to-many requests such receiving the
-            next ``eth_subscribe`` subscription response.
+        This method is available for listening to websocket responses indefinitely.
+        It is an asynchronous iterator that yields strictly one-to-many
+        (e.g. eth_subscription responses) request-to-response responses from the
+        websocket connection. To receive responses for 1-to-1 request-to-response
+        calls, use the standard API for making requests via the appropriate module
+        (e.g. ``block_num = await w3.eth.block_number``)
 
-        .. py:method:: send(method: RPCEndpoint, params: Sequence[Any])
+        The responses from this method are formatted by web3.py formatters and run
+        through the middlewares that were present at the time of subscription.
+        An example of its use can be seen above in the `Usage`_ section.
 
-            This method is available strictly for sending raw requests to the websocket,
-            if desired. It is not recommended to use this method directly, as the
-            responses will not be formatted by web3.py formatters or run through the
-            middlewares. Instead, use the methods available on the respective web3
-            module. For example, use ``w3.eth.get_block("latest")`` instead of
-            ``w3.ws.send("eth_getBlockByNumber", ["latest", True])``.
+    .. py:method:: recv()
+
+        The ``recv()`` method can be used to receive the next message from the
+        websocket. The response from this method is formatted by web3.py formatters
+        and run through the middlewares before being returned. This is useful for
+        receiving singled responses for one-to-many requests such receiving the
+        next ``eth_subscribe`` subscription response.
+
+    .. py:method:: send(method: RPCEndpoint, params: Sequence[Any])
+
+        This method is available strictly for sending raw requests to the websocket,
+        if desired. It is not recommended to use this method directly, as the
+        responses will not be formatted by web3.py formatters or run through the
+        middlewares. Instead, use the methods available on the respective web3
+        module. For example, use ``w3.eth.get_block("latest")`` instead of
+        ``w3.ws.send("eth_getBlockByNumber", ["latest", True])``.
 
 
 AutoProvider

--- a/newsfragments/3125.docs.rst
+++ b/newsfragments/3125.docs.rst
@@ -1,0 +1,1 @@
+Update ``WebsocketProviderV2`` documentation. Document a general overview of the ``RequestProcessor`` class and its internal caches.

--- a/newsfragments/3125.feature.rst
+++ b/newsfragments/3125.feature.rst
@@ -1,0 +1,1 @@
+Properly define an ``__await__()`` method on the ``_PersistentConnectionWeb3`` class so a persistent connection may be initialized using the ``await`` pattern. Integration tests added for initializing the persistent connection using the ``await`` pattern.

--- a/newsfragments/3125.internal.rst
+++ b/newsfragments/3125.internal.rst
@@ -1,0 +1,1 @@
+Updates and refactoring for the ``WebsocketProviderV2`` class and its internal supporting classes and logic. Separation of one-to-one and one-to-many request responses. Storing of one-to-many responses in a ``deque`` and one-to-one responses in a ``SimpleCache`` class. Provide an async lock around the websocket ``recv()``.

--- a/tests/core/providers/test_wsv2_provider.py
+++ b/tests/core/providers/test_wsv2_provider.py
@@ -61,7 +61,7 @@ async def test_async_make_request_caches_all_undesired_responses_and_returns_des
     assert response == json.loads(ws_recv_responses.pop())  # pop the expected response
 
     assert (
-        len(provider._request_processor._raw_response_cache)
+        len(provider._request_processor._request_response_cache)
         == len(ws_recv_responses)
         == undesired_responses_count
     )
@@ -69,7 +69,7 @@ async def test_async_make_request_caches_all_undesired_responses_and_returns_des
     for (
         _cache_key,
         cached_response,
-    ) in provider._request_processor._raw_response_cache.items():
+    ) in provider._request_processor._request_response_cache.items():
         # assert all cached responses are in the list of responses we received
         assert to_bytes(text=json.dumps(cached_response)) in ws_recv_responses
 
@@ -95,7 +95,7 @@ async def test_async_make_request_returns_cached_response_with_no_recv_if_cached
     response = await method_under_test(RPCEndpoint("some_method"), ["desired_params"])
     assert response == desired_response
 
-    assert len(provider._request_processor._raw_response_cache) == 0
+    assert len(provider._request_processor._request_response_cache) == 0
     assert not provider._ws.recv.called  # type: ignore
 
 

--- a/tests/integration/go_ethereum/test_goethereum_ws_v2/test_async_await_w3.py
+++ b/tests/integration/go_ethereum/test_goethereum_ws_v2/test_async_await_w3.py
@@ -29,9 +29,8 @@ from ..utils import (
 async def async_w3(geth_process, endpoint_uri):
     await wait_for_aiohttp(endpoint_uri)
 
-    # async context manager pattern
-    async with AsyncWeb3.persistent_websocket(WebsocketProviderV2(endpoint_uri)) as w3:
-        yield w3
+    # await the persistent connection itself
+    return await AsyncWeb3.persistent_websocket(WebsocketProviderV2(endpoint_uri))
 
 
 class TestGoEthereumAsyncAdminModuleTest(GoEthereumAsyncAdminModuleTest):

--- a/tests/integration/go_ethereum/test_goethereum_ws_v2/test_async_ctx_manager_w3.py
+++ b/tests/integration/go_ethereum/test_goethereum_ws_v2/test_async_ctx_manager_w3.py
@@ -31,7 +31,7 @@ async def async_w3(geth_process, endpoint_uri):
 
     # async context manager pattern
     async with AsyncWeb3.persistent_websocket(
-        WebsocketProviderV2(endpoint_uri, call_timeout=30)
+        WebsocketProviderV2(endpoint_uri, request_timeout=30)
     ) as w3:
         yield w3
 

--- a/tests/integration/go_ethereum/test_goethereum_ws_v2/test_async_iterator_w3.py
+++ b/tests/integration/go_ethereum/test_goethereum_ws_v2/test_async_iterator_w3.py
@@ -31,7 +31,7 @@ async def async_w3(geth_process, endpoint_uri):
 
     # async iterator pattern
     async for w3 in AsyncWeb3.persistent_websocket(
-        WebsocketProviderV2(endpoint_uri, call_timeout=30)
+        WebsocketProviderV2(endpoint_uri, request_timeout=30)
     ):
         return w3
 

--- a/tests/integration/go_ethereum/test_goethereum_ws_v2/test_async_iterator_w3.py
+++ b/tests/integration/go_ethereum/test_goethereum_ws_v2/test_async_iterator_w3.py
@@ -30,9 +30,7 @@ async def async_w3(geth_process, endpoint_uri):
     await wait_for_aiohttp(endpoint_uri)
 
     # async iterator pattern
-    async for w3 in AsyncWeb3.persistent_websocket(
-        WebsocketProviderV2(endpoint_uri, request_timeout=30)
-    ):
+    async for w3 in AsyncWeb3.persistent_websocket(WebsocketProviderV2(endpoint_uri)):
         return w3
 
 

--- a/web3/_utils/caching.py
+++ b/web3/_utils/caching.py
@@ -51,8 +51,10 @@ class RequestInformation:
         method: "RPCEndpoint",
         params: Any,
         response_formatters: Tuple[Callable[..., Any], ...],
+        subscription_id: str = None,
     ):
         self.method = method
         self.params = params
         self.response_formatters = response_formatters
+        self.subscription_id = subscription_id
         self.middleware_response_processors: List[Callable[..., Any]] = []

--- a/web3/main.py
+++ b/web3/main.py
@@ -32,6 +32,7 @@ from hexbytes import (
     HexBytes,
 )
 from typing import (
+    TYPE_CHECKING,
     Any,
     AsyncIterator,
     Dict,
@@ -40,7 +41,6 @@ from typing import (
     Optional,
     Sequence,
     Type,
-    TYPE_CHECKING,
     Union,
     cast,
 )
@@ -527,7 +527,7 @@ class AsyncWeb3(BaseWeb3):
 class _PersistentConnectionWeb3(AsyncWeb3):
     provider: PersistentConnectionProvider
 
-    # w3 = AsyncWeb3(provider)
+    # w3 = AsyncWeb3.persistent_websocket(provider)
     # await w3.provider.connect()
     def __init__(
         self,

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -369,10 +369,12 @@ class RequestManager:
             )
 
         while True:
+            # look in the cache for a response
             response = await self._request_processor.pop_raw_response(subscription=True)
             if response is not None:
                 break
             else:
+                # if no response in the cache, check the websocket connection
                 if not self._provider._ws_lock.locked():
                     async with self._provider._ws_lock:
                         try:

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -415,7 +415,7 @@ class RequestManager:
                     # subscription as it comes in
                     request_info.subscription_id = subscription_id
                     provider.logger.debug(
-                        f"Caching eth_subscription info:\n    "
+                        "Caching eth_subscription info:\n    "
                         f"cache_key={cache_key},\n    "
                         f"request_info={request_info.__dict__}"
                     )

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -74,6 +74,9 @@ if TYPE_CHECKING:
         AsyncBaseProvider,
         BaseProvider,
     )
+    from web3.providers.websocket.request_processor import (  # noqa: F401
+        RequestProcessor,
+    )
 
 
 NULL_RESPONSES = [None, HexBytes("0x"), "0x"]
@@ -152,7 +155,7 @@ class RequestManager:
             # set up the request processor to be able to properly process ordered
             # responses from the persistent connection as FIFO
             provider = cast(PersistentConnectionProvider, self.provider)
-            self._request_processor = provider._request_processor
+            self._request_processor: RequestProcessor = provider._request_processor
 
     w3: Union["AsyncWeb3", "Web3"] = None
     _provider = None
@@ -408,6 +411,7 @@ class RequestManager:
                 if cache_key not in self._request_processor._request_information_cache:
                     # cache by subscription id in order to process each response for the
                     # subscription as it comes in
+                    request_info.subscription_id = subscription_id
                     provider.logger.debug(
                         f"Caching eth_subscription info:\n    "
                         f"cache_key={cache_key},\n    "

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -390,7 +390,8 @@ class RequestManager:
                             response
                         )
 
-                await asyncio.sleep(0.01)
+                # this is important to let asyncio run other tasks
+                await asyncio.sleep(0.05)
 
         yield await self._process_ws_response(response)
 

--- a/web3/providers/persistent.py
+++ b/web3/providers/persistent.py
@@ -1,6 +1,7 @@
 from abc import (
     ABC,
 )
+import asyncio
 import logging
 from typing import (
     Optional,
@@ -28,19 +29,20 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
     has_persistent_connection = True
 
     _ws: Optional[WebSocketClientProtocol] = None
+    _ws_lock: asyncio.Lock = asyncio.Lock()
     _request_processor: RequestProcessor
 
     def __init__(
         self,
         endpoint_uri: str,
-        request_cache_size: int = 100,
         call_timeout: float = DEFAULT_PERSISTENT_CONNECTION_TIMEOUT,
+        subscription_response_deque_size: int = 500,
     ) -> None:
         super().__init__()
         self.endpoint_uri = endpoint_uri
         self._request_processor = RequestProcessor(
             self,
-            request_info_cache_size=request_cache_size,
+            subscription_response_deque_size=subscription_response_deque_size,
         )
         self.call_timeout = call_timeout
 

--- a/web3/providers/persistent.py
+++ b/web3/providers/persistent.py
@@ -35,7 +35,7 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
     def __init__(
         self,
         endpoint_uri: str,
-        call_timeout: float = DEFAULT_PERSISTENT_CONNECTION_TIMEOUT,
+        request_timeout: float = DEFAULT_PERSISTENT_CONNECTION_TIMEOUT,
         subscription_response_deque_size: int = 500,
     ) -> None:
         super().__init__()
@@ -44,7 +44,7 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
             self,
             subscription_response_deque_size=subscription_response_deque_size,
         )
-        self.call_timeout = call_timeout
+        self.request_timeout = request_timeout
 
     async def connect(self) -> None:
         raise NotImplementedError("Must be implemented by subclasses")
@@ -52,5 +52,5 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
     async def disconnect(self) -> None:
         raise NotImplementedError("Must be implemented by subclasses")
 
-    async def _ws_recv(self) -> RPCResponse:
+    async def _ws_recv(self, timeout: float = None) -> RPCResponse:
         raise NotImplementedError("Must be implemented by subclasses")

--- a/web3/providers/websocket/request_processor.py
+++ b/web3/providers/websocket/request_processor.py
@@ -8,6 +8,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Deque,
     Dict,
     Optional,
     Tuple,
@@ -34,7 +35,7 @@ if TYPE_CHECKING:
 class RequestProcessor:
     _request_information_cache: SimpleCache
     _request_response_cache: SimpleCache
-    _subscription_response_deque: deque[RPCResponse]
+    _subscription_response_deque: Deque[RPCResponse]
 
     def __init__(
         self,
@@ -104,7 +105,7 @@ class RequestProcessor:
             self._bump_cache_if_key_present(bump, request_id + 1)
 
             self._provider.logger.debug(
-                f"Caching internal request. Bumping original request in cache:\n"
+                "Caching internal request. Bumping original request in cache:\n"
                 f"    request_id=[{request_id}] -> [{request_id + 1}],\n"
                 f"    cache_key=[{cache_key}] -> [{bump}],\n"
                 f"    request_info={original_request_info.__dict__}"
@@ -117,7 +118,7 @@ class RequestProcessor:
         request_info = self._request_information_cache.pop(cache_key)
         if request_info is not None:
             self._provider.logger.debug(
-                f"Request info popped from cache:\n"
+                "Request info popped from cache:\n"
                 f"    cache_key={cache_key},\n    request_info={request_info.__dict__}"
             )
         return request_info
@@ -217,11 +218,11 @@ class RequestProcessor:
 
             raw_response = self._subscription_response_deque.popleft()
             self._provider.logger.debug(
-                f"Subscription response cache is not empty. Processing {deque_length} "
+                f"Subscription response deque is not empty. Processing {deque_length} "
                 "subscription(s) as FIFO before receiving new response."
             )
             self._provider.logger.debug(
-                f"Cached subscription response popped from cache to be processed:\n"
+                "Cached subscription response popped from deque to be processed:\n"
                 f"    raw_response={raw_response}"
             )
         else:
@@ -233,7 +234,7 @@ class RequestProcessor:
             raw_response = self._request_response_cache.pop(cache_key)
             if raw_response is not None:
                 self._provider.logger.debug(
-                    f"Cached response popped from cache to be processed:\n"
+                    "Cached response popped from cache to be processed:\n"
                     f"    cache_key={cache_key},\n"
                     f"    raw_response={raw_response}"
                 )

--- a/web3/providers/websocket/websocket_connection.py
+++ b/web3/providers/websocket/websocket_connection.py
@@ -1,6 +1,7 @@
 from typing import (
     TYPE_CHECKING,
     Any,
+    Dict,
 )
 
 from web3.types import (
@@ -24,13 +25,17 @@ class WebsocketConnection:
     """
 
     def __init__(self, w3: "_PersistentConnectionWeb3"):
-        self._w3 = w3
+        self._manager = w3.manager
+
+    @property
+    def subscriptions(self) -> Dict[str, Any]:
+        return self._manager._request_processor.active_subscriptions
 
     async def send(self, method: RPCEndpoint, params: Any) -> RPCResponse:
-        return await self._w3.manager.ws_send(method, params)
+        return await self._manager.ws_send(method, params)
 
     async def recv(self) -> Any:
-        return await self._w3.manager.ws_recv()
+        return await self._manager.ws_recv()
 
     def listen_to_websocket(self) -> "_AsyncPersistentRecvStream":
-        return self._w3.manager._persistent_recv_stream()
+        return self._manager._persistent_recv_stream()

--- a/web3/providers/websocket/websocket_v2.py
+++ b/web3/providers/websocket/websocket_v2.py
@@ -213,7 +213,7 @@ class WebsocketProviderV2(PersistentConnectionProvider):
                                 response, subscription=is_subscription
                             )
 
-                    # this is important to let asyncio run other tasksx
+                    # this is important to let asyncio run other tasks
                     await asyncio.sleep(0.05)
 
         try:

--- a/web3/providers/websocket/websocket_v2.py
+++ b/web3/providers/websocket/websocket_v2.py
@@ -151,7 +151,9 @@ class WebsocketProviderV2(PersistentConnectionProvider):
         request_data = self.encode_rpc_request(method, params)
 
         if self._ws is None:
-            await self.connect()
+            raise ProviderConnectionError(
+                "Connection to websocket has not been initiated for the provider."
+            )
 
         await asyncio.wait_for(
             self._ws.send(request_data), timeout=self.request_timeout

--- a/web3/providers/websocket/websocket_v2.py
+++ b/web3/providers/websocket/websocket_v2.py
@@ -203,8 +203,8 @@ class WebsocketProviderV2(PersistentConnectionProvider):
                                 response, subscription=is_subscription
                             )
 
-                    # this is important to let asyncio run other tasks
-                    await asyncio.sleep(0.1)
+                    # this is important to let asyncio run other tasksx
+                    await asyncio.sleep(0.05)
 
         try:
             # Enters a while loop, looking for a response id match to the request id.


### PR DESCRIPTION
### What was wrong?

Some use cases for `WebsocketProviderV2` don't allow `asyncio.gather(tasks...)`, for example, as it will halt when two coroutines try to call `recv()` on the websocket connection at once. This PR attempts to ameliorate these scenarios.

- Add an `asyncio.Lock` around the websocket `recv()` method.
- Change `listen_to_websocket()` so that it only listens to subscription (or one-to-many request / response) messages. This is because every `make_request()` expects a 1-to-1 response-to-request and expects it to be returned on the same line e.g. `variable_assignment = await w3.eth.block_number`. If we are persistently listening to the socket, we clearly expect many messages. So, we only listen to messages from one-to-many calls, triggered by a `ws.send()`.
- Add an API for retrieving active subscriptions: `w3.ws.subscriptions` (WebsocketConnection.subscriptions)
- Because of the separation of 1-to-1 request / response and one-to-many send() to recv() messages, separate the `RequestProcessor` caches into two types of "caches". The subscription cache is really a deque that always uses `popleft()`, so make it one. The response cache is looking for a particular cache key so this still makes sense to keep as an `OrderedDict`.

- Defines an ``__await__()`` on the ``_PersistentConnectionWeb3`` class so the ``AsyncWeb3.persistent_websocket()`` instantiation can be awaited 
(i.e. ``w3 = await AsyncWeb3.persistent_websocket(WebsocketProviderV2(...))``). New integration test suite added with this pattern of instantiation.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)
- [x] Add tests for new additions

#### Cute Animal Picture

snake socks

```
    Y
  .-^-.
 /     \      .- ~ ~ -.
()     ()    /   _ _   `.                     _ _ _
 \_   _/    /  /     \   \                . ~  _ _  ~ .
   | |     /  /       \   \             .' .~       ~-. `.
   | |    /  /         )   )           /  /             `.`.
   \ \_ _/  /         /   /           /  /                `'
    \_ _ _.'         /   /           (  (               |=====|
                    /   /             \  \`             |=====|
                   /   /               \  \             |     |
                  /   /                 )  )            |      \___
                 (   (                 /  /             (        (_)
                  `.  `.             .'  /               ``````````
                    `.   ~ - - - - ~   .'
                       ~ . _ _ _ _ . ~