### PR TITLE
break up `tox` test runs with underscores where they should be unique

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,14 +338,14 @@ jobs:
     docker:
       - image: cimg/python:3.7
     environment:
-      TOXENV: py37-integration-goethereum-ws-v2
+      TOXENV: py37-integration-goethereum-ws_v2
 
   py37-integration-goethereum-ws-v2_flaky:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.7
     environment:
-      TOXENV: py37-integration-goethereum-ws-v2_flaky
+      TOXENV: py37-integration-goethereum-ws_v2_flaky
 
   py37-integration-ethtester-pyevm:
     <<: *common
@@ -360,7 +360,7 @@ jobs:
     docker:
       - image: cimg/python:3.7
     environment:
-      TOXENV: py37-integration-ethtester-pyevm_flaky
+      TOXENV: py37-integration-ethtester_flaky
       ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
 
   py37-wheel-cli:
@@ -478,14 +478,14 @@ jobs:
     docker:
       - image: cimg/python:3.8
     environment:
-      TOXENV: py38-integration-goethereum-ws-v2
+      TOXENV: py38-integration-goethereum-ws_v2
 
   py38-integration-goethereum-ws-v2_flaky:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.8
     environment:
-      TOXENV: py38-integration-goethereum-ws-v2_flaky
+      TOXENV: py38-integration-goethereum-ws_v2_flaky
 
   py38-integration-ethtester-pyevm:
     <<: *common
@@ -500,7 +500,7 @@ jobs:
     docker:
       - image: cimg/python:3.8
     environment:
-      TOXENV: py38-integration-ethtester-pyevm_flaky
+      TOXENV: py38-integration-ethtester_flaky
       ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
 
   py38-wheel-cli:
@@ -617,14 +617,14 @@ jobs:
     docker:
       - image: cimg/python:3.9
     environment:
-      TOXENV: py39-integration-goethereum-ws-v2
+      TOXENV: py39-integration-goethereum-ws_v2
 
   py39-integration-goethereum-ws-v2_flaky:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.9
     environment:
-      TOXENV: py39-integration-goethereum-ws-v2_flaky
+      TOXENV: py39-integration-goethereum-ws_v2_flaky
 
   py39-integration-ethtester-pyevm:
     <<: *common
@@ -639,7 +639,7 @@ jobs:
     docker:
       - image: cimg/python:3.9
     environment:
-      TOXENV: py39-integration-ethtester-pyevm_flaky
+      TOXENV: py39-integration-ethtester_flaky
       ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
 
   py39-wheel-cli:
@@ -756,14 +756,14 @@ jobs:
     docker:
       - image: cimg/python:3.10
     environment:
-      TOXENV: py310-integration-goethereum-ws-v2
+      TOXENV: py310-integration-goethereum-ws_v2
 
   py310-integration-goethereum-ws-v2_flaky:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.10
     environment:
-      TOXENV: py310-integration-goethereum-ws-v2_flaky
+      TOXENV: py310-integration-goethereum-ws_v2_flaky
 
   py310-integration-ethtester-pyevm:
     <<: *common
@@ -778,7 +778,7 @@ jobs:
     docker:
       - image: cimg/python:3.10
     environment:
-      TOXENV: py310-integration-ethtester-pyevm_flaky
+      TOXENV: py310-integration-ethtester_flaky
       ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
 
   py310-wheel-cli:
@@ -901,14 +901,14 @@ jobs:
     docker:
       - image: cimg/python:3.11
     environment:
-      TOXENV: py311-integration-goethereum-ws-v2
+      TOXENV: py311-integration-goethereum-ws_v2
 
   py311-integration-goethereum-ws-v2_flaky:
     <<: *geth_steps
     docker:
       - image: cimg/python:3.11
     environment:
-      TOXENV: py311-integration-goethereum-ws-v2_flaky
+      TOXENV: py311-integration-goethereum-ws_v2_flaky
 
   py311-integration-ethtester-pyevm:
     <<: *common
@@ -923,7 +923,7 @@ jobs:
     docker:
       - image: cimg/python:3.11
     environment:
-      TOXENV: py311-integration-ethtester-pyevm_flaky
+      TOXENV: py311-integration-ethtester_flaky
       ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
 
   py311-wheel-cli:

--- a/newsfragments/3173.internal.rst
+++ b/newsfragments/3173.internal.rst
@@ -1,0 +1,1 @@
+Small fix for integration tests for ``tox`` to recognize independent patterns for each test run.

--- a/tox.ini
+++ b/tox.ini
@@ -33,10 +33,10 @@ commands=
     integration-goethereum-http_flaky: pytest {posargs:tests/integration/go_ethereum/test_goethereum_http.py --flaky}
     integration-goethereum-ws: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ws.py}
     integration-goethereum-ws_flaky: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ws.py --flaky}
-    integration-goethereum-ws-v2: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ws_v2}
-    integration-goethereum-ws-v2_flaky: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ws_v2 --flaky}
+    integration-goethereum-ws_v2: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ws_v2}
+    integration-goethereum-ws_v2_flaky: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ws_v2 --flaky}
     integration-ethtester: pytest {posargs:tests/integration/test_ethereum_tester.py}
-    integration-ethtester-pyevm_flaky: pytest {posargs:tests/integration/test_ethereum_tester.py --flaky}
+    integration-ethtester_flaky: pytest {posargs:tests/integration/test_ethereum_tester.py --flaky}
     docs: make -C {toxinidir} validate-docs
 deps =
     .[dev]


### PR DESCRIPTION
### What was wrong?

Related to PR #3157

### How was it fixed?

`tox` is looking at `commands` in the _tox.ini_ `testenv` section and running similarly named hyphenated commands together. Breaking up the naming with `_` underscores where they need to be unique seems to fix this.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

Big thanks to Eric Lam for the watermarked bug picture I just found

![Put a link to a cute animal picture inside the parenthesis-->](https://live.staticflickr.com/5085/5306713679_e92acd54e8_b.jpg)
