### PR TITLE
docs: Update advanced example to latest web3.py

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -928,7 +928,7 @@ The script can be run with: ``python ./eventscanner.py <your JSON-RPC API URL>``
         def get_block_timestamp(self, block_num) -> datetime.datetime:
             """Get Ethereum block timestamp"""
             try:
-                block_info = self.w3.eth.getBlock(block_num)
+                block_info = self.w3.eth.get_block(block_num)
             except BlockNotFound:
                 # Block was not mined yet,
                 # minor chain reorganisation?
@@ -956,7 +956,7 @@ The script can be run with: ``python ./eventscanner.py <your JSON-RPC API URL>``
 
             # Do not scan all the way to the final block, as this
             # block might not be mined yet
-            return self.w3.eth.blockNumber - 1
+            return self.w3.eth.block_number - 1
 
         def get_last_scanned_block(self) -> int:
             return self.state.get_last_scanned_block()


### PR DESCRIPTION
### What was wrong?

The advanced example in the docs contained some outdated syntax

### How was it fixed?
The advanced example contains two deprecated functions which do not work in the latest version of web3.py:
```
block_info = self.w3.eth.getBlock(block_num)
```
which got changed to
```
block_info = self.w3.eth.get_block(block_num)
```
and
```
return self.w3.eth.blockNumber - 1
```
which got changed to
```
return self.w3.eth.block_number - 1
```

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://lh3.googleusercontent.com/pw/ADCreHdcyoud9h4v9In_Buitj037_8zYkPFYa_8J7nlBMOxeD56K8OR2osKzelIRAFvNOTebKUg8jnzd77kxFS_QKKyDLSmrdYEocAU0vw-F5w0CH01StgFP1hr1iTJh5q5ssJ8BkVyHsMpVbSnWmb8LnZKxbA=w810-h1076-s-no-gm)
