### PR TITLE
Return function in contract function iterator

### DIFF
--- a/newsfragments/3200.breaking.rst
+++ b/newsfragments/3200.breaking.rst
@@ -1,0 +1,1 @@
+Return iterable of `ABIFunction`s from the `BaseContractFunctions` iterator.

--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -30,6 +30,12 @@ from web3._utils.contract_sources.contract_data.bytes_contracts import (
 from web3._utils.ens import (
     contract_ens_addresses,
 )
+from web3.contract.async_contract import (
+    AsyncContractFunction,
+)
+from web3.contract.contract import (
+    ContractFunction,
+)
 from web3.exceptions import (
     BadFunctionCallOutput,
     BlockNumberOutofRange,
@@ -1147,6 +1153,15 @@ def test_changing_default_block_identifier(w3, math_contract):
     assert math_contract.functions.counter().call(block_identifier=None) == 0
     w3.eth.default_block = 0x2
     assert math_contract.functions.counter().call(block_identifier=None) == 7
+
+
+def test_functions_iterator(w3, math_contract):
+    all_functions = math_contract.all_functions()
+    functions_iter = math_contract.functions
+
+    for fn, expected_fn in zip(iter(functions_iter), all_functions):
+        assert isinstance(fn, ContractFunction)
+        assert fn.fn_name == expected_fn.fn_name
 
 
 # -- async -- #
@@ -2313,3 +2328,12 @@ async def test_async_changing_default_block_identifier(async_w3, async_math_cont
     assert (
         await async_math_contract.functions.counter().call(block_identifier=None) == 7
     )
+
+
+def test_async_functions_iterator(async_w3, async_math_contract):
+    all_functions = async_math_contract.all_functions()
+    functions_iter = async_math_contract.functions
+
+    for fn, expected_fn in zip(iter(functions_iter), all_functions):
+        assert isinstance(fn, AsyncContractFunction)
+        assert fn.fn_name == expected_fn.fn_name

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -4,7 +4,6 @@ from typing import (
     Callable,
     Collection,
     Dict,
-    Generator,
     Iterable,
     List,
     NoReturn,
@@ -662,12 +661,12 @@ class BaseContractFunctions:
                     ),
                 )
 
-    def __iter__(self) -> Generator[str, None, None]:
+    def __iter__(self) -> Iterable["ABIFunction"]:
         if not hasattr(self, "_functions") or not self._functions:
             return
 
         for func in self._functions:
-            yield func["name"]
+            yield self[func["name"]]
 
     def __getitem__(self, function_name: str) -> ABIFunction:
         return getattr(self, function_name)


### PR DESCRIPTION
### What was wrong?

Related to Issue #961

### How was it fixed?

`contract.functions` yields `ContractFunction` rather than just the `str` name.



### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://miro.medium.com/v2/resize:fit:1400/1*C6Aj_0WBzy8sqzM1Oh63aQ.png)
