### PR TITLE
change fee_history arg reward_percentiles default to pass empty list instead of None

### DIFF
--- a/newsfragments/3185.bugfix.rst
+++ b/newsfragments/3185.bugfix.rst
@@ -1,0 +1,1 @@
+Change ``fee_history`` default behavior. If ``reward_percentiles`` arg not included, pass it to the provider as an empty list instead of ``None``.

--- a/tests/core/eth-module/test_eth_fee_history.py
+++ b/tests/core/eth-module/test_eth_fee_history.py
@@ -1,0 +1,22 @@
+import pytest
+from unittest.mock import (
+    MagicMock,
+    patch,
+)
+
+
+@pytest.mark.parametrize(
+    "fee_history_args, expected",
+    (
+        ((1, "latest"), (1, "latest", [])),
+        ((1, "latest", []), (1, "latest", [])),
+        ((1, "latest", None), (1, "latest", [])),
+        ((1, "latest", [50]), (1, "latest", [50])),
+    ),
+)
+@patch("web3.eth.Eth._fee_history", new=MagicMock())
+def test_eth_fee_history_reward_percentiles_default_is_empty_list(
+    w3, fee_history_args, expected
+) -> None:
+    w3.eth.fee_history(*fee_history_args)
+    w3.eth._fee_history.assert_called_with(*expected)

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -234,6 +234,7 @@ class AsyncEth(BaseEth):
         newest_block: Union[BlockParams, BlockNumber],
         reward_percentiles: Optional[List[float]] = None,
     ) -> FeeHistory:
+        reward_percentiles = reward_percentiles or []
         return await self._fee_history(block_count, newest_block, reward_percentiles)
 
     # eth_call

--- a/web3/eth/eth.py
+++ b/web3/eth/eth.py
@@ -226,6 +226,7 @@ class Eth(BaseEth):
         newest_block: Union[BlockParams, BlockNumber],
         reward_percentiles: Optional[List[float]] = None,
     ) -> FeeHistory:
+        reward_percentiles = reward_percentiles or []
         return self._fee_history(block_count, newest_block, reward_percentiles)
 
     # eth_call


### PR DESCRIPTION
### What was wrong?

`fee_history`s optional `reward_percentiles` errors when omitted for Anvil and Hardhat providers.

Related to Issue #3184 

### How was it fixed?

Changed the default value that is passed to the provider from `None` to an empty list.

Manually tested with Anvil to confirm it works. The other option is to remove the `reward_percentiles` arg completely if it's `None` and only call `fee_history` with `block_count` and `newest_block`. That also works locally, but requires more code to be changed.

In looking through the geth and anvil implementations (with some chatgpt assistance), it looks like it's a difference in how they handle the `None` default. Geth accepts it and moves on, while Anvil will only apply its default empty vector if the value is missing. So defaulting to an empty list seems appropriate on our end.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/7b09340d-fa96-4776-b990-8541becbef14)
