### PR TITLE
Add types for constants

### DIFF
--- a/newsfragments/3138.internal.rst
+++ b/newsfragments/3138.internal.rst
@@ -1,0 +1,1 @@
+Fix type annotations for ``web3`` constants.

--- a/web3/constants.py
+++ b/web3/constants.py
@@ -1,7 +1,14 @@
+from eth_typing import (
+    ChecksumAddress,
+    HexAddress,
+    HexStr,
+)
+
 # Constants as Strings
-ADDRESS_ZERO = "0x0000000000000000000000000000000000000000"
-MAX_INT = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-HASH_ZERO = "0x0000000000000000000000000000000000000000000000000000000000000000"
+ADDRESS_ZERO = HexAddress(HexStr("0x0000000000000000000000000000000000000000"))
+CHECKSUM_ADDRESSS_ZERO = ChecksumAddress(ADDRESS_ZERO)
+MAX_INT = HexStr("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+HASH_ZERO = HexStr("0x0000000000000000000000000000000000000000000000000000000000000000")
 
 # Constants as Int
 WEI_PER_ETHER = 1000000000000000000


### PR DESCRIPTION
### What was wrong?

No typing in web3 constants

### How was it fixed?

Adding types

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://github.com/ethereum/web3.py/assets/6909403/27eb0e07-073b-42a9-9f23-f9d45082aea2)
