### PR TITLE
xfail failing py37 tests

### DIFF
--- a/tests/core/eth-module/test_accounts.py
+++ b/tests/core/eth-module/test_accounts.py
@@ -1,6 +1,7 @@
-# coding=utf-8
-
 import pytest
+
+# coding=utf-8
+import sys
 from unittest.mock import (
     patch,
 )
@@ -465,6 +466,7 @@ def test_eth_account_recover_transaction_from_eth_test(acct, transaction):
     assert acct.recover_transaction(raw_txn) == expected_sender
 
 
+@pytest.mark.xfail(sys.version_info < (3, 8), reason="Dependencies dropping py<3.8")
 def test_eth_account_encrypt(acct, web3js_key, web3js_password):
     encrypted = acct.encrypt(web3js_key, web3js_password)
 
@@ -476,6 +478,7 @@ def test_eth_account_encrypt(acct, web3js_key, web3js_password):
     assert decrypted_key == to_bytes(hexstr=web3js_key)
 
 
+@pytest.mark.xfail(sys.version_info < (3, 8), reason="Dependencies dropping py<3.8")
 def test_eth_account_prepared_encrypt(acct, web3js_key, web3js_password):
     account = acct.from_key(web3js_key)
     encrypted = account.encrypt(web3js_password)


### PR DESCRIPTION
### What was wrong?

2 tests have started failing for our python 3.7 CI, most likely due to several dependencies recently dropping py37 support.

### How was it fixed?

Marked the offending tests to xfail for <py38

I don't think this needs a newsfragment, but can add on request.

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/a495287e-3f32-4999-a261-5a8883249426)
