### PR TITLE
 Fix a Broken Link and a Typo in URL 

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -206,7 +206,7 @@ web3.py can help you deploy, read from, or execute functions on a deployed contr
 Deployment requires that the contract already be compiled, with its bytecode and ABI
 available. This compilation step can be done within
 `Remix <http://remix.ethereum.org/>`_ or one of the many contract development
-frameworks, such as `Ape <https://docs.apeworx.io/ape/stable/index.html/>`_.
+frameworks, such as `Ape <https://docs.apeworx.io/ape/stable/index.html>`_.
 
 Once the contract object is instantiated, calling ``transact`` on the
 :meth:`constructor <web3.contract.Contract.constructor>` method will deploy an

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -122,7 +122,7 @@ out of date, try the `Ethereum Stackexchange <https://ethereum.stackexchange.com
 Here are some links to testnet ether instructions (in no particular order):
 
 - `Goerli <https://goerli.net>`_ (different faucet links on top menu bar)
-- `Sepolia <https://faucet.sepolia.dev>`_
+- `Sepolia <https://sepoliafaucet.com>`_
 
 .. _account_troubleshooting:
 

--- a/newsfragments/3130.docs.rst
+++ b/newsfragments/3130.docs.rst
@@ -1,0 +1,1 @@
+Fix broken links for Apeworx and Sepolia faucet


### PR DESCRIPTION
1) Fix Sepolia Faucet Broken Link
Old: https://faucet.sepolia.dev/
New: https://sepoliafaucet.com/

2) Fix Typo in URL
Old: https://docs.apeworx.io/ape/stable/index.html/
New: https://docs.apeworx.io/ape/stable/index.html

### What was wrong?
Broken Sepolia Faucet Link

Related to Issue #

### How was it fixed?
Change to New Sepolia faucet link

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
