### PR TITLE
Add upper pin to deprecated lru-dict

### DIFF
--- a/newsfragments/3144.internal.rst
+++ b/newsfragments/3144.internal.rst
@@ -1,0 +1,1 @@
+Add upper pin to deprecated dependency ``lru-dict`` whose new minor version release introduced a typing issue with CI lint builds.

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         "eth-utils>=2.1.0",
         "hexbytes>=0.1.0,<0.4.0",
         "jsonschema>=4.0.0",
-        "lru-dict>=1.1.6",
+        "lru-dict>=1.1.6,<1.3.0",
         "protobuf>=4.21.6",
         "pywin32>=223;platform_system=='Windows'",
         "requests>=2.16.0",


### PR DESCRIPTION
### What was wrong?

Our linting CI is failing with a new typing issue.

### How was it fixed?

- ``lru-dict`` will be removed in web3.py v7. A new minor version is causing some issues with linting. add an upper pin for ``<1.3.0``.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.shutterstock.com/image-photo/framed-collection-insects-beetles-pins-260nw-1036087015.jpg)
