### PR TITLE
Raise exceptions by default; opt to silence in message listener task

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -186,6 +186,7 @@ The Manager acts as a gatekeeper for the request/response lifecycle.  It is
 unlikely that you will need to change the Manager as most functionality can be
 implemented in the Middleware layer.
 
+.. _internals__persistent_connection_providers:
 
 Request Processing for Persistent Connection Providers
 ------------------------------------------------------

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -219,14 +219,38 @@ WebsocketProvider
         >>> w3 = Web3(Web3.WebsocketProvider("ws://127.0.0.1:8546", websocket_timeout=60))
 
 
+Persistent Connection Providers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. py:class:: web3.providers.persistent.PersistentConnectionProvider(endpoint_uri: str, request_timeout: float = 50.0, subscription_response_queue_size: int = 500)
+
+    This is a base provider class, currently inherited by the ``WebsocketProviderV2``.
+    It handles interactions with a persistent connection to a JSON-RPC server. Among
+    its configuration, it houses all of the
+    :class:`~web3.providers.websocket.request_processor.RequestProcessor` logic for
+    handling the asynchronous sending and receiving of requests and responses. See
+    the :ref:`internals__persistent_connection_providers` section for more details on
+    the internals of persistent connection providers.
+
+    * ``request_timeout`` is the timeout in seconds, used when sending data over the
+      connection and waiting for a response to be received from the listener task.
+      Defaults to ``50.0``.
+
+    * ``subscription_response_queue_size`` is the size of the queue used to store
+      subscription responses, defaults to ``500``. While messages are being consumed,
+      this queue should never fill up as it is a transient queue and meant to handle
+      asynchronous receiving and processing of responses. When in sync with the
+      websocket stream, this queue should only ever store 1 to a few messages at a time.
+
+
 WebsocketProviderV2 (beta)
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+``````````````````````````
 
 .. warning:: This provider is still in beta. However, it is being actively developed
     and supported and is expected to be stable in the next major version of *web3.py*
     (v7).
 
-.. py:class:: web3.providers.websocket.WebsocketProviderV2(endpoint_uri, websocket_kwargs, call_timeout)
+.. py:class:: web3.providers.websocket.WebsocketProviderV2(endpoint_uri: str, websocket_kwargs: Dict[str, Any] = {}, silence_listener_task_exceptions: bool = False)
 
     This provider handles interactions with an WS or WSS based JSON-RPC server.
 
@@ -234,8 +258,14 @@ WebsocketProviderV2 (beta)
       ``'ws://localhost:8546'``.
     * ``websocket_kwargs`` this should be a dictionary of keyword arguments which
       will be passed onto the ws/wss websocket connection.
-    * ``request_timeout`` is the timeout in seconds, as a float. Used when receiving or
-      sending data over the connection. This value defaults to 20 seconds.
+    * ``silence_listener_task_exceptions`` is a boolean that determines whether
+      exceptions raised by the listener task are silenced. Defaults to ``False``,
+      raising any exceptions that occur in the listener task.
+
+    This provider inherits from the
+    :class:`~web3.providers.persistent.PersistentConnectionProvider` class. Refer to
+    the :class:`~web3.providers.persistent.PersistentConnectionProvider` documentation
+    for details on additional configuration options available for this provider.
 
     Under the hood, the ``WebsocketProviderV2`` uses the python websockets library for
     making requests.  If you would like to modify how requests are made, you can
@@ -244,7 +274,7 @@ WebsocketProviderV2 (beta)
 
 
 Usage
-~~~~~
++++++
 
 The ``AsyncWeb3`` class may be used as a context manager, utilizing the ``async with``
 syntax, when connecting via ``persistent_websocket()`` using the
@@ -363,7 +393,7 @@ one-to-many request-to-response requests. Refer to the
 documentation for details.
 
 _PersistentConnectionWeb3 via AsyncWeb3.persistent_websocket()
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 When an ``AsyncWeb3`` class is connected to a persistent websocket connection, via the
 ``persistent_websocket()`` method, it becomes an instance of the

--- a/newsfragments/3202.internal.rst
+++ b/newsfragments/3202.internal.rst
@@ -1,0 +1,1 @@
+Internal change to ``WebsocketsProviderV2`` before release: raise exceptions in message listener task by default; opting to silence them via a flag.

--- a/tests/core/providers/test_wsv2_provider.py
+++ b/tests/core/providers/test_wsv2_provider.py
@@ -39,6 +39,10 @@ async def _coro():
     return None
 
 
+class WSException(Exception):
+    pass
+
+
 @pytest.mark.asyncio
 async def test_async_make_request_returns_desired_response():
     provider = WebsocketProviderV2("ws://mocked")
@@ -126,7 +130,7 @@ async def test_msg_listener_task_starts_on_provider_connect_and_cancels_on_disco
 
 
 @pytest.mark.asyncio
-async def test_msg_listener_task_silences_exceptions_by_default_and_error_logs(caplog):
+async def test_msg_listener_task_raises_exceptions_by_default():
     provider = WebsocketProviderV2("ws://mocked")
     _mock_ws(provider)
 
@@ -135,29 +139,22 @@ async def test_msg_listener_task_silences_exceptions_by_default_and_error_logs(c
     ):
         await provider.connect()
         assert provider._message_listener_task is not None
-        assert provider.raise_listener_task_exceptions is False
+        assert provider.silence_listener_task_exceptions is False
 
     provider._ws = WebsocketMessageStreamMock(
-        raise_exception=Exception("test exception")
+        raise_exception=WSException("test exception")
     )
-    await asyncio.sleep(0.05)
+    with pytest.raises(WSException, match="test exception"):
+        await provider._message_listener_task
 
-    assert "test exception" in caplog.text
-    assert (
-        "Exception caught in listener, error logging and keeping listener background "
-        "task alive.\n    error=test exception"
-    ) in caplog.text
-
-    # assert is still running
-    assert not provider._message_listener_task.cancelled()
-
-    # proper cleanup
-    await provider.disconnect()
+    assert provider._message_listener_task.done()
 
 
 @pytest.mark.asyncio
-async def test_msg_listener_task_raises_when_raise_listener_task_exceptions_is_true():
-    provider = WebsocketProviderV2("ws://mocked", raise_listener_task_exceptions=True)
+async def test_msg_listener_task_silences_exceptions_and_error_logs_when_configured(
+    caplog,
+):
+    provider = WebsocketProviderV2("ws://mocked", silence_listener_task_exceptions=True)
     _mock_ws(provider)
 
     with patch(
@@ -165,14 +162,24 @@ async def test_msg_listener_task_raises_when_raise_listener_task_exceptions_is_t
     ):
         await provider.connect()
         assert provider._message_listener_task is not None
+        assert provider.silence_listener_task_exceptions is True
 
     provider._ws = WebsocketMessageStreamMock(
-        raise_exception=Exception("test exception")
+        raise_exception=WSException("test exception")
     )
-    with pytest.raises(Exception, match="test exception"):
-        await provider._message_listener_task
+    await asyncio.sleep(0.05)
 
-    assert provider._message_listener_task.done()
+    assert "test exception" in caplog.text
+    assert (
+        "Exception caught in listener, error logging and keeping listener background "
+        "task alive.\n    error=WSException: test exception"
+    ) in caplog.text
+
+    # assert is still running
+    assert not provider._message_listener_task.cancelled()
+
+    # proper cleanup
+    await provider.disconnect()
 
 
 @pytest.mark.asyncio

--- a/web3/providers/persistent.py
+++ b/web3/providers/persistent.py
@@ -18,12 +18,13 @@ from web3.providers.websocket.request_processor import (
     RequestProcessor,
 )
 
-DEFAULT_PERSISTENT_CONNECTION_TIMEOUT = 50
+DEFAULT_PERSISTENT_CONNECTION_TIMEOUT = 50.0
 
 
 class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
     logger = logging.getLogger("web3.providers.PersistentConnectionProvider")
     has_persistent_connection = True
+    endpoint_uri: Optional[str] = None
 
     _ws: Optional[WebSocketClientProtocol] = None
     _request_processor: RequestProcessor
@@ -32,12 +33,10 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
 
     def __init__(
         self,
-        endpoint_uri: str,
         request_timeout: float = DEFAULT_PERSISTENT_CONNECTION_TIMEOUT,
         subscription_response_queue_size: int = 500,
     ) -> None:
         super().__init__()
-        self.endpoint_uri = endpoint_uri
         self._request_processor = RequestProcessor(
             self,
             subscription_response_queue_size=subscription_response_queue_size,

--- a/web3/providers/websocket/websocket_v2.py
+++ b/web3/providers/websocket/websocket_v2.py
@@ -96,7 +96,7 @@ class WebsocketProviderV2(PersistentConnectionProvider):
         self.websocket_kwargs = merge(DEFAULT_WEBSOCKET_KWARGS, websocket_kwargs or {})
         self.silence_listener_task_exceptions = silence_listener_task_exceptions
 
-        super().__init__(endpoint_uri, **kwargs)
+        super().__init__(**kwargs)
 
     def __str__(self) -> str:
         return f"Websocket connection: {self.endpoint_uri}"


### PR DESCRIPTION
### What was wrong?

It is often best to fail hard and fast and be able to silence exceptions rather than let exceptions possibly go unnoticed. We were defaulting to silencing exceptions in the message listener task for `WebsocketProviderV2`. This hasn't been released yet and so this change just aims to tweak the configuration and opt to silence exceptions that are raised by default.

### How was it fixed?

- `raise_listener_task_exceptions` -> `silence_listener_task_exceptions`
- Modify tests accordingly
- Close all current tasks in the loop before raising the exception

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20240123_141138](https://github.com/ethereum/web3.py/assets/3532824/9f72472d-341c-4699-a7a4-aa078202fbf2)
