### PR TITLE
drop `lru-dict` dependency

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -9,7 +9,7 @@ force_sort_within_sections=true
 include_trailing_comma=true
 extra_standard_library=pytest
 known_first_party=web3,ens,ethpm
-known_third_party=lru,eth_tester
+known_third_party=eth_tester
 line_length=88
 use_parentheses=true
 # skip `__init__.py` files because sometimes order of initialization is important

--- a/newsfragments/3196.breaking.rst
+++ b/newsfragments/3196.breaking.rst
@@ -1,0 +1,1 @@
+Drop dependency on ``lru-dict`` library.

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ setup(
         "eth-utils>=2.1.0",
         "hexbytes>=0.1.0,<0.4.0",
         "jsonschema>=4.0.0",
-        "lru-dict>=1.1.6,<1.3.0",
         "protobuf>=4.21.6",
         "pydantic>=2.4.0",
         "pywin32>=223;platform_system=='Windows'",


### PR DESCRIPTION
### What was wrong?

closes #2884
closes #2926 

### How was it fixed?

#3169 removed the need for LRU but did not drop the dependency on the `lru-dict` library. This removes it from the dependencies, successfully closing #2884 and #2926.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20240122_120825](https://github.com/ethereum/web3.py/assets/3532824/cc22d6ec-265d-4766-814e-98e61371f08e)
