### PR TITLE
remove docs ref to protocol_version which was removed in pr2432

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -170,18 +170,6 @@ The following properties are available on the ``web3.eth`` namespace.
         2206939
 
 
-.. py:attribute:: Eth.protocol_version
-
-    * Delegates to ``eth_protocolVersion`` RPC Method
-
-    Returns the id of the current Ethereum protocol version.
-
-    .. code-block:: python
-
-       >>> web3.eth.protocol_version
-       '63'
-
-
 .. py:attribute:: Eth.chain_id
 
     * Delegates to ``eth_chainId`` RPC Method

--- a/newsfragments/3183.docs.rst
+++ b/newsfragments/3183.docs.rst
@@ -1,0 +1,1 @@
+Remove docs reference for removed ``protocol_version`` RPC method


### PR DESCRIPTION
### What was wrong?

PR #2432 dropped the `protocol_version` method, but didn't remove it from the docs.
Closes #3182 

### How was it fixed?

Removed the section from the docs.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/aeea43b6-be21-4093-9205-1f0498d4e277)
