### PR TITLE
Use a message listener background task over ws.recv()

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -317,6 +317,6 @@ checking this deque (in case somewhere else in the code, subscriptions responses
 put in the deque by another call looking for another response type) and calling
 ``recv()`` on the websocket connection to see if the response is yet to be received.
 With each iteration on this iterator, if the ``deque`` is non-empty, it will yield
-messages from the ``deque`` as FIFO order until the deque is empty before receiving any
+messages from the ``queue`` as FIFO order until the deque is empty before receiving any
 new messages from the websocket connection, guaranteeing the messages are yielded in the
 order they were received.

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -203,6 +203,19 @@ not adhere to the `JSON-RPC 2.0 specification <https://www.jsonrpc.org/specifica
 in this way will not work with ``PersistentConnectionProvider`` instances. The specifics
 of how the request processor handles this are outlined below.
 
+Listening for Responses
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Implementations of the ``PersistentConnectionProvider`` class have a message listener
+background task that is called when the websocket connection is established. This task
+is responsible for listening for any and all messages coming in over the websocket
+connection and storing them in the ``RequestProcessor`` instance internal to the
+``PersistentConnectionProvider`` instance. The ``RequestProcessor`` instance is
+responsible for storing the messages in the correct cache, either the one-to-one cache
+or the one-to-many (subscriptions) queue, depending on whether the message has a
+JSON-RPC *id* value or not.
+
+
 One-To-One Requests
 ~~~~~~~~~~~~~~~~~~~
 
@@ -221,12 +234,17 @@ back. An example is using the ``eth`` module API to request the latest block num
     >>> asyncio.run(wsV2_one_to_one_example())
 
 With websockets we have to call ``send()`` and asynchronously receive responses via
-``recv()``. In order to make the one-to-one request-to-response call work, we
-have to save the request information somewhere so that when the response is received
-we can match it to the original request that was made i.e. the request with a matching
-*id* to the response that was received). The stored request information is then used to
-process the response when it is received, piping it through the response formatters and
-middlewares internal to the *web3.py* library.
+another means, generally by calling ``recv()`` or by iterating on the websocket
+connection for messages. As outlined above, the ``PersistentConnectionProvider`` class
+has a message listener background task that handles the receiving of messages.
+
+Due to this asynchronous nature of sending and receiving, in order to make one-to-one
+request-to-response calls work, we have to save the request information somewhere so
+that, when the response is received, we can match it to the original request that was
+made (i.e. the request with a matching *id* to the response that was received). The
+stored request information is then used to process the response when it is received,
+piping it through the response formatters and middlewares internal to the *web3.py*
+library.
 
 In order to store the request information, the ``RequestProcessor`` class has an
 internal ``RequestInformation`` cache. The ``RequestInformation`` class saves important
@@ -264,20 +282,24 @@ information about a request.
 One-to-one responses, those that include a JSON-RPC *id* in the response object, are
 stored in an internal ``SimpleCache`` class, isolated from any one-to-many responses.
 When the ``PersistentConnectionProvider`` is looking for a response internally, it will
-cycle within a ``while`` loop, alternating between checking this cache (in case
-somewhere else in the code our desired response was cached by another call) and calling
-``recv()`` on the websocket connection to see if it is yet to come.
+expect the message listener task to store the response in this cache. Since the request
+*id* is used in the cache key generation, it will then look for a cache key that matches
+the response *id* with that of the request *id*. If the cache key is found, the response
+is processed and returned to the user. If the cache key is not found, the operation will
+time out and raise a ``TimeExhausted`` exception. This timeout can be configured by the
+user when instantiating the ``PersistentConnectionProvider`` instance via the
+``response_timeout`` keyword argument.
 
 One-To-Many Requests
 ~~~~~~~~~~~~~~~~~~~~
 
 One-to-many requests can be summarized by any request that expects many responses as a
-result of the initial request. An example is the ``eth_subscribe`` request. The initial
-``eth_subscribe`` request expects only one response, the subscription *id* value, but
-it also expects to receive many ``eth_subscription`` messages if and when the request is
-successful. For this reason, the original request is considered a one-to-one request
-so that a subscription *id* can be returned to the user on the same line, but the
-``listen_to_websocket()`` method on the
+result of the initial request. The only current example is the ``eth_subscribe``
+request. The initial ``eth_subscribe`` request expects only one response, the
+subscription *id* value, but it also expects to receive many ``eth_subscription``
+messages if and when the request is successful. For this reason, the original request
+is considered a one-to-one request so that a subscription *id* can be returned to the
+user on the same line, but the ``process_subscriptions()`` method on the
 :class:`~web3.providers.websocket.WebsocketConnection` class, the public API for
 interacting with the active websocket connection, is set up to receive
 ``eth_subscription`` responses over an asynchronous interator pattern.
@@ -293,8 +315,8 @@ interacting with the active websocket connection, is set up to receive
     ...         subscription_id = await w3.eth.subscribe("newHeads")
     ...
     ...         # Listen to the websocket for the many responses utilizing the ``w3.ws``
-    ...         # ``WebsocketConnection`` public API method ``listen_to_websocket()``
-    ...         async for response in w3.ws.listen_to_websocket():
+    ...         # ``WebsocketConnection`` public API method ``process_subscriptions()``
+    ...         async for response in w3.ws.process_subscriptions():
     ...             # Receive only one-to-many responses here so that we don't
     ...             # accidentally return the response for a one-to-one request in this
     ...             # block
@@ -310,13 +332,22 @@ interacting with the active websocket connection, is set up to receive
     >>> asyncio.run(ws_v2_subscription_example())
 
 One-to-many responses, those that do not include a JSON-RPC *id* in the response object,
-are stored in an internal ``collections.deque`` instance, isolated from any one-to-one
-responses. When the ``PersistentConnectionProvider`` is looking for a one-to-many
-response internally, it will cycle within a ``while`` loop, alternating between
-checking this deque (in case somewhere else in the code, subscriptions responses were
-put in the deque by another call looking for another response type) and calling
-``recv()`` on the websocket connection to see if the response is yet to be received.
-With each iteration on this iterator, if the ``deque`` is non-empty, it will yield
-messages from the ``queue`` as FIFO order until the deque is empty before receiving any
-new messages from the websocket connection, guaranteeing the messages are yielded in the
-order they were received.
+are stored in an internal ``asyncio.Queue`` instance, isolated from any one-to-one
+responses. When the ``PersistentConnectionProvider`` is looking for one-to-many
+responses internally, it will expect the message listener task to store these messages
+in this queue. Since the order of the messages is important, the queue is a FIFO queue.
+The ``process_subscriptions()`` method on the ``WebsocketConnection`` class is set up
+to pop messages from this queue as FIFO over an asynchronous iterator pattern.
+
+If the stream of messages from the websocket is not being interrupted by any other
+tasks, the queue will generally be in sync with the messages coming in over the
+websocket. That is, the message listener will put a message in the queue and the
+``process_subscriptions()`` method will pop that message from the queue and yield
+control of the loop back to the listener. This will continue until the websocket
+connection is closed or the user unsubscribes from the subscription. If the stream of
+messages lags a bit, or the provider is not consuming messages but has subscribed to
+a subscription, this internal queue may fill up with messages until it reaches its max
+size and then trigger a waiting ``asyncio.Event`` until the provider begins consuming
+messages from the queue again. For this reason, it's important to begin consuming
+messages from the queue, via the ``process_subscriptions()`` method, as soon as a
+subscription is made.

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -273,7 +273,7 @@ asynchronous context manager, can be found in the `websockets connection`_ docs.
         ...         # subscribe to new block headers
         ...         subscription_id = await w3.eth.subscribe("newHeads")
         ...
-        ...         async for response in w3.ws.listen_to_websocket():
+        ...         async for response in w3.ws.process_subscriptions():
         ...             print(f"{response}\n")
         ...             # handle responses here
         ...
@@ -319,6 +319,7 @@ and reconnect automatically if the connection is lost. A similar example, using 
     ...         except websockets.ConnectionClosed:
     ...             continue
 
+    # run the example
     >>> asyncio.run(ws_v2_subscription_iterator_example())
 
 
@@ -338,6 +339,9 @@ provider in separate lines. Both of these examples are shown below.
     ...     # manual cleanup
     ...     await w3.provider.disconnect()
 
+    # run the example
+    >>> asyncio.run(ws_v2_alternate_init_example_1)
+
     >>> async def ws_v2_alternate_init_example_2():
     ...     # instantiation and connection via the provider as separate lines
     ...     w3 = AsyncWeb3.persistent_websocket(WebsocketProviderV2(f"ws://127.0.0.1:8546"))
@@ -348,8 +352,7 @@ provider in separate lines. Both of these examples are shown below.
     ...     # manual cleanup
     ...     await w3.provider.disconnect()
 
-    >>> # run the examples:
-    >>> asyncio.run(ws_v2_alternate_init_example_1)
+    # run the example
     >>> asyncio.run(ws_v2_alternate_init_example_2)
 
 The ``WebsocketProviderV2`` class uses the
@@ -393,11 +396,11 @@ Interacting with the Websocket Connection
         the subscription ``id`` to a dict of metadata about the subscription
         request.
 
-    .. py:method:: listen_to_websocket()
+    .. py:method:: process_subscriptions()
 
-        This method is available for listening to websocket responses indefinitely.
+        This method is available for listening to websocket subscriptions indefinitely.
         It is an asynchronous iterator that yields strictly one-to-many
-        (e.g. ``eth_subscription`` responses) request-to-response responses from the
+        (e.g. ``eth_subscription`` responses) request-to-response messages from the
         websocket connection. To receive responses for one-to-one request-to-response
         calls, use the standard API for making requests via the appropriate module
         (e.g. ``block_num = await w3.eth.block_number``)
@@ -410,9 +413,12 @@ Interacting with the Websocket Connection
 
         The ``recv()`` method can be used to receive the next message from the
         websocket. The response from this method is formatted by web3.py formatters
-        and run through the middlewares before being returned. This is useful for
-        receiving singled responses for one-to-many requests such receiving the
-        next ``eth_subscribe`` subscription response.
+        and run through the middlewares before being returned. This is not the
+        recommended way to receive a message as the ``process_subscriptions()`` method
+        is available for listening to websocket subscriptions and the standard API for
+        making requests via the appropriate module
+        (e.g. ``block_num = await w3.eth.block_number``) is available for receiving
+        responses for one-to-one request-to-response calls.
 
     .. py:method:: send(method: RPCEndpoint, params: Sequence[Any])
 

--- a/newsfragments/3179.breaking.rst
+++ b/newsfragments/3179.breaking.rst
@@ -1,0 +1,1 @@
+Use a message listener background task for ``WebsocketProviderV2`` rather than relying on ``ws.recv()`` blocking. Some breaking changes to API, notably ``listen_to_websocket`` -> ``process_subscriptions``.

--- a/web3/_utils/module_testing/module_testing_utils.py
+++ b/web3/_utils/module_testing/module_testing_utils.py
@@ -174,14 +174,20 @@ def async_mock_offchain_lookup_request_response(
 class WebsocketMessageStreamMock:
     closed: bool = False
 
-    def __init__(self, messages: Collection[bytes]) -> None:
-        self.messages = deque(messages)
+    def __init__(
+        self, messages: Collection[bytes] = None, raise_exception: Exception = None
+    ) -> None:
+        self.messages = deque(messages) if messages else deque()
+        self.raise_exception = raise_exception
 
     def __aiter__(self) -> "Self":
         return self
 
     async def __anext__(self) -> bytes:
-        if len(self.messages) == 0:
+        if self.raise_exception:
+            raise self.raise_exception
+
+        elif len(self.messages) == 0:
             raise StopAsyncIteration
 
         return self.messages.popleft()

--- a/web3/_utils/module_testing/module_testing_utils.py
+++ b/web3/_utils/module_testing/module_testing_utils.py
@@ -1,7 +1,11 @@
+from collections import (
+    deque,
+)
 import time
 from typing import (
     TYPE_CHECKING,
     Any,
+    Collection,
     Dict,
     Generator,
     Sequence,
@@ -40,6 +44,9 @@ if TYPE_CHECKING:
     from requests import Response  # noqa: F401
 
     from web3 import Web3  # noqa: F401
+    from web3._utils.compat import (  # noqa: F401
+        Self,
+    )
 
 
 def mine_pending_block(w3: "Web3") -> None:
@@ -162,3 +169,25 @@ def async_mock_offchain_lookup_request_response(
     monkeypatch.setattr(
         f"aiohttp.ClientSession.{http_method.lower()}", _mock_specific_request
     )
+
+
+class WebsocketMessageStreamMock:
+    closed: bool = False
+
+    def __init__(self, messages: Collection[bytes]) -> None:
+        self.messages = deque(messages)
+
+    def __aiter__(self) -> "Self":
+        return self
+
+    async def __anext__(self) -> bytes:
+        if len(self.messages) == 0:
+            raise StopAsyncIteration
+
+        return self.messages.popleft()
+
+    async def send(self, data: bytes) -> None:
+        pass
+
+    async def close(self) -> None:
+        pass

--- a/web3/_utils/module_testing/persistent_connection_provider.py
+++ b/web3/_utils/module_testing/persistent_connection_provider.py
@@ -295,7 +295,7 @@ class PersistentConnectionProviderTest:
             ws_subscription_response, subscription=True
         )
 
-        async for msg in async_w3.ws.listen_to_websocket():
+        async for msg in async_w3.ws.process_subscriptions():
             response = cast(FormattedEthSubscriptionResponse, msg)
             assert response["subscription"] == sub_id
             assert response["result"] == expected_formatted_result
@@ -331,7 +331,7 @@ class PersistentConnectionProviderTest:
             subscription=True,
         )
 
-        async for msg in async_w3.ws.listen_to_websocket():
+        async for msg in async_w3.ws.process_subscriptions():
             response = cast(FormattedEthSubscriptionResponse, msg)
             assert response.keys() == {"subscription", "result"}
             assert response["subscription"] == sub_id

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -339,7 +339,7 @@ class RequestManager:
                 "can listen to websocket recv streams."
             )
 
-        if self._provider._message_listener is None:
+        if self._provider._message_listener_task is None:
             raise ProviderConnectionError("No listener found for websocket connection.")
 
         while True:

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -348,7 +348,12 @@ class RequestManager:
             await asyncio.sleep(0)
 
             response = self._request_processor.pop_raw_response(subscription=True)
-            if response is not None:
+            if (
+                response is not None
+                and response.get("params").get("subscription")
+                in self._request_processor.active_subscriptions
+            ):
+                # if response is an active subscription response, process it
                 yield await self._process_ws_response(response)
 
     async def _process_ws_response(self, response: RPCResponse) -> RPCResponse:

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -350,7 +350,7 @@ class RequestManager:
             response = self._request_processor.pop_raw_response(subscription=True)
             if (
                 response is not None
-                and response.get("params").get("subscription")
+                and response.get("params", {}).get("subscription")
                 in self._request_processor.active_subscriptions
             ):
                 # if response is an active subscription response, process it

--- a/web3/providers/persistent.py
+++ b/web3/providers/persistent.py
@@ -27,7 +27,7 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
 
     _ws: Optional[WebSocketClientProtocol] = None
     _request_processor: RequestProcessor
-    _message_listener: Optional["asyncio.Task[None]"] = None
+    _message_listener_task: Optional["asyncio.Task[None]"] = None
     _listen_event: asyncio.Event = asyncio.Event()
 
     def __init__(
@@ -50,5 +50,5 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
     async def disconnect(self) -> None:
         raise NotImplementedError("Must be implemented by subclasses")
 
-    async def _ws_listener_task(self) -> None:
+    async def _ws_message_listener(self) -> None:
         raise NotImplementedError("Must be implemented by subclasses")

--- a/web3/providers/persistent.py
+++ b/web3/providers/persistent.py
@@ -17,9 +17,6 @@ from web3.providers.async_base import (
 from web3.providers.websocket.request_processor import (
     RequestProcessor,
 )
-from web3.types import (
-    RPCResponse,
-)
 
 DEFAULT_PERSISTENT_CONNECTION_TIMEOUT = 50
 
@@ -31,18 +28,20 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
     _ws: Optional[WebSocketClientProtocol] = None
     _ws_lock: asyncio.Lock = asyncio.Lock()
     _request_processor: RequestProcessor
+    _message_listener: Optional["asyncio.Task[None]"] = None
+    _listen_event: asyncio.Event = asyncio.Event()
 
     def __init__(
         self,
         endpoint_uri: str,
         request_timeout: float = DEFAULT_PERSISTENT_CONNECTION_TIMEOUT,
-        subscription_response_deque_size: int = 500,
+        subscription_response_queue_size: int = 500,
     ) -> None:
         super().__init__()
         self.endpoint_uri = endpoint_uri
         self._request_processor = RequestProcessor(
             self,
-            subscription_response_deque_size=subscription_response_deque_size,
+            subscription_response_queue_size=subscription_response_queue_size,
         )
         self.request_timeout = request_timeout
 
@@ -52,5 +51,5 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
     async def disconnect(self) -> None:
         raise NotImplementedError("Must be implemented by subclasses")
 
-    async def _ws_recv(self, timeout: float = None) -> RPCResponse:
+    async def _ws_listener_task(self) -> None:
         raise NotImplementedError("Must be implemented by subclasses")

--- a/web3/providers/persistent.py
+++ b/web3/providers/persistent.py
@@ -26,7 +26,6 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
     has_persistent_connection = True
 
     _ws: Optional[WebSocketClientProtocol] = None
-    _ws_lock: asyncio.Lock = asyncio.Lock()
     _request_processor: RequestProcessor
     _message_listener: Optional["asyncio.Task[None]"] = None
     _listen_event: asyncio.Event = asyncio.Event()

--- a/web3/providers/websocket/websocket_connection.py
+++ b/web3/providers/websocket/websocket_connection.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
         _PersistentConnectionWeb3,
     )
     from web3.manager import (  # noqa: F401
-        _AsyncPersistentRecvStream,
+        _AsyncPersistentMessageStream,
     )
 
 
@@ -36,7 +36,7 @@ class WebsocketConnection:
         return await self._manager.ws_send(method, params)
 
     async def recv(self) -> Any:
-        return await self._manager._ws_recv()
+        return await self._manager._get_next_ws_message()
 
-    def listen_to_websocket(self) -> "_AsyncPersistentRecvStream":
-        return self._manager._persistent_recv_stream()
+    def listen_to_websocket(self) -> "_AsyncPersistentMessageStream":
+        return self._manager._persistent_message_stream()

--- a/web3/providers/websocket/websocket_connection.py
+++ b/web3/providers/websocket/websocket_connection.py
@@ -38,5 +38,5 @@ class WebsocketConnection:
     async def recv(self) -> Any:
         return await self._manager._get_next_ws_message()
 
-    def listen_to_websocket(self) -> "_AsyncPersistentMessageStream":
+    def process_subscriptions(self) -> "_AsyncPersistentMessageStream":
         return self._manager._persistent_message_stream()

--- a/web3/providers/websocket/websocket_connection.py
+++ b/web3/providers/websocket/websocket_connection.py
@@ -27,6 +27,7 @@ class WebsocketConnection:
     def __init__(self, w3: "_PersistentConnectionWeb3"):
         self._manager = w3.manager
 
+    # -- public methods -- #
     @property
     def subscriptions(self) -> Dict[str, Any]:
         return self._manager._request_processor.active_subscriptions
@@ -35,7 +36,7 @@ class WebsocketConnection:
         return await self._manager.ws_send(method, params)
 
     async def recv(self) -> Any:
-        return await self._manager.ws_recv()
+        return await self._manager._ws_recv()
 
     def listen_to_websocket(self) -> "_AsyncPersistentRecvStream":
         return self._manager._persistent_recv_stream()

--- a/web3/providers/websocket/websocket_v2.py
+++ b/web3/providers/websocket/websocket_v2.py
@@ -32,7 +32,6 @@ from web3.exceptions import (
     Web3ValidationError,
 )
 from web3.providers.persistent import (
-    DEFAULT_PERSISTENT_CONNECTION_TIMEOUT,
     PersistentConnectionProvider,
 )
 from web3.types import (
@@ -67,8 +66,9 @@ class WebsocketProviderV2(PersistentConnectionProvider):
         self,
         endpoint_uri: Optional[Union[URI, str]] = None,
         websocket_kwargs: Optional[Dict[str, Any]] = None,
-        request_timeout: Optional[float] = DEFAULT_PERSISTENT_CONNECTION_TIMEOUT,
         raise_listener_task_exceptions: bool = False,
+        # `PersistentConnectionProvider` kwargs can be passed through
+        **kwargs: Any,
     ) -> None:
         self.endpoint_uri = URI(endpoint_uri)
         if self.endpoint_uri is None:
@@ -96,7 +96,7 @@ class WebsocketProviderV2(PersistentConnectionProvider):
         self.websocket_kwargs = merge(DEFAULT_WEBSOCKET_KWARGS, websocket_kwargs or {})
         self.raise_listener_task_exceptions = raise_listener_task_exceptions
 
-        super().__init__(endpoint_uri, request_timeout=request_timeout)
+        super().__init__(endpoint_uri, **kwargs)
 
     def __str__(self) -> str:
         return f"Websocket connection: {self.endpoint_uri}"

--- a/web3/providers/websocket/websocket_v2.py
+++ b/web3/providers/websocket/websocket_v2.py
@@ -154,12 +154,8 @@ class WebsocketProviderV2(PersistentConnectionProvider):
         try:
             self._message_listener_task.cancel()
             await self._message_listener_task
-        except (asyncio.CancelledError, StopAsyncIteration) as e:
-            self.logger.info(
-                "Websocket message listener background task caught and ignored an "
-                f"exception during cancellation: {e}"
-            )
-
+        except (asyncio.CancelledError, StopAsyncIteration):
+            pass
         self._request_processor.clear_caches()
 
     @async_handle_request_caching


### PR DESCRIPTION
### What was wrong?

- Get rid of ``websockets.recv()`` calls in favor of a background task that listens for messages and puts them into appropriate queues / caches.

- This rids us of the need to have an ``asyncio.Lock()`` around the ``recv()`` calls.

- Each provider instance has a listener task that error logs unless it is configured to raise exceptions, in which case exceptions will be raised and halt the listener task.

- In the (ideally) rare case that the subscription queue fills up to its max size, this will trigger an ``asycio.Event`` that will cause the listener task to wait until messages are consumed from the queue to resume listening.


closes #3174 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)
- [x] Add tests around the subscription cache being full and triggering the `asyncio.Event` until messages are being consumed again
- [x] Add tests around exception suppression in the listener task
- [x] Update documentation to reflect above changes
- [x] Do not yield subscription messages that are no longer active. It isn't very easy to remove items from an `asyncio.Queue` so we should probably skip over the messages that are no longer active (ones that no longer have a `RequestInformation` object mapping to the subscription `id`). This effectively loses the subscriptions without having to re-create the queue every time we unsubscribe.

#### Cute Animal Picture

![20231220_091455](https://github.com/ethereum/web3.py/assets/3532824/76263b8f-d1ea-4874-9404-b6bb426499dc)
