### PR TITLE
[WS_V2] Improve upon yielding control to the event loop

### DIFF
--- a/newsfragments/3135.internal.rst
+++ b/newsfragments/3135.internal.rst
@@ -1,0 +1,1 @@
+Improvements on yielding to the event loop while searching in response caches and calling ``recv()`` on the websocket connection.

--- a/web3/providers/persistent.py
+++ b/web3/providers/persistent.py
@@ -21,7 +21,7 @@ from web3.types import (
     RPCResponse,
 )
 
-DEFAULT_PERSISTENT_CONNECTION_TIMEOUT = 20
+DEFAULT_PERSISTENT_CONNECTION_TIMEOUT = 50
 
 
 class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):

--- a/web3/providers/websocket/request_processor.py
+++ b/web3/providers/websocket/request_processor.py
@@ -191,9 +191,7 @@ class RequestProcessor:
 
     # raw response cache
 
-    async def cache_raw_response(
-        self, raw_response: Any, subscription: bool = False
-    ) -> None:
+    def cache_raw_response(self, raw_response: Any, subscription: bool = False) -> None:
         if subscription:
             self._provider.logger.debug(
                 f"Caching subscription response:\n    response={raw_response}"
@@ -208,7 +206,7 @@ class RequestProcessor:
             )
             self._request_response_cache.cache(cache_key, raw_response)
 
-    async def pop_raw_response(
+    def pop_raw_response(
         self, cache_key: str = None, subscription: bool = False
     ) -> Any:
         if subscription:


### PR DESCRIPTION
### What was wrong?

- In order to guarantee that the event loop can run other tasks more efficiently, asyncio.sleep(0) seems to be the most efficient way to yield control back to the event loop in a way that many tasks can still run concurrently without quickly timing out.
- Increase the default timeout to look for a response to a request from 20 seconds to 50 seconds.
- Make the caching methods in the request processor synchronous since they don't need to be async.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![1000019835](https://github.com/ethereum/web3.py/assets/3532824/160f6c83-ea54-41cf-9c27-17599cfc3dbc)
