### PR TITLE
Mark tests for async test suite more accurately

### DIFF
--- a/newsfragments/3180.internal.rst
+++ b/newsfragments/3180.internal.rst
@@ -1,0 +1,1 @@
+Re-define how async vs sync core test suites are ran.

--- a/tests/core/eth-module/test_eth_filter.py
+++ b/tests/core/eth-module/test_eth_filter.py
@@ -21,7 +21,7 @@ from web3.providers.eth_tester.main import (
 )
 
 
-def test_Eth_filter_creates_correct_filter_type(w3):
+def test_eth_filter_creates_correct_filter_type(w3):
     filter1 = w3.eth.filter("latest")
     assert isinstance(filter1, BlockFilter)
     filter2 = w3.eth.filter("pending")
@@ -41,7 +41,7 @@ async def async_w3():
 
 
 @pytest.mark.asyncio
-async def test_AsyncEth_filter_creates_correct_filter_type(async_w3):
+async def test_async_eth_filter_creates_correct_filter_type(async_w3):
     filter1 = await async_w3.eth.filter("latest")
     assert isinstance(filter1, AsyncBlockFilter)
     filter2 = await async_w3.eth.filter("pending")

--- a/tests/core/providers/test_async_http_provider.py
+++ b/tests/core/providers/test_async_http_provider.py
@@ -47,7 +47,7 @@ async def clean_async_session_cache():
 
 
 @pytest.mark.asyncio
-async def test_no_args() -> None:
+async def test_async_no_args() -> None:
     provider = AsyncHTTPProvider()
     w3 = AsyncWeb3(provider)
     assert w3.manager.provider == provider
@@ -101,7 +101,7 @@ def test_web3_with_async_http_provider_has_default_middlewares_and_modules() -> 
 
 
 @pytest.mark.asyncio
-async def test_user_provided_session() -> None:
+async def test_async_user_provided_session() -> None:
     session = ClientSession()
     provider = AsyncHTTPProvider(endpoint_uri=URI)
     cached_session = await provider.cache_async_session(session)

--- a/tests/core/utilities/test_async_transaction.py
+++ b/tests/core/utilities/test_async_transaction.py
@@ -24,20 +24,20 @@ SIMPLE_CURRENT_TRANSACTION = {
 }
 
 
-@pytest.mark.asyncio()
-async def test_get_block_gas_limit_with_block_number(async_w3):
+@pytest.mark.asyncio
+async def test_async_get_block_gas_limit_with_block_number(async_w3):
     gas_limit = await get_block_gas_limit(async_w3.eth, BlockNumber(0))
     assert isinstance(gas_limit, int)
 
 
-@pytest.mark.asyncio()
-async def test_get_block_gas_limit_without_block_number(async_w3):
+@pytest.mark.asyncio
+async def test_async_get_block_gas_limit_without_block_number(async_w3):
     gas_limit = await get_block_gas_limit(async_w3.eth)
     assert isinstance(gas_limit, int)
 
 
-@pytest.mark.asyncio()
-async def test_get_buffered_gas_estimate(async_w3):
+@pytest.mark.asyncio
+async def test_async_get_buffered_gas_estimate(async_w3):
     txn_params = {
         "data": b"0x1",
     }
@@ -50,8 +50,8 @@ async def test_get_buffered_gas_estimate(async_w3):
     assert buffered_gas_estimate == min(gas_estimate + gas_buffer, gas_limit)
 
 
-@pytest.mark.asyncio()
-async def test_fill_transaction_defaults_for_all_params(async_w3):
+@pytest.mark.asyncio
+async def test_async_fill_transaction_defaults_for_all_params(async_w3):
     default_transaction = await async_fill_transaction_defaults(async_w3, {})
 
     block = await async_w3.eth.get_block("latest")
@@ -68,7 +68,7 @@ async def test_fill_transaction_defaults_for_all_params(async_w3):
 
 
 @pytest.mark.asyncio()
-async def test_fill_transaction_defaults_nondynamic_tranaction_fee(async_w3):
+async def test_async_fill_transaction_defaults_nondynamic_tranaction_fee(async_w3):
     gasPrice_transaction = {
         "gasPrice": 10,
     }
@@ -79,8 +79,8 @@ async def test_fill_transaction_defaults_nondynamic_tranaction_fee(async_w3):
     assert none_in_dict(DYNAMIC_FEE_TXN_PARAMS, default_transaction)
 
 
-@pytest.mark.asyncio()
-async def test_fill_transaction_defaults_for_zero_gas_price(async_w3):
+@pytest.mark.asyncio
+async def test_async_fill_transaction_defaults_for_zero_gas_price(async_w3):
     def gas_price_strategy(_w3, tx):
         return 0
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,8 +20,8 @@ allowlist_externals=/usr/bin/make
 install_command=python -m pip install {opts} {packages}
 usedevelop=True
 commands=
-    core: pytest {posargs:tests/core -m "not asyncio" -k "not async"}
-    core_async: pytest {posargs:tests/core -k "asyncio or async"}
+    core: pytest {posargs:tests/core -m "not asyncio"}
+    core_async: pytest {posargs:tests/core -m asyncio}
     ens: pytest {posargs:tests/ens --ignore=tests/ens/normalization/test_normalize_name_ensip15.py}
     ensip15: pytest {posargs:tests/ens/normalization/test_normalize_name_ensip15.py -q}
     ethpm: pytest {posargs:tests/ethpm}

--- a/tox.ini
+++ b/tox.ini
@@ -20,8 +20,8 @@ allowlist_externals=/usr/bin/make
 install_command=python -m pip install {opts} {packages}
 usedevelop=True
 commands=
-    core: pytest {posargs:tests/core -k "not async"}
-    core_async: pytest {posargs:tests/core -k async}
+    core: pytest {posargs:tests/core -m "not asyncio" -k "not async"}
+    core_async: pytest {posargs:tests/core -k "asyncio or async"}
     ens: pytest {posargs:tests/ens --ignore=tests/ens/normalization/test_normalize_name_ensip15.py}
     ensip15: pytest {posargs:tests/ens/normalization/test_normalize_name_ensip15.py -q}
     ethpm: pytest {posargs:tests/ethpm}


### PR DESCRIPTION
### What was wrong?

- All async tests need the ``@pytest.mark.asyncio`` decorator to be picked up by pytest-asyncio. This already marks them as asyncio tests, so we should use the ``-m`` option to call them. Looking for "async" in the test name with the``-k`` option caused us to miss some tests that we didn't name with "async" in them in the async test suite.

- Note to any reviewers: Be sure to check that the selected number in one test run equals the deselected number in the other.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20240108_191245](https://github.com/ethereum/web3.py/assets/3532824/54c81639-334f-45ba-a1fe-3df6df6f5a7a)
