### PR TITLE
Add formatter for ``data`` field for transaction results

### DIFF
--- a/newsfragments/3129.misc.rst
+++ b/newsfragments/3129.misc.rst
@@ -1,0 +1,1 @@
+Add transaction result formatter for ``data`` field. Nethermind, for example, returns both ``data`` and ``input`` for transaction results.

--- a/tests/core/contracts/test_contract_constructor.py
+++ b/tests/core/contracts/test_contract_constructor.py
@@ -3,6 +3,9 @@ import pytest
 from eth_utils import (
     decode_hex,
 )
+from hexbytes import (
+    HexBytes,
+)
 
 from web3._utils.contract_sources.contract_data.constructor_contracts import (
     CONSTRUCTOR_WITH_ADDRESS_ARGUMENT_CONTRACT_RUNTIME,
@@ -217,11 +220,11 @@ def test_contract_constructor_build_transaction_no_constructor(
     txn = w3.eth.get_transaction(txn_hash)
     nonce = w3.eth.get_transaction_count(w3.eth.coinbase)
     unsent_txn = math_contract_factory.constructor().build_transaction({"nonce": nonce})
-    assert txn["data"] == unsent_txn["data"]
+    assert txn["data"] == HexBytes(unsent_txn["data"])
 
     new_txn_hash = w3.eth.send_transaction(unsent_txn)
     new_txn = w3.eth.get_transaction(new_txn_hash)
-    assert new_txn["data"] == unsent_txn["data"]
+    assert new_txn["data"] == HexBytes(unsent_txn["data"])
     assert new_txn["nonce"] == nonce
 
 
@@ -234,11 +237,11 @@ def test_contract_constructor_build_transaction_without_arguments(
     txn = w3.eth.get_transaction(txn_hash)
     nonce = w3.eth.get_transaction_count(w3.eth.coinbase)
     unsent_txn = math_contract_factory.constructor().build_transaction({"nonce": nonce})
-    assert txn["data"] == unsent_txn["data"]
+    assert txn["data"] == HexBytes(unsent_txn["data"])
 
     new_txn_hash = w3.eth.send_transaction(unsent_txn)
     new_txn = w3.eth.get_transaction(new_txn_hash)
-    assert new_txn["data"] == unsent_txn["data"]
+    assert new_txn["data"] == HexBytes(unsent_txn["data"])
     assert new_txn["nonce"] == nonce
 
 
@@ -266,11 +269,11 @@ def test_contract_constructor_build_transaction_with_arguments(
     unsent_txn = non_strict_contract_with_constructor_args_factory.constructor(
         *constructor_args, **constructor_kwargs
     ).build_transaction({"nonce": nonce})
-    assert txn["data"] == unsent_txn["data"]
+    assert txn["data"] == HexBytes(unsent_txn["data"])
 
     new_txn_hash = w3_non_strict_abi.eth.send_transaction(unsent_txn)
     new_txn = w3_non_strict_abi.eth.get_transaction(new_txn_hash)
-    assert new_txn["data"] == unsent_txn["data"]
+    assert new_txn["data"] == HexBytes(unsent_txn["data"])
     assert new_txn["nonce"] == nonce
 
 
@@ -525,11 +528,11 @@ async def test_async_contract_constructor_build_transaction_no_constructor(
     unsent_txn = await async_math_contract_factory.constructor().build_transaction(
         {"nonce": nonce}
     )
-    assert txn["data"] == unsent_txn["data"]
+    assert txn["data"] == HexBytes(unsent_txn["data"])
 
     new_txn_hash = await async_w3.eth.send_transaction(unsent_txn)
     new_txn = await async_w3.eth.get_transaction(new_txn_hash)
-    assert new_txn["data"] == unsent_txn["data"]
+    assert new_txn["data"] == HexBytes(unsent_txn["data"])
     assert new_txn["nonce"] == nonce
 
 
@@ -547,11 +550,11 @@ async def test_async_contract_constructor_build_transaction_without_arguments(
     unsent_txn = await async_math_contract_factory.constructor().build_transaction(
         {"nonce": nonce}
     )
-    assert txn["data"] == unsent_txn["data"]
+    assert txn["data"] == HexBytes(unsent_txn["data"])
 
     new_txn_hash = await async_w3.eth.send_transaction(unsent_txn)
     new_txn = await async_w3.eth.get_transaction(new_txn_hash)
-    assert new_txn["data"] == unsent_txn["data"]
+    assert new_txn["data"] == HexBytes(unsent_txn["data"])
     assert new_txn["nonce"] == nonce
 
 
@@ -586,9 +589,9 @@ async def test_async_contract_constructor_build_transaction_with_arguments(
             *constructor_args, **constructor_kwargs
         ).build_transaction({"nonce": nonce})
     )
-    assert txn["data"] == unsent_txn["data"]
+    assert txn["data"] == HexBytes(unsent_txn["data"])
 
     new_txn_hash = await async_w3_non_strict_abi.eth.send_transaction(unsent_txn)
     new_txn = await async_w3_non_strict_abi.eth.get_transaction(new_txn_hash)
-    assert new_txn["data"] == unsent_txn["data"]
+    assert new_txn["data"] == HexBytes(unsent_txn["data"])
     assert new_txn["nonce"] == nonce

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -219,6 +219,7 @@ TRANSACTION_RESULT_FORMATTERS = {
         ),
     ),
     "input": HexBytes,
+    "data": HexBytes,  # Nethermind, for example, returns both `input` and `data`
 }
 
 


### PR DESCRIPTION
### What was wrong?

- Nethermind returns both ``data`` and ``input`` with the same value for each. Add a formatter for ``data`` that will format the field if it is present.
- Add a test for transaction result formatters via ``eth.get_transaction()`` test.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

```
   00
 8====--
   00
```
