### PR TITLE
Add better validation around matching response with request information

### DIFF
--- a/newsfragments/3140.bugfix.rst
+++ b/newsfragments/3140.bugfix.rst
@@ -1,0 +1,1 @@
+When coming back through the middleware onion after a request is made, we have the response ``id``. Use it to match to the cached request information and process the response accordingly.

--- a/web3/middleware/attrdict.py
+++ b/web3/middleware/attrdict.py
@@ -71,7 +71,7 @@ async def async_attrdict_middleware(
             # asynchronous response processing
             provider = cast("PersistentConnectionProvider", async_w3.provider)
             provider._request_processor.append_middleware_response_processor(
-                _handle_async_response
+                response.get("id"), _handle_async_response
             )
             return response
         else:

--- a/web3/middleware/attrdict.py
+++ b/web3/middleware/attrdict.py
@@ -71,7 +71,7 @@ async def async_attrdict_middleware(
             # asynchronous response processing
             provider = cast("PersistentConnectionProvider", async_w3.provider)
             provider._request_processor.append_middleware_response_processor(
-                response.get("id"), _handle_async_response
+                response, _handle_async_response
             )
             return response
         else:

--- a/web3/middleware/fixture.py
+++ b/web3/middleware/fixture.py
@@ -129,7 +129,8 @@ async def async_construct_result_generator_middleware(
                     provider._request_processor.append_middleware_response_processor(
                         # processed asynchronously later but need to pass the actual
                         # response to the next middleware
-                        lambda _: {"result": result}
+                        response.get("id"),
+                        lambda _: {"result": result},
                     )
                     return response
                 else:
@@ -175,7 +176,8 @@ async def async_construct_error_generator_middleware(
                     provider._request_processor.append_middleware_response_processor(
                         # processed asynchronously later but need to pass the actual
                         # response to the next middleware
-                        lambda _: error_response
+                        response.get("id"),
+                        lambda _: error_response,
                     )
                     return response
                 else:

--- a/web3/middleware/fixture.py
+++ b/web3/middleware/fixture.py
@@ -129,7 +129,7 @@ async def async_construct_result_generator_middleware(
                     provider._request_processor.append_middleware_response_processor(
                         # processed asynchronously later but need to pass the actual
                         # response to the next middleware
-                        response.get("id"),
+                        response,
                         lambda _: {"result": result},
                     )
                     return response
@@ -176,7 +176,7 @@ async def async_construct_error_generator_middleware(
                     provider._request_processor.append_middleware_response_processor(
                         # processed asynchronously later but need to pass the actual
                         # response to the next middleware
-                        response.get("id"),
+                        response,
                         lambda _: error_response,
                     )
                     return response

--- a/web3/middleware/formatting.py
+++ b/web3/middleware/formatting.py
@@ -188,11 +188,12 @@ async def async_construct_web3_formatting_middleware(
                 # asynchronous response processing
                 provider = cast("PersistentConnectionProvider", async_w3.provider)
                 provider._request_processor.append_middleware_response_processor(
+                    response.get("id"),
                     _apply_response_formatters(
                         method,
                         formatters["result_formatters"],
                         formatters["error_formatters"],
-                    )
+                    ),
                 )
                 return response
             else:

--- a/web3/middleware/formatting.py
+++ b/web3/middleware/formatting.py
@@ -188,7 +188,7 @@ async def async_construct_web3_formatting_middleware(
                 # asynchronous response processing
                 provider = cast("PersistentConnectionProvider", async_w3.provider)
                 provider._request_processor.append_middleware_response_processor(
-                    response.get("id"),
+                    response,
                     _apply_response_formatters(
                         method,
                         formatters["result_formatters"],

--- a/web3/providers/websocket/request_processor.py
+++ b/web3/providers/websocket/request_processor.py
@@ -177,15 +177,15 @@ class RequestProcessor:
 
     def append_middleware_response_processor(
         self,
+        response_id: int,
         middleware_response_processor: Callable[..., Any],
     ) -> None:
-        request_id = next(copy(self._provider.request_counter)) - 1
-        cache_key = generate_cache_key(request_id)
-        current_request_cached_info: RequestInformation = (
+        cache_key = generate_cache_key(response_id)
+        cached_request_info_for_id: RequestInformation = (
             self._request_information_cache.get_cache_entry(cache_key)
         )
-        if current_request_cached_info:
-            current_request_cached_info.middleware_response_processors.append(
+        if cached_request_info_for_id is not None:
+            cached_request_info_for_id.middleware_response_processors.append(
                 middleware_response_processor
             )
 

--- a/web3/providers/websocket/request_processor.py
+++ b/web3/providers/websocket/request_processor.py
@@ -177,16 +177,29 @@ class RequestProcessor:
 
     def append_middleware_response_processor(
         self,
-        response_id: int,
+        response: RPCResponse,
         middleware_response_processor: Callable[..., Any],
     ) -> None:
-        cache_key = generate_cache_key(response_id)
-        cached_request_info_for_id: RequestInformation = (
-            self._request_information_cache.get_cache_entry(cache_key)
-        )
-        if cached_request_info_for_id is not None:
-            cached_request_info_for_id.middleware_response_processors.append(
-                middleware_response_processor
+        response_id = response.get("id", None)
+
+        if response_id is not None:
+            cache_key = generate_cache_key(response_id)
+            cached_request_info_for_id: RequestInformation = (
+                self._request_information_cache.get_cache_entry(cache_key)
+            )
+            if cached_request_info_for_id is not None:
+                cached_request_info_for_id.middleware_response_processors.append(
+                    middleware_response_processor
+                )
+            else:
+                self._provider.logger.debug(
+                    f"No cached request info for response id `{response_id}`. Cannot "
+                    f"append middleware response processor for response: {response}"
+                )
+        else:
+            self._provider.logger.debug(
+                "No response `id` in response. Cannot append middleware response "
+                f"processor for response: {response}"
             )
 
     # raw response cache


### PR DESCRIPTION
### What was wrong?

- Add better validation that the cached request information really matches the response we are trying to process. This is done by passing the actual `response_id` for the matching request once we go back through the middleware onion and the response is present. This area of the code hadn't been iterated on since some of the earlier commits in the building out of the provider. This is a very important and necessary improvement on `id` matching.

This resolves an issue reported on Discord where ``await asyncio.gather(one_request, second_request)`` was guessing the wrong request id for each request since they are basically being triggered / yielding to each other in a shared context.

### Steps to reproduce

```py
async def reproducible_example():
    async with AsyncWeb3.persistent_websocket(WebsocketProviderV2(PROVIDER_URI)) as w3:
        (
            latest,
            chain_id,
            block_num,
            pending,
            chain_id2,
            chain_id3,
            finalized,
            balance,
        ) = await asyncio.gather(
            w3.eth.get_block("latest"),
            w3.eth.chain_id,
            w3.eth.block_number,
            w3.eth.get_block("pending"),
            w3.eth.chain_id,
            w3.eth.chain_id,
            w3.eth.get_block("finalized"),
            w3.eth.get_balance("shaq.eth")
        )
        print(f"block num from latest block: {latest['number']}\n")
        print(f"chain_id: {chain_id}\n")
        print(f"block_num: {block_num}\n")
        print(f"block num from pending block: {pending['number']}\n")
        print(f"chain_id2: {chain_id2}\n")
        print(f"chain_id3: {chain_id3}\n")
        print(f"block num from finalized block: {finalized['number']}\n")
        print(f"balance: {balance}\n")

asyncio.run(reproducible_example())
```

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20231102_160925](https://github.com/ethereum/web3.py/assets/3532824/22ea7e20-f7cb-44ec-b631-02c3faa74e1f)

