### PR TITLE
Run flaky async integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,6 +305,13 @@ jobs:
     environment:
       TOXENV: py37-integration-goethereum-http_async
 
+  py37-integration-goethereum-http_async_flaky:
+    <<: *geth_steps
+    docker:
+      - image: cimg/python:3.7
+    environment:
+      TOXENV: py37-integration-goethereum-http_async_flaky
+
   py37-integration-goethereum-http_flaky:
     <<: *geth_steps
     docker:
@@ -438,6 +445,13 @@ jobs:
     environment:
       TOXENV: py38-integration-goethereum-http_async
 
+  py38-integration-goethereum-http_async_flaky:
+    <<: *geth_steps
+    docker:
+      - image: cimg/python:3.8
+    environment:
+      TOXENV: py38-integration-goethereum-http_async_flaky
+
   py38-integration-goethereum-http_flaky:
     <<: *geth_steps
     docker:
@@ -570,6 +584,13 @@ jobs:
     environment:
       TOXENV: py39-integration-goethereum-http_async
 
+  py39-integration-goethereum-http_async_flaky:
+    <<: *geth_steps
+    docker:
+      - image: cimg/python:3.9
+    environment:
+      TOXENV: py39-integration-goethereum-http_async_flaky
+
   py39-integration-goethereum-http_flaky:
     <<: *geth_steps
     docker:
@@ -701,6 +722,13 @@ jobs:
       - image: cimg/python:3.10
     environment:
       TOXENV: py310-integration-goethereum-http_async
+
+  py310-integration-goethereum-http_async_flaky:
+    <<: *geth_steps
+    docker:
+      - image: cimg/python:3.10
+    environment:
+      TOXENV: py310-integration-goethereum-http_async_flaky
 
   py310-integration-goethereum-http_flaky:
     <<: *geth_steps
@@ -840,6 +868,13 @@ jobs:
     environment:
       TOXENV: py311-integration-goethereum-http_async
 
+  py311-integration-goethereum-http_async_flaky:
+    <<: *geth_steps
+    docker:
+      - image: cimg/python:3.11
+    environment:
+      TOXENV: py311-integration-goethereum-http_async_flaky
+
   py311-integration-goethereum-http_flaky:
     <<: *geth_steps
     docker:
@@ -929,6 +964,7 @@ workflows:
       - py37-integration-goethereum-ipc_flaky
       - py37-integration-goethereum-http
       - py37-integration-goethereum-http_async
+      - py37-integration-goethereum-http_async_flaky
       - py37-integration-goethereum-http_flaky
       - py37-integration-goethereum-ws
       - py37-integration-goethereum-ws_flaky
@@ -945,6 +981,7 @@ workflows:
       - py38-integration-goethereum-ipc_flaky
       - py38-integration-goethereum-http
       - py38-integration-goethereum-http_async
+      - py38-integration-goethereum-http_async_flaky
       - py38-integration-goethereum-http_flaky
       - py38-integration-goethereum-ws
       - py38-integration-goethereum-ws_flaky
@@ -961,6 +998,7 @@ workflows:
       - py39-integration-goethereum-ipc_flaky
       - py39-integration-goethereum-http
       - py39-integration-goethereum-http_async
+      - py39-integration-goethereum-http_async_flaky
       - py39-integration-goethereum-http_flaky
       - py39-integration-goethereum-ws
       - py39-integration-goethereum-ws_flaky
@@ -977,6 +1015,7 @@ workflows:
       - py310-integration-goethereum-ipc_flaky
       - py310-integration-goethereum-http
       - py310-integration-goethereum-http_async
+      - py310-integration-goethereum-http_async_flaky
       - py310-integration-goethereum-http_flaky
       - py310-integration-goethereum-ws
       - py310-integration-goethereum-ws_flaky
@@ -993,6 +1032,7 @@ workflows:
       - py311-integration-goethereum-ipc_flaky
       - py311-integration-goethereum-http
       - py311-integration-goethereum-http_async
+      - py311-integration-goethereum-http_async_flaky
       - py311-integration-goethereum-http_flaky
       - py311-integration-goethereum-ws
       - py311-integration-goethereum-ws_flaky

--- a/newsfragments/3170.internal.rst
+++ b/newsfragments/3170.internal.rst
@@ -1,0 +1,1 @@
+Add flaky async Geth integration tests to CI

--- a/tests/integration/go_ethereum/common.py
+++ b/tests/integration/go_ethereum/common.py
@@ -98,6 +98,7 @@ class GoEthereumPersonalModuleTest(GoEthereumPersonalModuleTest):
 
 class GoEthereumAsyncEthModuleTest(AsyncEthModuleTest):
     @pytest.mark.xfail(reason="eth_signTypedData has not been released in geth")
+    @pytest.mark.asyncio
     async def test_eth_sign_typed_data(
         self, async_w3, unlocked_account_dual_type, async_skip_if_testrpc
     ):
@@ -106,6 +107,7 @@ class GoEthereumAsyncEthModuleTest(AsyncEthModuleTest):
         )
 
     @pytest.mark.xfail(reason="eth_signTypedData has not been released in geth")
+    @pytest.mark.asyncio
     async def test_invalid_eth_sign_typed_data(
         self, async_w3, unlocked_account_dual_type, async_skip_if_testrpc
     ):

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ commands=
     integration-goethereum-ipc_flaky: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ipc.py --flaky}
     integration-goethereum-http: pytest {posargs:tests/integration/go_ethereum/test_goethereum_http.py -k "not Async"}
     integration-goethereum-http_async: pytest {posargs:tests/integration/go_ethereum/test_goethereum_http.py -k Async}
+    integration-goethereum-http_async_flaky: pytest {posargs:tests/integration/go_ethereum/test_goethereum_http.py -k Async --flaky}
     integration-goethereum-http_flaky: pytest {posargs:tests/integration/go_ethereum/test_goethereum_http.py --flaky}
     integration-goethereum-ws: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ws.py}
     integration-goethereum-ws_flaky: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ws.py --flaky}


### PR DESCRIPTION
### What was wrong?
Geth integration async tests weren't being run. I noticed because the create_access_list tests in #3167 weren't being run.

### How was it fixed?
Added to tox and circleci config. 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://static.demilked.com/wp-content/uploads/2021/11/618ccd33426a1-tiniest-of-units-2-618becdfa4353__700.jpg)
