### PR TITLE
Improve efficiency checking cache and ws.recv() for WebsocketProviderV2 responses

### DIFF
--- a/newsfragments/3176.performance.rst
+++ b/newsfragments/3176.performance.rst
@@ -1,0 +1,1 @@
+Use concurrent tasks to check the cache and check the websocket for a particular response we care about for the ``WebsocketProviderV2`` with a persistent connection.

--- a/tests/core/providers/test_wsv2_provider.py
+++ b/tests/core/providers/test_wsv2_provider.py
@@ -40,6 +40,7 @@ async def test_async_make_request_caches_all_undesired_responses_and_returns_des
     method_under_test = provider.make_request
 
     _mock_ws(provider)
+
     undesired_responses_count = 10
     ws_recv_responses = [
         to_bytes(
@@ -53,6 +54,7 @@ async def test_async_make_request_caches_all_undesired_responses_and_returns_des
         )
         for i in range(0, undesired_responses_count)
     ]
+
     # The first request we make should have an id of `0`, expect the response to match
     # that id. Append it as the last response in the list.
     ws_recv_responses.append(b'{"jsonrpc": "2.0", "id":0, "result": "0x1337"}')
@@ -90,11 +92,12 @@ async def test_async_make_request_returns_cached_response_with_no_recv_if_cached
     desired_response = {"jsonrpc": "2.0", "id": 0, "result": "0x1337"}
     provider._request_processor.cache_raw_response(desired_response)
 
+    # request with id `0` should return the cached response
     response = await method_under_test(RPCEndpoint("some_method"), ["desired_params"])
     assert response == desired_response
 
     assert len(provider._request_processor._request_response_cache) == 0
-    assert not provider._ws.recv.called  # type: ignore
+    assert provider._ws.recv.not_called  # type: ignore
 
 
 @pytest.mark.asyncio

--- a/web3/providers/persistent.py
+++ b/web3/providers/persistent.py
@@ -18,6 +18,7 @@ from web3.providers.websocket.request_processor import (
     RequestProcessor,
 )
 from web3.types import (
+    RPCId,
     RPCResponse,
 )
 
@@ -52,5 +53,10 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
     async def disconnect(self) -> None:
         raise NotImplementedError("Must be implemented by subclasses")
 
-    async def _ws_recv(self, timeout: float = None) -> RPCResponse:
+    async def _ws_recv(self) -> RPCResponse:
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    async def _await_next_ws_response(
+        self, request_id: Optional[RPCId] = None, subscription: bool = False
+    ) -> RPCResponse:
         raise NotImplementedError("Must be implemented by subclasses")


### PR DESCRIPTION
### What was wrong?

Instead of re-creating some complex while loop to look for request id to match a response id and another to look for subscription responses, both in the cache and in the websocket, use `asyncio.wait(tasks, FIRST_COMPLETED)` with some more-simply-defined tasks to check for both at the same time. Previously we had to check the websocket for some x amount of time (0.5 seconds) and then check back in with the cache and then try the socket again. This way, we check both tasks at the same time and return when the winner finds the response we want.

Related to #3174

Bonus:

- Adds some `INFO` level logs to websocket provider V2 around request caching to help visualize what responses are coming from the cache and what responses are coming directly from checking the websocket.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20231220_091455](https://github.com/ethereum/web3.py/assets/3532824/f978eb1c-23d0-4277-962c-dae09e79425e)

