### PR TITLE
use importlib.metadata for version info if >py37

### DIFF
--- a/newsfragments/3187.bugfix.rst
+++ b/newsfragments/3187.bugfix.rst
@@ -1,0 +1,1 @@
+Use ``importlib.metadata`` for version info if python>=3.8

--- a/newsfragments/3187.internal.rst
+++ b/newsfragments/3187.internal.rst
@@ -1,0 +1,1 @@
+Add basic import and version tests for the ``web3`` module

--- a/tests/core/web3-module/test_import_and_version.py
+++ b/tests/core/web3-module/test_import_and_version.py
@@ -1,0 +1,5 @@
+def test_import_and_version():
+    import web3
+
+    version = web3.__version__
+    assert isinstance(version, str)

--- a/web3/__init__.py
+++ b/web3/__init__.py
@@ -1,5 +1,15 @@
-from eth_account import Account  # noqa: E402,
-import pkg_resources
+from eth_account import Account  # noqa: E402
+import sys
+
+if sys.version_info.major == 3 and sys.version_info.minor < 8:
+    import pkg_resources
+
+    __version__ = pkg_resources.get_distribution("web3").version
+else:
+    from importlib.metadata import version
+
+    __version__ = version("web3")
+
 
 from web3.main import (
     AsyncWeb3,
@@ -22,7 +32,6 @@ from web3.providers.websocket import (  # noqa: E402
     WebsocketProviderV2,
 )
 
-__version__ = pkg_resources.get_distribution("web3").version
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
### What was wrong?

Using `pkg_resources` in python 3.12 causes an error.

Closes #3186 

### How was it fixed?

Conditionally use the new `importlib.metadata` format for supplying version info as it will be a bit before python 3.7 support is dropped here. We don't technically support python 3.12 yet, but this is a simple enough fix.

Added a basic test for version info while in there.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/bc1e58b0-45fd-4706-8559-7047831dd23b)
