### PR TITLE
Fix types - AsyncContractConstructor

### DIFF
--- a/3192.bugfix.rst
+++ b/3192.bugfix.rst
@@ -1,0 +1,1 @@
+Fix return type of ``AsyncContract.constructor``

--- a/web3/contract/async_contract.py
+++ b/web3/contract/async_contract.py
@@ -428,37 +428,6 @@ class AsyncContractFunctions(BaseContractFunctions):
             return super().__getattribute__(function_name)
 
 
-class AsyncContractConstructor(BaseContractConstructor):
-    # mypy types
-    w3: "AsyncWeb3"
-
-    @combomethod
-    async def transact(self, transaction: Optional[TxParams] = None) -> HexBytes:
-        return await self.w3.eth.send_transaction(self._get_transaction(transaction))
-
-    @combomethod
-    async def build_transaction(
-        self, transaction: Optional[TxParams] = None
-    ) -> TxParams:
-        """
-        Build the transaction dictionary without sending
-        """
-        built_transaction = self._build_transaction(transaction)
-        return await async_fill_transaction_defaults(self.w3, built_transaction)
-
-    @combomethod
-    async def estimate_gas(
-        self,
-        transaction: Optional[TxParams] = None,
-        block_identifier: Optional[BlockIdentifier] = None,
-    ) -> int:
-        transaction = self._estimate_gas(transaction)
-
-        return await self.w3.eth.estimate_gas(
-            transaction, block_identifier=block_identifier
-        )
-
-
 class AsyncContract(BaseContract):
     functions: AsyncContractFunctions = None
     caller: "AsyncContractCaller" = None
@@ -546,7 +515,7 @@ class AsyncContract(BaseContract):
         return contract
 
     @classmethod
-    def constructor(cls, *args: Any, **kwargs: Any) -> AsyncContractConstructor:
+    def constructor(cls, *args: Any, **kwargs: Any) -> "AsyncContractConstructor":
         """
         :param args: The contract constructor arguments as positional arguments
         :param kwargs: The contract constructor arguments as keyword arguments
@@ -643,4 +612,35 @@ class AsyncContractCaller(BaseContractCaller):
             block_identifier=block_identifier,
             ccip_read_enabled=ccip_read_enabled,
             decode_tuples=self.decode_tuples,
+        )
+
+
+class AsyncContractConstructor(BaseContractConstructor):
+    # mypy types
+    w3: "AsyncWeb3"
+
+    @combomethod
+    async def transact(self, transaction: Optional[TxParams] = None) -> HexBytes:
+        return await self.w3.eth.send_transaction(self._get_transaction(transaction))
+
+    @combomethod
+    async def build_transaction(
+        self, transaction: Optional[TxParams] = None
+    ) -> TxParams:
+        """
+        Build the transaction dictionary without sending
+        """
+        built_transaction = self._build_transaction(transaction)
+        return await async_fill_transaction_defaults(self.w3, built_transaction)
+
+    @combomethod
+    async def estimate_gas(
+        self,
+        transaction: Optional[TxParams] = None,
+        block_identifier: Optional[BlockIdentifier] = None,
+    ) -> int:
+        transaction = self._estimate_gas(transaction)
+
+        return await self.w3.eth.estimate_gas(
+            transaction, block_identifier=block_identifier
         )


### PR DESCRIPTION
### What was wrong?

IDE shows warning 
<img width="461" alt="image" src="https://github.com/ethereum/web3.py/assets/8822182/bcf06819-c184-4780-a794-aad004e64d58">

### How was it fixed?

There is wrong return type.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="311" alt="image" src="https://github.com/ethereum/web3.py/assets/8822182/5ed6e282-46bb-4213-8de5-02a79cb180f0">
