### PR TITLE
Validate geth version in test fixture against binary used for tests

### DIFF
--- a/newsfragments/3193.internal.rst
+++ b/newsfragments/3193.internal.rst
@@ -1,0 +1,1 @@
+Validate geth version used to generate the integration test fixture against the version in the binary that is used to run the tests.

--- a/tests/integration/go_ethereum/conftest.py
+++ b/tests/integration/go_ethereum/conftest.py
@@ -75,7 +75,17 @@ def get_geth_version(geth_binary):
         get_geth_version,
     )
 
-    return get_geth_version(geth_executable=os.path.expanduser(geth_binary))
+    geth_version = get_geth_version(geth_executable=os.path.expanduser(geth_binary))
+
+    fixture_geth_version = GETH_FIXTURE_ZIP.split("-")[1]
+    if fixture_geth_version not in str(geth_version):
+        raise AssertionError(
+            f"geth fixture version `{fixture_geth_version}` does not match geth "
+            f"version for binary being used to run the test suite: `{geth_version}`. "
+            "For CI runs, make sure to update the geth version in the CI config file."
+        )
+
+    return geth_version
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
### What was wrong?

We've had instances where we forget to update the `geth` version being used in the circleCI runs and this goes unnoticed since two versions can be compatible with each other. This means we create the fixture with one version, but run it with another - and, as long as no noticeable changes have happened, this is silently unintended.

### How was it fixed?

- Validate the geth binary version being used to run the tests against the version in the generated zip file for the test fixture. This version is automatically named in the zip file to be the geth version used to create the zip so it should be a decent enough check.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20240118_112335](https://github.com/ethereum/web3.py/assets/3532824/44d850b7-03a2-4cc1-8950-b0abdc2ce568)

