### PR TITLE
docs: add discord bot template to resources page

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -83,3 +83,4 @@ Hackathon Helpers
 - `ape-hackathon-kit <https://github.com/wolovim/ape-hackathon-kit>`__ - Ape project template with a web front-end (Next.js, Tailwind, RainbowKit, wagmi)
 - `eth-flogger <https://github.com/wolovim/eth-flogger>`__ - Sample web app utilizing async web3.py, Flask, SQLite, Sourcify
 - `Temo <https://github.com/wolovim/temo>`__ - Sample terminal app utilizing async web3py, Textual, Anvil
+- `web3py-discord-bot <https://github.com/wolovim/web3py-discord-bot>`__ - Sample Discord bot utilizing websockets, ``eth_subscribe``, and discord.py

--- a/newsfragments/3143.docs.rst
+++ b/newsfragments/3143.docs.rst
@@ -1,0 +1,1 @@
+Adds Discord bot template repo to Resources page


### PR DESCRIPTION
### What was wrong?

not enough discord bots or websocket examples

### How was it fixed?

link to a template repo in the community resources page 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/wdjno3vvab961.jpg)
