### PR TITLE
Add ``yParity`` to ``TxData`` type class

### DIFF
--- a/newsfragments/3148.misc.rst
+++ b/newsfragments/3148.misc.rst
@@ -1,0 +1,1 @@
+Add ``int`` type to ``yParity`` field for ``TxData``.

--- a/web3/types.py
+++ b/web3/types.py
@@ -157,6 +157,7 @@ TxData = TypedDict(
         "type": Union[int, HexStr],
         "v": int,
         "value": Wei,
+        "yParity": int,
     },
     total=False,
 )


### PR DESCRIPTION
### What was wrong?

- ``yParity`` was a recent addition to geth json transaction data. We added formatters for it but we missed it in the ``TxData`` class.

### How was it fixed?

- Update `TxData` to have `yParity` field as `int` type

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%3Fid%3DOIP.e7A5-13W6gU608LpB3MZvAHaEK%26pid%3DApi&f=1&ipt=466ebb247328af47d973a434f321fd41a1061406bab58f8c10114b5a1f49d136&ipo=images)
