### PR TITLE
add upper pin to hexbytes dep due to incoming breaking update in 0.4.0

### DIFF
--- a/newsfragments/3127.internal.rst
+++ b/newsfragments/3127.internal.rst
@@ -1,0 +1,1 @@
+Add upper pin to ``hexbytes`` dependency to due incoming breaking change

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
         "eth-hash[pycryptodome]>=0.5.1",
         "eth-typing>=3.0.0",
         "eth-utils>=2.1.0",
-        "hexbytes>=0.1.0",
+        "hexbytes>=0.1.0,<0.4.0",
         "jsonschema>=4.0.0",
         "lru-dict>=1.1.6",
         "protobuf>=4.21.6",


### PR DESCRIPTION
### What was wrong?

The hexbytes lib will be changing the way `Hexbytes.hex()` works - https://github.com/ethereum/hexbytes/issues/14

### How was it fixed?

Add upper pin to hexbytes dep now, then web3 v7 will use hexbytes 0.4.0 as a lower bound.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/c59e61df-d04b-4b65-bc2d-af827df9b133)
