### PR TITLE
Pin pytest-asyncio

### DIFF
--- a/newsfragments/3160.internal.rst
+++ b/newsfragments/3160.internal.rst
@@ -1,0 +1,1 @@
+Pin ``pytest-asyncio`` dependency to <0.23

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ extras_require = {
         "hypothesis>=3.31.2",
         "importlib-metadata<5.0;python_version<'3.8'",
         "pytest>=7.0.0",
-        "pytest-asyncio>=0.18.1",
+        "pytest-asyncio>=0.18.1,<0.23",
         "pytest-mock>=1.10",
         "pytest-watch>=4.2",
         "pytest-xdist>=1.29",


### PR DESCRIPTION
### What was wrong?
`pytest-asyncio v0.23` changed something that caused all of our async tests to fail. Putting this up so we can move on, but I'll circle back soon.

### How was it fixed?
Pinned to `<0.23`

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://lh3.googleusercontent.com/QMlvJMx9zqXhRLQVem_7CNBqimMiXhFii9BHvGQpjDKRSMHFW_GMiD3MJBoYvhJQrRc2eNHcGUzCtC9EYWoTkiaV=w640-h400-e365-rj-sc0x00ffffff)
