### PR TITLE
add formats key to rtd to enable downloadable docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,8 @@ build:
     python: "3.8"
 
 sphinx:
-   configuration: docs/conf.py
+  configuration: docs/conf.py
+  fail_on_warning: true 
 
 python:
   install:
@@ -14,3 +15,6 @@ python:
       path: .
       extra_requirements:
         - docs
+
+# Build all formats for RTD Downloads - htmlzip, pdf, epub
+formats: all

--- a/newsfragments/3153.docs.rst
+++ b/newsfragments/3153.docs.rst
@@ -1,0 +1,1 @@
+Make downloadable versions of docs available in ``pdf``, ``htmlzip``, and ``epub`` formats 


### PR DESCRIPTION
### What was wrong?

Related to Issue #3152

### How was it fixed?

Added `formats` key to `.readthedocs.yaml` to enable downloadable docs

It doesn't look like I can actually verify that they are built and available for download until this update is merged, but this is how to do it per the RTD [docs](https://docs.readthedocs.io/en/stable/guides/enable-offline-formats.html#how-to-enable-offline-formats).

Added the `fail_on_warning` key (from the template) while updating RTD settings.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/62480c5c-71d9-4668-9b91-2b5ddf225c05)
