### PR TITLE
[v6] websocket background listener task

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -317,6 +317,6 @@ checking this deque (in case somewhere else in the code, subscriptions responses
 put in the deque by another call looking for another response type) and calling
 ``recv()`` on the websocket connection to see if the response is yet to be received.
 With each iteration on this iterator, if the ``deque`` is non-empty, it will yield
-messages from the ``deque`` as FIFO order until the deque is empty before receiving any
+messages from the ``queue`` as FIFO order until the deque is empty before receiving any
 new messages from the websocket connection, guaranteeing the messages are yielded in the
 order they were received.

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -203,6 +203,19 @@ not adhere to the `JSON-RPC 2.0 specification <https://www.jsonrpc.org/specifica
 in this way will not work with ``PersistentConnectionProvider`` instances. The specifics
 of how the request processor handles this are outlined below.
 
+Listening for Responses
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Implementations of the ``PersistentConnectionProvider`` class have a message listener
+background task that is called when the websocket connection is established. This task
+is responsible for listening for any and all messages coming in over the websocket
+connection and storing them in the ``RequestProcessor`` instance internal to the
+``PersistentConnectionProvider`` instance. The ``RequestProcessor`` instance is
+responsible for storing the messages in the correct cache, either the one-to-one cache
+or the one-to-many (subscriptions) queue, depending on whether the message has a
+JSON-RPC *id* value or not.
+
+
 One-To-One Requests
 ~~~~~~~~~~~~~~~~~~~
 
@@ -221,12 +234,17 @@ back. An example is using the ``eth`` module API to request the latest block num
     >>> asyncio.run(wsV2_one_to_one_example())
 
 With websockets we have to call ``send()`` and asynchronously receive responses via
-``recv()``. In order to make the one-to-one request-to-response call work, we
-have to save the request information somewhere so that when the response is received
-we can match it to the original request that was made i.e. the request with a matching
-*id* to the response that was received). The stored request information is then used to
-process the response when it is received, piping it through the response formatters and
-middlewares internal to the *web3.py* library.
+another means, generally by calling ``recv()`` or by iterating on the websocket
+connection for messages. As outlined above, the ``PersistentConnectionProvider`` class
+has a message listener background task that handles the receiving of messages.
+
+Due to this asynchronous nature of sending and receiving, in order to make one-to-one
+request-to-response calls work, we have to save the request information somewhere so
+that, when the response is received, we can match it to the original request that was
+made (i.e. the request with a matching *id* to the response that was received). The
+stored request information is then used to process the response when it is received,
+piping it through the response formatters and middlewares internal to the *web3.py*
+library.
 
 In order to store the request information, the ``RequestProcessor`` class has an
 internal ``RequestInformation`` cache. The ``RequestInformation`` class saves important
@@ -264,20 +282,24 @@ information about a request.
 One-to-one responses, those that include a JSON-RPC *id* in the response object, are
 stored in an internal ``SimpleCache`` class, isolated from any one-to-many responses.
 When the ``PersistentConnectionProvider`` is looking for a response internally, it will
-cycle within a ``while`` loop, alternating between checking this cache (in case
-somewhere else in the code our desired response was cached by another call) and calling
-``recv()`` on the websocket connection to see if it is yet to come.
+expect the message listener task to store the response in this cache. Since the request
+*id* is used in the cache key generation, it will then look for a cache key that matches
+the response *id* with that of the request *id*. If the cache key is found, the response
+is processed and returned to the user. If the cache key is not found, the operation will
+time out and raise a ``TimeExhausted`` exception. This timeout can be configured by the
+user when instantiating the ``PersistentConnectionProvider`` instance via the
+``response_timeout`` keyword argument.
 
 One-To-Many Requests
 ~~~~~~~~~~~~~~~~~~~~
 
 One-to-many requests can be summarized by any request that expects many responses as a
-result of the initial request. An example is the ``eth_subscribe`` request. The initial
-``eth_subscribe`` request expects only one response, the subscription *id* value, but
-it also expects to receive many ``eth_subscription`` messages if and when the request is
-successful. For this reason, the original request is considered a one-to-one request
-so that a subscription *id* can be returned to the user on the same line, but the
-``listen_to_websocket()`` method on the
+result of the initial request. The only current example is the ``eth_subscribe``
+request. The initial ``eth_subscribe`` request expects only one response, the
+subscription *id* value, but it also expects to receive many ``eth_subscription``
+messages if and when the request is successful. For this reason, the original request
+is considered a one-to-one request so that a subscription *id* can be returned to the
+user on the same line, but the ``process_subscriptions()`` method on the
 :class:`~web3.providers.websocket.WebsocketConnection` class, the public API for
 interacting with the active websocket connection, is set up to receive
 ``eth_subscription`` responses over an asynchronous interator pattern.
@@ -293,8 +315,8 @@ interacting with the active websocket connection, is set up to receive
     ...         subscription_id = await w3.eth.subscribe("newHeads")
     ...
     ...         # Listen to the websocket for the many responses utilizing the ``w3.ws``
-    ...         # ``WebsocketConnection`` public API method ``listen_to_websocket()``
-    ...         async for response in w3.ws.listen_to_websocket():
+    ...         # ``WebsocketConnection`` public API method ``process_subscriptions()``
+    ...         async for response in w3.ws.process_subscriptions():
     ...             # Receive only one-to-many responses here so that we don't
     ...             # accidentally return the response for a one-to-one request in this
     ...             # block
@@ -310,13 +332,22 @@ interacting with the active websocket connection, is set up to receive
     >>> asyncio.run(ws_v2_subscription_example())
 
 One-to-many responses, those that do not include a JSON-RPC *id* in the response object,
-are stored in an internal ``collections.deque`` instance, isolated from any one-to-one
-responses. When the ``PersistentConnectionProvider`` is looking for a one-to-many
-response internally, it will cycle within a ``while`` loop, alternating between
-checking this deque (in case somewhere else in the code, subscriptions responses were
-put in the deque by another call looking for another response type) and calling
-``recv()`` on the websocket connection to see if the response is yet to be received.
-With each iteration on this iterator, if the ``deque`` is non-empty, it will yield
-messages from the ``queue`` as FIFO order until the deque is empty before receiving any
-new messages from the websocket connection, guaranteeing the messages are yielded in the
-order they were received.
+are stored in an internal ``asyncio.Queue`` instance, isolated from any one-to-one
+responses. When the ``PersistentConnectionProvider`` is looking for one-to-many
+responses internally, it will expect the message listener task to store these messages
+in this queue. Since the order of the messages is important, the queue is a FIFO queue.
+The ``process_subscriptions()`` method on the ``WebsocketConnection`` class is set up
+to pop messages from this queue as FIFO over an asynchronous iterator pattern.
+
+If the stream of messages from the websocket is not being interrupted by any other
+tasks, the queue will generally be in sync with the messages coming in over the
+websocket. That is, the message listener will put a message in the queue and the
+``process_subscriptions()`` method will pop that message from the queue and yield
+control of the loop back to the listener. This will continue until the websocket
+connection is closed or the user unsubscribes from the subscription. If the stream of
+messages lags a bit, or the provider is not consuming messages but has subscribed to
+a subscription, this internal queue may fill up with messages until it reaches its max
+size and then trigger a waiting ``asyncio.Event`` until the provider begins consuming
+messages from the queue again. For this reason, it's important to begin consuming
+messages from the queue, via the ``process_subscriptions()`` method, as soon as a
+subscription is made.

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -186,6 +186,7 @@ The Manager acts as a gatekeeper for the request/response lifecycle.  It is
 unlikely that you will need to change the Manager as most functionality can be
 implemented in the Middleware layer.
 
+.. _internals__persistent_connection_providers:
 
 Request Processing for Persistent Connection Providers
 ------------------------------------------------------

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -219,14 +219,38 @@ WebsocketProvider
         >>> w3 = Web3(Web3.WebsocketProvider("ws://127.0.0.1:8546", websocket_timeout=60))
 
 
+Persistent Connection Providers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. py:class:: web3.providers.persistent.PersistentConnectionProvider(endpoint_uri: str, request_timeout: float = 50.0, subscription_response_queue_size: int = 500)
+
+    This is a base provider class, currently inherited by the ``WebsocketProviderV2``.
+    It handles interactions with a persistent connection to a JSON-RPC server. Among
+    its configuration, it houses all of the
+    :class:`~web3.providers.websocket.request_processor.RequestProcessor` logic for
+    handling the asynchronous sending and receiving of requests and responses. See
+    the :ref:`internals__persistent_connection_providers` section for more details on
+    the internals of persistent connection providers.
+
+    * ``request_timeout`` is the timeout in seconds, used when sending data over the
+      connection and waiting for a response to be received from the listener task.
+      Defaults to ``50.0``.
+
+    * ``subscription_response_queue_size`` is the size of the queue used to store
+      subscription responses, defaults to ``500``. While messages are being consumed,
+      this queue should never fill up as it is a transient queue and meant to handle
+      asynchronous receiving and processing of responses. When in sync with the
+      websocket stream, this queue should only ever store 1 to a few messages at a time.
+
+
 WebsocketProviderV2 (beta)
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+``````````````````````````
 
 .. warning:: This provider is still in beta. However, it is being actively developed
     and supported and is expected to be stable in the next major version of *web3.py*
     (v7).
 
-.. py:class:: web3.providers.websocket.WebsocketProviderV2(endpoint_uri, websocket_kwargs, call_timeout)
+.. py:class:: web3.providers.websocket.WebsocketProviderV2(endpoint_uri: str, websocket_kwargs: Dict[str, Any] = {}, silence_listener_task_exceptions: bool = False)
 
     This provider handles interactions with an WS or WSS based JSON-RPC server.
 
@@ -234,8 +258,14 @@ WebsocketProviderV2 (beta)
       ``'ws://localhost:8546'``.
     * ``websocket_kwargs`` this should be a dictionary of keyword arguments which
       will be passed onto the ws/wss websocket connection.
-    * ``request_timeout`` is the timeout in seconds, as a float. Used when receiving or
-      sending data over the connection. This value defaults to 20 seconds.
+    * ``silence_listener_task_exceptions`` is a boolean that determines whether
+      exceptions raised by the listener task are silenced. Defaults to ``False``,
+      raising any exceptions that occur in the listener task.
+
+    This provider inherits from the
+    :class:`~web3.providers.persistent.PersistentConnectionProvider` class. Refer to
+    the :class:`~web3.providers.persistent.PersistentConnectionProvider` documentation
+    for details on additional configuration options available for this provider.
 
     Under the hood, the ``WebsocketProviderV2`` uses the python websockets library for
     making requests.  If you would like to modify how requests are made, you can
@@ -244,7 +274,7 @@ WebsocketProviderV2 (beta)
 
 
 Usage
-~~~~~
++++++
 
 The ``AsyncWeb3`` class may be used as a context manager, utilizing the ``async with``
 syntax, when connecting via ``persistent_websocket()`` using the
@@ -363,7 +393,7 @@ one-to-many request-to-response requests. Refer to the
 documentation for details.
 
 _PersistentConnectionWeb3 via AsyncWeb3.persistent_websocket()
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 When an ``AsyncWeb3`` class is connected to a persistent websocket connection, via the
 ``persistent_websocket()`` method, it becomes an instance of the

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -273,7 +273,7 @@ asynchronous context manager, can be found in the `websockets connection`_ docs.
         ...         # subscribe to new block headers
         ...         subscription_id = await w3.eth.subscribe("newHeads")
         ...
-        ...         async for response in w3.ws.listen_to_websocket():
+        ...         async for response in w3.ws.process_subscriptions():
         ...             print(f"{response}\n")
         ...             # handle responses here
         ...
@@ -319,6 +319,7 @@ and reconnect automatically if the connection is lost. A similar example, using 
     ...         except websockets.ConnectionClosed:
     ...             continue
 
+    # run the example
     >>> asyncio.run(ws_v2_subscription_iterator_example())
 
 
@@ -338,6 +339,9 @@ provider in separate lines. Both of these examples are shown below.
     ...     # manual cleanup
     ...     await w3.provider.disconnect()
 
+    # run the example
+    >>> asyncio.run(ws_v2_alternate_init_example_1)
+
     >>> async def ws_v2_alternate_init_example_2():
     ...     # instantiation and connection via the provider as separate lines
     ...     w3 = AsyncWeb3.persistent_websocket(WebsocketProviderV2(f"ws://127.0.0.1:8546"))
@@ -348,8 +352,7 @@ provider in separate lines. Both of these examples are shown below.
     ...     # manual cleanup
     ...     await w3.provider.disconnect()
 
-    >>> # run the examples:
-    >>> asyncio.run(ws_v2_alternate_init_example_1)
+    # run the example
     >>> asyncio.run(ws_v2_alternate_init_example_2)
 
 The ``WebsocketProviderV2`` class uses the
@@ -393,11 +396,11 @@ Interacting with the Websocket Connection
         the subscription ``id`` to a dict of metadata about the subscription
         request.
 
-    .. py:method:: listen_to_websocket()
+    .. py:method:: process_subscriptions()
 
-        This method is available for listening to websocket responses indefinitely.
+        This method is available for listening to websocket subscriptions indefinitely.
         It is an asynchronous iterator that yields strictly one-to-many
-        (e.g. ``eth_subscription`` responses) request-to-response responses from the
+        (e.g. ``eth_subscription`` responses) request-to-response messages from the
         websocket connection. To receive responses for one-to-one request-to-response
         calls, use the standard API for making requests via the appropriate module
         (e.g. ``block_num = await w3.eth.block_number``)
@@ -410,9 +413,12 @@ Interacting with the Websocket Connection
 
         The ``recv()`` method can be used to receive the next message from the
         websocket. The response from this method is formatted by web3.py formatters
-        and run through the middlewares before being returned. This is useful for
-        receiving singled responses for one-to-many requests such receiving the
-        next ``eth_subscribe`` subscription response.
+        and run through the middlewares before being returned. This is not the
+        recommended way to receive a message as the ``process_subscriptions()`` method
+        is available for listening to websocket subscriptions and the standard API for
+        making requests via the appropriate module
+        (e.g. ``block_num = await w3.eth.block_number``) is available for receiving
+        responses for one-to-one request-to-response calls.
 
     .. py:method:: send(method: RPCEndpoint, params: Sequence[Any])
 

--- a/newsfragments/3206.breaking.rst
+++ b/newsfragments/3206.breaking.rst
@@ -1,0 +1,1 @@
+Use a message listener background task for ``WebsocketProviderV2`` rather than relying on ``ws.recv()`` blocking. Some breaking changes to API, notably ``listen_to_websocket`` -> ``process_subscriptions``.

--- a/tests/core/providers/test_wsv2_provider.py
+++ b/tests/core/providers/test_wsv2_provider.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import pytest
 from unittest.mock import (
@@ -9,6 +10,12 @@ from eth_utils import (
     to_bytes,
 )
 
+from web3 import (
+    AsyncWeb3,
+)
+from web3._utils.caching import (
+    RequestInformation,
+)
 from web3._utils.module_testing.module_testing_utils import (
     WebsocketMessageStreamMock,
 )
@@ -176,3 +183,89 @@ async def test_msg_listener_task_raises_when_raise_listener_task_exceptions_is_t
         await provider._message_listener_task
 
     assert provider._message_listener_task.done()
+
+
+@pytest.mark.asyncio
+@skip_if_py37
+async def test_listen_event_awaits_msg_processing_when_subscription_queue_is_full():
+    """
+    This test is to ensure that the `listen_event` method will wait for the
+    `process_subscriptions` method to process a message when the subscription queue
+    is full.
+    """
+    from unittest.mock import (
+        AsyncMock,
+    )
+
+    with patch(
+        "web3.providers.websocket.websocket_v2.connect", new=lambda *_1, **_2: _coro()
+    ):
+        async_w3 = await AsyncWeb3.persistent_websocket(
+            WebsocketProviderV2("ws://mocked")
+        )
+
+    _mock_ws(async_w3.provider)
+
+    assert async_w3.provider._message_listener_task is not None
+    assert not async_w3.provider._message_listener_task.cancelled()
+
+    # assert queue is instance of asyncio.Queue and replace with a new queue, maxsize=1
+    assert isinstance(
+        async_w3.provider._request_processor._subscription_response_queue,
+        type(asyncio.Queue()),
+    )
+    async_w3.provider._request_processor._subscription_response_queue = asyncio.Queue(
+        maxsize=1
+    )
+    assert not async_w3.provider._request_processor._subscription_response_queue.full()
+
+    # mock listen event
+    async_w3.provider._listen_event.wait = AsyncMock()
+    async_w3.provider._listen_event.set = AsyncMock()
+
+    # mock subscription and add to active subscriptions
+    sub_id = "0x1"
+    sub_request_information = RequestInformation(
+        method=RPCEndpoint("eth_subscribe"),
+        params=["mock"],
+        response_formatters=(),
+        subscription_id=sub_id,
+    )
+    async_w3.provider._request_processor._request_information_cache.cache(
+        "", sub_request_information
+    )
+
+    mocked_sub = {
+        "jsonrpc": "2.0",
+        "method": "eth_subscription",
+        "params": {"subscription": sub_id, "result": "0x1337"},
+    }
+
+    # fill queue with one item so it is full
+    async_w3.provider._request_processor._subscription_response_queue.put_nowait(
+        mocked_sub
+    )
+    assert async_w3.provider._request_processor._subscription_response_queue.full()
+
+    # wait will be called on the _listen_event when the next message comes in
+    async_w3.provider._listen_event.wait.assert_not_called()
+
+    # mock the message stream with a single message
+    # the message listener task should then call the _listen_event.wait since the
+    # queue is full
+    async_w3.provider._ws = WebsocketMessageStreamMock(
+        messages=[to_bytes(text=json.dumps(mocked_sub))]
+    )
+    await asyncio.sleep(0.05)
+    async_w3.provider._listen_event.wait.assert_called_once()
+
+    # set is not called until we start consuming messages
+    async_w3.provider._listen_event.set.assert_not_called()
+
+    async for message in async_w3.ws.process_subscriptions():
+        # assert the very next message is the mocked subscription
+        assert message == mocked_sub
+        break
+
+    # assert we set the _listen_event after we consume the message
+    async_w3.provider._listen_event.set.assert_called_once()

--- a/tests/core/providers/test_wsv2_provider.py
+++ b/tests/core/providers/test_wsv2_provider.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import pytest
 from unittest.mock import (
@@ -44,7 +43,7 @@ async def _coro():
     sys.version_info < (3, 8),
     reason="Uses AsyncMock, not supported by python 3.7",
 )
-async def test_async_make_request_caches_all_undesired_responses_and_returns_desired():
+async def test_async_make_request_returns_desired_response():
     provider = WebsocketProviderV2("ws://mocked")
 
     with patch(
@@ -56,7 +55,7 @@ async def test_async_make_request_caches_all_undesired_responses_and_returns_des
     method_under_test = provider.make_request
 
     undesired_responses_count = 10
-    ws_recv_responses = [
+    ws_messages = [
         to_bytes(
             text=json.dumps(
                 {
@@ -70,21 +69,21 @@ async def test_async_make_request_caches_all_undesired_responses_and_returns_des
     ]
     # The first request we make should have an id of `0`, expect the response to match
     # that id. Append it as the last response in the list.
-    ws_recv_responses.append(b'{"jsonrpc": "2.0", "id": 0, "result": "0x1337"}')
-    provider._ws = WebsocketMessageStreamMock(ws_recv_responses)
+    ws_messages.append(b'{"jsonrpc": "2.0", "id": 0, "result": "0x1337"}')
+    provider._ws = WebsocketMessageStreamMock(messages=ws_messages)
 
     response = await method_under_test(RPCEndpoint("some_method"), ["desired_params"])
-    assert response == json.loads(ws_recv_responses.pop())
+    assert response == json.loads(ws_messages.pop())
 
     qsize = provider._request_processor._subscription_response_queue.qsize()
-    assert qsize == len(ws_recv_responses) == undesired_responses_count
+    assert qsize == len(ws_messages) == undesired_responses_count
 
     for i in range(qsize):
         cached_response = (
             await provider._request_processor._subscription_response_queue.get()
         )
         # assert all cached responses are in the list of responses we received
-        assert to_bytes(text=json.dumps(cached_response)) in ws_recv_responses
+        assert to_bytes(text=json.dumps(cached_response)) in ws_messages
 
     assert provider._request_processor._subscription_response_queue.empty()
     assert len(provider._request_processor._request_response_cache) == 0
@@ -104,10 +103,7 @@ async def test_async_make_request_times_out_of_while_loop_looking_for_response()
     provider = WebsocketProviderV2("ws://mocked", request_timeout=timeout)
 
     method_under_test = provider.make_request
-
     _mock_ws(provider)
-    # mock the websocket to never receive a response & sleep longer than the timeout
-    provider._ws.recv = lambda *args, **kwargs: asyncio.sleep(1)
 
     with pytest.raises(
         TimeExhausted,
@@ -115,3 +111,68 @@ async def test_async_make_request_times_out_of_while_loop_looking_for_response()
         rf"{timeout} second\(s\)",
     ):
         await method_under_test(RPCEndpoint("some_method"), ["desired_params"])
+
+
+@pytest.mark.asyncio
+async def test_msg_listener_task_starts_on_provider_connect_and_cancels_on_disconnect():
+    provider = WebsocketProviderV2("ws://mocked")
+    _mock_ws(provider)
+
+    assert provider._message_listener_task is None
+
+    with patch(
+        "web3.providers.websocket.websocket_v2.connect", new=lambda *_1, **_2: _coro()
+    ):
+        await provider.connect()  # connect
+
+    assert provider._message_listener_task is not None
+    assert not provider._message_listener_task.cancelled()
+
+    await provider.disconnect()  # disconnect
+
+    assert provider._message_listener_task.cancelled()
+    assert provider._message_listener_task.done()
+
+
+@pytest.mark.asyncio
+async def test_msg_listener_task_silences_exceptions_by_default_and_error_logs(caplog):
+    provider = WebsocketProviderV2("ws://mocked")
+    _mock_ws(provider)
+
+    with patch(
+        "web3.providers.websocket.websocket_v2.connect", new=lambda *_1, **_2: _coro()
+    ):
+        await provider.connect()
+        assert provider._message_listener_task is not None
+        assert provider.raise_listener_task_exceptions is False
+
+    provider._ws = WebsocketMessageStreamMock(
+        raise_exception=Exception("test exception")
+    )
+    await provider._message_listener_task
+
+    assert "test exception" in caplog.text
+    assert (
+        "Exception caught in listener, error logging and keeping listener background "
+        "task alive.\n    error=test exception"
+    ) in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_msg_listener_task_raises_when_raise_listener_task_exceptions_is_true():
+    provider = WebsocketProviderV2("ws://mocked", raise_listener_task_exceptions=True)
+    _mock_ws(provider)
+
+    with patch(
+        "web3.providers.websocket.websocket_v2.connect", new=lambda *_1, **_2: _coro()
+    ):
+        await provider.connect()
+        assert provider._message_listener_task is not None
+
+    provider._ws = WebsocketMessageStreamMock(
+        raise_exception=Exception("test exception")
+    )
+    with pytest.raises(Exception, match="test exception"):
+        await provider._message_listener_task
+
+    assert provider._message_listener_task.done()

--- a/tests/core/providers/test_wsv2_provider.py
+++ b/tests/core/providers/test_wsv2_provider.py
@@ -122,6 +122,12 @@ async def test_async_make_request_times_out_of_while_loop_looking_for_response()
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    # TODO: remove when python 3.7 is no longer supported in web3.py
+    #  python 3.7 is already sunset so this feels like a reasonable tradeoff
+    sys.version_info < (3, 8),
+    reason="Uses AsyncMock, not supported by python 3.7",
+)
 async def test_msg_listener_task_starts_on_provider_connect_and_cancels_on_disconnect():
     provider = WebsocketProviderV2("ws://mocked")
     _mock_ws(provider)
@@ -143,6 +149,12 @@ async def test_msg_listener_task_starts_on_provider_connect_and_cancels_on_disco
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    # TODO: remove when python 3.7 is no longer supported in web3.py
+    #  python 3.7 is already sunset so this feels like a reasonable tradeoff
+    sys.version_info < (3, 8),
+    reason="Uses AsyncMock, not supported by python 3.7",
+)
 async def test_msg_listener_task_silences_exceptions_by_default_and_error_logs(caplog):
     provider = WebsocketProviderV2("ws://mocked")
     _mock_ws(provider)
@@ -173,6 +185,12 @@ async def test_msg_listener_task_silences_exceptions_by_default_and_error_logs(c
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    # TODO: remove when python 3.7 is no longer supported in web3.py
+    #  python 3.7 is already sunset so this feels like a reasonable tradeoff
+    sys.version_info < (3, 8),
+    reason="Uses AsyncMock, not supported by python 3.7",
+)
 async def test_msg_listener_task_raises_when_raise_listener_task_exceptions_is_true():
     provider = WebsocketProviderV2("ws://mocked", raise_listener_task_exceptions=True)
     _mock_ws(provider)
@@ -193,12 +211,22 @@ async def test_msg_listener_task_raises_when_raise_listener_task_exceptions_is_t
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    # TODO: remove when python 3.7 is no longer supported in web3.py
+    #  python 3.7 is already sunset so this feels like a reasonable tradeoff
+    sys.version_info < (3, 8),
+    reason="Uses AsyncMock, not supported by python 3.7",
+)
 async def test_listen_event_awaits_msg_processing_when_subscription_queue_is_full():
     """
     This test is to ensure that the `listen_event` method will wait for the
     `process_subscriptions` method to process a message when the subscription queue
     is full.
     """
+    from unittest.mock import (
+        AsyncMock,
+    )
+
     with patch(
         "web3.providers.websocket.websocket_v2.connect", new=lambda *_1, **_2: _coro()
     ):

--- a/tests/core/providers/test_wsv2_provider.py
+++ b/tests/core/providers/test_wsv2_provider.py
@@ -1,12 +1,18 @@
 import asyncio
 import json
 import pytest
+from unittest.mock import (
+    patch,
+)
 import sys
 
 from eth_utils import (
     to_bytes,
 )
 
+from web3._utils.module_testing.module_testing_utils import (
+    WebsocketMessageStreamMock,
+)
 from web3.exceptions import (
     TimeExhausted,
 )
@@ -27,6 +33,10 @@ def _mock_ws(provider):
     provider._ws = AsyncMock()
 
 
+async def _coro():
+    return None
+
+
 @pytest.mark.asyncio
 @pytest.mark.skipif(
     # TODO: remove when python 3.7 is no longer supported in web3.py
@@ -37,9 +47,14 @@ def _mock_ws(provider):
 async def test_async_make_request_caches_all_undesired_responses_and_returns_desired():
     provider = WebsocketProviderV2("ws://mocked")
 
-    method_under_test = provider.make_request
+    with patch(
+        "web3.providers.websocket.websocket_v2.connect", new=lambda *_1, **_2: _coro()
+    ):
+        await provider.connect()
 
     _mock_ws(provider)
+    method_under_test = provider.make_request
+
     undesired_responses_count = 10
     ws_recv_responses = [
         to_bytes(
@@ -51,50 +66,30 @@ async def test_async_make_request_caches_all_undesired_responses_and_returns_des
                 }
             )
         )
-        for i in range(0, undesired_responses_count)
+        for i in range(undesired_responses_count)
     ]
     # The first request we make should have an id of `0`, expect the response to match
     # that id. Append it as the last response in the list.
-    ws_recv_responses.append(b'{"jsonrpc": "2.0", "id":0, "result": "0x1337"}')
-    provider._ws.recv.side_effect = ws_recv_responses
+    ws_recv_responses.append(b'{"jsonrpc": "2.0", "id": 0, "result": "0x1337"}')
+    provider._ws = WebsocketMessageStreamMock(ws_recv_responses)
 
     response = await method_under_test(RPCEndpoint("some_method"), ["desired_params"])
-    assert response == json.loads(ws_recv_responses.pop())  # pop the expected response
+    assert response == json.loads(ws_recv_responses.pop())
 
-    assert (
-        len(provider._request_processor._subscription_response_deque)
-        == len(ws_recv_responses)
-        == undesired_responses_count
-    )
+    qsize = provider._request_processor._subscription_response_queue.qsize()
+    assert qsize == len(ws_recv_responses) == undesired_responses_count
 
-    for cached_response in provider._request_processor._subscription_response_deque:
+    for i in range(qsize):
+        cached_response = (
+            await provider._request_processor._subscription_response_queue.get()
+        )
         # assert all cached responses are in the list of responses we received
         assert to_bytes(text=json.dumps(cached_response)) in ws_recv_responses
 
-
-@pytest.mark.asyncio
-@pytest.mark.skipif(
-    # TODO: remove when python 3.7 is no longer supported in web3.py
-    #  python 3.7 is already sunset so this feels like a reasonable tradeoff
-    sys.version_info < (3, 8),
-    reason="Uses AsyncMock, not supported by python 3.7",
-)
-async def test_async_make_request_returns_cached_response_with_no_recv_if_cached():
-    provider = WebsocketProviderV2("ws://mocked")
-
-    method_under_test = provider.make_request
-
-    _mock_ws(provider)
-
-    # cache the response, so we should get it immediately & should never call `recv()`
-    desired_response = {"jsonrpc": "2.0", "id": 0, "result": "0x1337"}
-    provider._request_processor.cache_raw_response(desired_response)
-
-    response = await method_under_test(RPCEndpoint("some_method"), ["desired_params"])
-    assert response == desired_response
-
+    assert provider._request_processor._subscription_response_queue.empty()
     assert len(provider._request_processor._request_response_cache) == 0
-    assert not provider._ws.recv.called  # type: ignore
+
+    await provider.disconnect()
 
 
 @pytest.mark.asyncio

--- a/tests/core/providers/test_wsv2_provider.py
+++ b/tests/core/providers/test_wsv2_provider.py
@@ -50,8 +50,6 @@ class WSException(Exception):
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(
-    # TODO: remove when python 3.7 is no longer supported in web3.py
-    #  python 3.7 is already sunset so this feels like a reasonable tradeoff
     sys.version_info < (3, 8),
     reason="Uses AsyncMock, not supported by python 3.7",
 )
@@ -105,8 +103,6 @@ async def test_async_make_request_returns_desired_response():
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(
-    # TODO: remove when python 3.7 is no longer supported in web3.py
-    #  python 3.7 is already sunset so this feels like a reasonable tradeoff
     sys.version_info < (3, 8),
     reason="Uses AsyncMock, not supported by python 3.7",
 )
@@ -127,8 +123,6 @@ async def test_async_make_request_times_out_of_while_loop_looking_for_response()
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(
-    # TODO: remove when python 3.7 is no longer supported in web3.py
-    #  python 3.7 is already sunset so this feels like a reasonable tradeoff
     sys.version_info < (3, 8),
     reason="Uses AsyncMock, not supported by python 3.7",
 )
@@ -154,8 +148,6 @@ async def test_msg_listener_task_starts_on_provider_connect_and_cancels_on_disco
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(
-    # TODO: remove when python 3.7 is no longer supported in web3.py
-    #  python 3.7 is already sunset so this feels like a reasonable tradeoff
     sys.version_info < (3, 8),
     reason="Uses AsyncMock, not supported by python 3.7",
 )
@@ -180,6 +172,10 @@ async def test_msg_listener_task_raises_exceptions_by_default():
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="Uses AsyncMock, not supported by python 3.7",
+)
 async def test_msg_listener_task_silences_exceptions_and_error_logs_when_configured(
     caplog,
 ):
@@ -213,8 +209,6 @@ async def test_msg_listener_task_silences_exceptions_and_error_logs_when_configu
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(
-    # TODO: remove when python 3.7 is no longer supported in web3.py
-    #  python 3.7 is already sunset so this feels like a reasonable tradeoff
     sys.version_info < (3, 8),
     reason="Uses AsyncMock, not supported by python 3.7",
 )

--- a/tests/core/providers/test_wsv2_provider.py
+++ b/tests/core/providers/test_wsv2_provider.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import pytest
 from unittest.mock import (
+    Mock,
     patch,
 )
 import sys
@@ -156,13 +157,19 @@ async def test_msg_listener_task_silences_exceptions_by_default_and_error_logs(c
     provider._ws = WebsocketMessageStreamMock(
         raise_exception=Exception("test exception")
     )
-    await provider._message_listener_task
+    await asyncio.sleep(0.05)
 
     assert "test exception" in caplog.text
     assert (
         "Exception caught in listener, error logging and keeping listener background "
         "task alive.\n    error=test exception"
     ) in caplog.text
+
+    # assert is still running
+    assert not provider._message_listener_task.cancelled()
+
+    # proper cleanup
+    await provider.disconnect()
 
 
 @pytest.mark.asyncio
@@ -186,17 +193,12 @@ async def test_msg_listener_task_raises_when_raise_listener_task_exceptions_is_t
 
 
 @pytest.mark.asyncio
-@skip_if_py37
 async def test_listen_event_awaits_msg_processing_when_subscription_queue_is_full():
     """
     This test is to ensure that the `listen_event` method will wait for the
     `process_subscriptions` method to process a message when the subscription queue
     is full.
     """
-    from unittest.mock import (
-        AsyncMock,
-    )
-
     with patch(
         "web3.providers.websocket.websocket_v2.connect", new=lambda *_1, **_2: _coro()
     ):
@@ -221,7 +223,7 @@ async def test_listen_event_awaits_msg_processing_when_subscription_queue_is_ful
 
     # mock listen event
     async_w3.provider._listen_event.wait = AsyncMock()
-    async_w3.provider._listen_event.set = AsyncMock()
+    async_w3.provider._listen_event.set = Mock()
 
     # mock subscription and add to active subscriptions
     sub_id = "0x1"
@@ -269,3 +271,6 @@ async def test_listen_event_awaits_msg_processing_when_subscription_queue_is_ful
 
     # assert we set the _listen_event after we consume the message
     async_w3.provider._listen_event.set.assert_called_once()
+
+    # proper cleanup
+    await async_w3.provider.disconnect()

--- a/web3/_utils/module_testing/module_testing_utils.py
+++ b/web3/_utils/module_testing/module_testing_utils.py
@@ -174,14 +174,20 @@ def async_mock_offchain_lookup_request_response(
 class WebsocketMessageStreamMock:
     closed: bool = False
 
-    def __init__(self, messages: Collection[bytes]) -> None:
-        self.messages = deque(messages)
+    def __init__(
+        self, messages: Collection[bytes] = None, raise_exception: Exception = None
+    ) -> None:
+        self.messages = deque(messages) if messages else deque()
+        self.raise_exception = raise_exception
 
     def __aiter__(self) -> "Self":
         return self
 
     async def __anext__(self) -> bytes:
-        if len(self.messages) == 0:
+        if self.raise_exception:
+            raise self.raise_exception
+
+        elif len(self.messages) == 0:
             raise StopAsyncIteration
 
         return self.messages.popleft()

--- a/web3/_utils/module_testing/module_testing_utils.py
+++ b/web3/_utils/module_testing/module_testing_utils.py
@@ -1,7 +1,11 @@
+from collections import (
+    deque,
+)
 import time
 from typing import (
     TYPE_CHECKING,
     Any,
+    Collection,
     Dict,
     Generator,
     Sequence,
@@ -40,6 +44,9 @@ if TYPE_CHECKING:
     from requests import Response  # noqa: F401
 
     from web3 import Web3  # noqa: F401
+    from web3._utils.compat import (  # noqa: F401
+        Self,
+    )
 
 
 def mine_pending_block(w3: "Web3") -> None:
@@ -162,3 +169,25 @@ def async_mock_offchain_lookup_request_response(
     monkeypatch.setattr(
         f"aiohttp.ClientSession.{http_method.lower()}", _mock_specific_request
     )
+
+
+class WebsocketMessageStreamMock:
+    closed: bool = False
+
+    def __init__(self, messages: Collection[bytes]) -> None:
+        self.messages = deque(messages)
+
+    def __aiter__(self) -> "Self":
+        return self
+
+    async def __anext__(self) -> bytes:
+        if len(self.messages) == 0:
+            raise StopAsyncIteration
+
+        return self.messages.popleft()
+
+    async def send(self, data: bytes) -> None:
+        pass
+
+    async def close(self) -> None:
+        pass

--- a/web3/_utils/module_testing/persistent_connection_provider.py
+++ b/web3/_utils/module_testing/persistent_connection_provider.py
@@ -295,7 +295,7 @@ class PersistentConnectionProviderTest:
             ws_subscription_response, subscription=True
         )
 
-        async for msg in async_w3.ws.listen_to_websocket():
+        async for msg in async_w3.ws.process_subscriptions():
             response = cast(FormattedEthSubscriptionResponse, msg)
             assert response["subscription"] == sub_id
             assert response["result"] == expected_formatted_result
@@ -331,7 +331,7 @@ class PersistentConnectionProviderTest:
             subscription=True,
         )
 
-        async for msg in async_w3.ws.listen_to_websocket():
+        async for msg in async_w3.ws.process_subscriptions():
             response = cast(FormattedEthSubscriptionResponse, msg)
             assert response.keys() == {"subscription", "result"}
             assert response["subscription"] == sub_id

--- a/web3/_utils/module_testing/persistent_connection_provider.py
+++ b/web3/_utils/module_testing/persistent_connection_provider.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import pytest
 from typing import (
     TYPE_CHECKING,
@@ -11,7 +10,6 @@ from typing import (
 
 from eth_utils import (
     is_hexstr,
-    to_bytes,
 )
 from hexbytes import (
     HexBytes,
@@ -31,13 +29,6 @@ if TYPE_CHECKING:
     from web3.main import (
         _PersistentConnectionWeb3,
     )
-
-
-def _mocked_recv(sub_id: str, ws_subscription_response: Dict[str, Any]) -> bytes:
-    # Must be same subscription id so we can know how to parse the message.
-    # We don't have this information when mocking the response.
-    ws_subscription_response["params"]["subscription"] = sub_id
-    return to_bytes(text=json.dumps(ws_subscription_response))
 
 
 class PersistentConnectionProviderTest:
@@ -295,13 +286,13 @@ class PersistentConnectionProviderTest:
         sub_id = await async_w3.eth.subscribe(*subscription_params)
         assert is_hexstr(sub_id)
 
-        async def _mocked_recv_coro() -> bytes:
-            return _mocked_recv(sub_id, ws_subscription_response)
+        # stub out the subscription id so we know how to process the response
+        ws_subscription_response["params"]["subscription"] = sub_id
 
-        actual_recv_fxn = async_w3.provider._ws.recv
-        async_w3.provider._ws.__setattr__(
-            "recv",
-            _mocked_recv_coro,
+        # add the response to the subscription response cache as if it came from the
+        # websocket connection
+        await async_w3.provider._request_processor.cache_raw_response(
+            ws_subscription_response, subscription=True
         )
 
         async for msg in async_w3.ws.listen_to_websocket():
@@ -311,9 +302,6 @@ class PersistentConnectionProviderTest:
 
             # only testing one message, so break here
             break
-
-        # reset the mocked recv
-        async_w3.provider._ws.__setattr__("recv", actual_recv_fxn)
 
     @pytest.mark.asyncio
     async def test_async_geth_poa_middleware_on_eth_subscription(
@@ -327,25 +315,20 @@ class PersistentConnectionProviderTest:
         sub_id = await async_w3.eth.subscribe("newHeads")
         assert is_hexstr(sub_id)
 
-        async def _mocked_recv_coro() -> bytes:
-            return _mocked_recv(
-                sub_id,
-                {
-                    "jsonrpc": "2.0",
-                    "method": "eth_subscription",
-                    "params": {
-                        "subscription": sub_id,
-                        "result": {
-                            "extraData": f"0x{'00' * 100}",
-                        },
+        # add the response to the subscription response cache as if it came from the
+        # websocket connection
+        await async_w3.provider._request_processor.cache_raw_response(
+            {
+                "jsonrpc": "2.0",
+                "method": "eth_subscription",
+                "params": {
+                    "subscription": sub_id,
+                    "result": {
+                        "extraData": f"0x{'00' * 100}",
                     },
                 },
-            )
-
-        actual_recv_fxn = async_w3.provider._ws.recv
-        async_w3.provider._ws.__setattr__(
-            "recv",
-            _mocked_recv_coro,
+            },
+            subscription=True,
         )
 
         async for msg in async_w3.ws.listen_to_websocket():
@@ -356,10 +339,10 @@ class PersistentConnectionProviderTest:
                 f"0x{'00' * 100}"
             )
 
+            # only testing one message, so break here
             break
 
-        # reset the mocked recv
-        async_w3.provider._ws.__setattr__("recv", actual_recv_fxn)
+        # clean up
         async_w3.middleware_onion.remove("poa_middleware")
 
     @pytest.mark.asyncio

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -381,7 +381,7 @@ class RequestManager:
             response = self._request_processor.pop_raw_response(subscription=True)
             if (
                 response is not None
-                and response.get("params").get("subscription")
+                and response.get("params", {}).get("subscription")
                 in self._request_processor.active_subscriptions
             ):
                 # if response is an active subscription response, process it

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -35,6 +35,7 @@ from web3.datastructures import (
 from web3.exceptions import (
     BadResponseFormat,
     MethodUnavailable,
+    ProviderConnectionError,
 )
 from web3.middleware import (
     abi_middleware,
@@ -355,7 +356,7 @@ class RequestManager:
         response = await request_func(method, params)
         return await self._process_ws_response(response)
 
-    async def ws_recv(self) -> Any:
+    async def _ws_recv(self) -> Any:
         return await self._ws_recv_stream().__anext__()
 
     def _persistent_recv_stream(self) -> "_AsyncPersistentRecvStream":
@@ -368,34 +369,17 @@ class RequestManager:
                 "can listen to websocket recv streams."
             )
 
+        if self._provider._message_listener is None:
+            raise ProviderConnectionError("No listener found for websocket connection.")
+
         while True:
-            # sleep(0) here seems to be the most efficient way to yield control back to
-            # the event loop while waiting for the response to be cached or received on
-            # the websocket.
+            # sleep(0) here seems to be the most efficient way to yield control
+            # back to the event loop while waiting for the response in the queue.
             await asyncio.sleep(0)
 
-            # look in the cache for a response
             response = self._request_processor.pop_raw_response(subscription=True)
             if response is not None:
-                break
-            else:
-                # if no response in the cache, check the websocket connection
-                if not self._provider._ws_lock.locked():
-                    async with self._provider._ws_lock:
-                        try:
-                            # keep timeout low but reasonable to check both the cache
-                            # and the websocket connection for new responses
-                            response = await self._provider._ws_recv(timeout=0.5)
-                        except asyncio.TimeoutError:
-                            # if no response received, continue to next iteration
-                            continue
-
-                    if response.get("method") == "eth_subscription":
-                        break
-                    else:
-                        self._provider._request_processor.cache_raw_response(response)
-
-        yield await self._process_ws_response(response)
+                yield await self._process_ws_response(response)
 
     async def _process_ws_response(self, response: RPCResponse) -> RPCResponse:
         provider = cast(PersistentConnectionProvider, self._provider)
@@ -459,6 +443,6 @@ class _AsyncPersistentRecvStream:
 
     async def __anext__(self) -> RPCResponse:
         try:
-            return await self.manager.ws_recv()
+            return await self.manager._ws_recv()
         except ConnectionClosedOK:
             raise StopAsyncIteration

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -342,7 +342,8 @@ class RequestManager:
             response, params, error_formatters, null_result_formatters
         )
 
-    # persistent connection
+    # -- persistent connection -- #
+
     async def ws_send(self, method: RPCEndpoint, params: Any) -> RPCResponse:
         provider = cast(PersistentConnectionProvider, self._provider)
         request_func = await provider.request_func(
@@ -356,13 +357,13 @@ class RequestManager:
         response = await request_func(method, params)
         return await self._process_ws_response(response)
 
-    async def _ws_recv(self) -> Any:
-        return await self._ws_recv_stream().__anext__()
+    def _persistent_message_stream(self) -> "_AsyncPersistentMessageStream":
+        return _AsyncPersistentMessageStream(self)
 
-    def _persistent_recv_stream(self) -> "_AsyncPersistentRecvStream":
-        return _AsyncPersistentRecvStream(self)
+    async def _get_next_ws_message(self) -> Any:
+        return await self._ws_message_stream().__anext__()
 
-    async def _ws_recv_stream(self) -> AsyncGenerator[RPCResponse, None]:
+    async def _ws_message_stream(self) -> AsyncGenerator[RPCResponse, None]:
         if not isinstance(self._provider, PersistentConnectionProvider):
             raise TypeError(
                 "Only websocket providers that maintain an open, persistent connection "
@@ -427,15 +428,18 @@ class RequestManager:
             return apply_result_formatters(result_formatters, partly_formatted_response)
 
 
-class _AsyncPersistentRecvStream:
+class _AsyncPersistentMessageStream:
     """
-    Async generator for receiving responses from a persistent connection. This
-    abstraction is necessary to define the `__aiter__()` method required for
-    use with "async for" loops.
+    Async generator for pulling subscription responses from the request processor
+    subscription queue. This abstraction is necessary to define the `__aiter__()`
+    method required for use with "async for" loops.
     """
 
     def __init__(self, manager: RequestManager, *args: Any, **kwargs: Any) -> None:
         self.manager = manager
+        self.provider: PersistentConnectionProvider = cast(
+            PersistentConnectionProvider, manager._provider
+        )
         super().__init__(*args, **kwargs)
 
     def __aiter__(self) -> Self:
@@ -443,6 +447,6 @@ class _AsyncPersistentRecvStream:
 
     async def __anext__(self) -> RPCResponse:
         try:
-            return await self.manager._ws_recv()
+            return await self.manager._get_next_ws_message()
         except ConnectionClosedOK:
             raise StopAsyncIteration

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -370,7 +370,7 @@ class RequestManager:
                 "can listen to websocket recv streams."
             )
 
-        if self._provider._message_listener is None:
+        if self._provider._message_listener_task is None:
             raise ProviderConnectionError("No listener found for websocket connection.")
 
         while True:

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -379,7 +379,12 @@ class RequestManager:
             await asyncio.sleep(0)
 
             response = self._request_processor.pop_raw_response(subscription=True)
-            if response is not None:
+            if (
+                response is not None
+                and response.get("params").get("subscription")
+                in self._request_processor.active_subscriptions
+            ):
+                # if response is an active subscription response, process it
                 yield await self._process_ws_response(response)
 
     async def _process_ws_response(self, response: RPCResponse) -> RPCResponse:

--- a/web3/providers/persistent.py
+++ b/web3/providers/persistent.py
@@ -27,7 +27,7 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
 
     _ws: Optional[WebSocketClientProtocol] = None
     _request_processor: RequestProcessor
-    _message_listener: Optional["asyncio.Task[None]"] = None
+    _message_listener_task: Optional["asyncio.Task[None]"] = None
     _listen_event: asyncio.Event = asyncio.Event()
 
     def __init__(
@@ -50,5 +50,5 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
     async def disconnect(self) -> None:
         raise NotImplementedError("Must be implemented by subclasses")
 
-    async def _ws_listener_task(self) -> None:
+    async def _ws_message_listener(self) -> None:
         raise NotImplementedError("Must be implemented by subclasses")

--- a/web3/providers/persistent.py
+++ b/web3/providers/persistent.py
@@ -17,9 +17,6 @@ from web3.providers.async_base import (
 from web3.providers.websocket.request_processor import (
     RequestProcessor,
 )
-from web3.types import (
-    RPCResponse,
-)
 
 DEFAULT_PERSISTENT_CONNECTION_TIMEOUT = 50
 
@@ -31,18 +28,20 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
     _ws: Optional[WebSocketClientProtocol] = None
     _ws_lock: asyncio.Lock = asyncio.Lock()
     _request_processor: RequestProcessor
+    _message_listener: Optional["asyncio.Task[None]"] = None
+    _listen_event: asyncio.Event = asyncio.Event()
 
     def __init__(
         self,
         endpoint_uri: str,
         request_timeout: float = DEFAULT_PERSISTENT_CONNECTION_TIMEOUT,
-        subscription_response_deque_size: int = 500,
+        subscription_response_queue_size: int = 500,
     ) -> None:
         super().__init__()
         self.endpoint_uri = endpoint_uri
         self._request_processor = RequestProcessor(
             self,
-            subscription_response_deque_size=subscription_response_deque_size,
+            subscription_response_queue_size=subscription_response_queue_size,
         )
         self.request_timeout = request_timeout
 
@@ -52,5 +51,5 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
     async def disconnect(self) -> None:
         raise NotImplementedError("Must be implemented by subclasses")
 
-    async def _ws_recv(self, timeout: float = None) -> RPCResponse:
+    async def _ws_listener_task(self) -> None:
         raise NotImplementedError("Must be implemented by subclasses")

--- a/web3/providers/persistent.py
+++ b/web3/providers/persistent.py
@@ -18,12 +18,13 @@ from web3.providers.websocket.request_processor import (
     RequestProcessor,
 )
 
-DEFAULT_PERSISTENT_CONNECTION_TIMEOUT = 50
+DEFAULT_PERSISTENT_CONNECTION_TIMEOUT = 50.0
 
 
 class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
     logger = logging.getLogger("web3.providers.PersistentConnectionProvider")
     has_persistent_connection = True
+    endpoint_uri: Optional[str] = None
 
     _ws: Optional[WebSocketClientProtocol] = None
     _request_processor: RequestProcessor
@@ -32,12 +33,10 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
 
     def __init__(
         self,
-        endpoint_uri: str,
         request_timeout: float = DEFAULT_PERSISTENT_CONNECTION_TIMEOUT,
         subscription_response_queue_size: int = 500,
     ) -> None:
         super().__init__()
-        self.endpoint_uri = endpoint_uri
         self._request_processor = RequestProcessor(
             self,
             subscription_response_queue_size=subscription_response_queue_size,

--- a/web3/providers/persistent.py
+++ b/web3/providers/persistent.py
@@ -26,7 +26,6 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
     has_persistent_connection = True
 
     _ws: Optional[WebSocketClientProtocol] = None
-    _ws_lock: asyncio.Lock = asyncio.Lock()
     _request_processor: RequestProcessor
     _message_listener: Optional["asyncio.Task[None]"] = None
     _listen_event: asyncio.Event = asyncio.Event()

--- a/web3/providers/websocket/request_processor.py
+++ b/web3/providers/websocket/request_processor.py
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
 
 
 class RequestProcessor:
+    _subscription_queue_synced_with_ws_stream: bool = False
+
     def __init__(
         self,
         provider: "PersistentConnectionProvider",
@@ -193,7 +195,7 @@ class RequestProcessor:
         if subscription:
             if self._subscription_response_queue.full():
                 self._provider.logger.info(
-                    "Subscription queue is full. Waiting for listener to process "
+                    "Subscription queue is full. Waiting for provider to consume "
                     "messages before caching."
                 )
                 await self._provider._listen_event.wait()
@@ -223,10 +225,21 @@ class RequestProcessor:
                 self._provider._listen_event.set()
 
             raw_response = self._subscription_response_queue.get_nowait()
-            self._provider.logger.debug(
-                f"Subscription response queue has {qsize} subscription(s). Processing "
-                "as FIFO."
-            )
+            if qsize == 1:
+                if not self._subscription_queue_synced_with_ws_stream:
+                    self._subscription_queue_synced_with_ws_stream = True
+                    self._provider.logger.info(
+                        "Subscription response queue synced with websocket message "
+                        "stream."
+                    )
+            else:
+                if self._subscription_queue_synced_with_ws_stream:
+                    self._subscription_queue_synced_with_ws_stream = False
+                self._provider.logger.info(
+                    f"Subscription response queue has {qsize} subscriptions. "
+                    "Processing as FIFO."
+                )
+
             self._provider.logger.debug(
                 "Subscription response popped from queue to be processed:\n"
                 f"    raw_response={raw_response}"

--- a/web3/providers/websocket/request_processor.py
+++ b/web3/providers/websocket/request_processor.py
@@ -1,6 +1,4 @@
-from collections import (
-    deque,
-)
+import asyncio
 from copy import (
     copy,
 )
@@ -8,7 +6,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Deque,
     Dict,
     Optional,
     Tuple,
@@ -33,21 +30,17 @@ if TYPE_CHECKING:
 
 
 class RequestProcessor:
-    _request_information_cache: SimpleCache
-    _request_response_cache: SimpleCache
-    _subscription_response_deque: Deque[RPCResponse]
-
     def __init__(
         self,
         provider: "PersistentConnectionProvider",
-        subscription_response_deque_size: int = 500,
+        subscription_response_queue_size: int = 500,
     ) -> None:
         self._provider = provider
 
-        self._request_information_cache = SimpleCache(500)
-        self._request_response_cache = SimpleCache(500)
-        self._subscription_response_deque = deque(
-            maxlen=subscription_response_deque_size
+        self._request_information_cache: SimpleCache = SimpleCache(500)
+        self._request_response_cache: SimpleCache = SimpleCache(500)
+        self._subscription_response_queue: asyncio.Queue[RPCResponse] = asyncio.Queue(
+            maxsize=subscription_response_queue_size
         )
 
     @property
@@ -163,16 +156,6 @@ class RequestProcessor:
                 subscribe_cache_key = generate_cache_key(subscription_id)
                 self.pop_cached_request_information(subscribe_cache_key)
 
-                # rebuild the deque without the unsubscribed subscription responses
-                self._subscription_response_deque = deque(
-                    filter(
-                        lambda sub_response: sub_response["params"]["subscription"]
-                        != subscription_id,
-                        self._subscription_response_deque,
-                    ),
-                    maxlen=self._subscription_response_deque.maxlen,
-                )
-
         return request_info
 
     def append_middleware_response_processor(
@@ -204,12 +187,21 @@ class RequestProcessor:
 
     # raw response cache
 
-    def cache_raw_response(self, raw_response: Any, subscription: bool = False) -> None:
+    async def cache_raw_response(
+        self, raw_response: Any, subscription: bool = False
+    ) -> None:
         if subscription:
+            if self._subscription_response_queue.full():
+                self._provider.logger.info(
+                    "Subscription queue is full. Waiting for listener to process "
+                    "messages before caching."
+                )
+                await self._provider._listen_event.wait()
+
             self._provider.logger.debug(
                 f"Caching subscription response:\n    response={raw_response}"
             )
-            self._subscription_response_deque.append(raw_response)
+            await self._subscription_response_queue.put(raw_response)
         else:
             response_id = raw_response.get("id")
             cache_key = generate_cache_key(response_id)
@@ -223,17 +215,20 @@ class RequestProcessor:
         self, cache_key: str = None, subscription: bool = False
     ) -> Any:
         if subscription:
-            deque_length = len(self._subscription_response_deque)
-            if deque_length == 0:
+            qsize = self._subscription_response_queue.qsize()
+            if qsize == 0:
                 return None
 
-            raw_response = self._subscription_response_deque.popleft()
+            if not self._provider._listen_event.is_set():
+                self._provider._listen_event.set()
+
+            raw_response = self._subscription_response_queue.get_nowait()
             self._provider.logger.debug(
-                f"Subscription response deque is not empty. Processing {deque_length} "
-                "subscription(s) as FIFO before receiving new response."
+                f"Subscription response queue has {qsize} subscription(s). Processing "
+                "as FIFO."
             )
             self._provider.logger.debug(
-                "Cached subscription response popped from deque to be processed:\n"
+                "Subscription response popped from queue to be processed:\n"
                 f"    raw_response={raw_response}"
             )
         else:
@@ -261,4 +256,6 @@ class RequestProcessor:
 
         self._request_information_cache.clear()
         self._request_response_cache.clear()
-        self._subscription_response_deque.clear()
+        self._subscription_response_queue = asyncio.Queue(
+            maxsize=self._subscription_response_queue.maxsize
+        )

--- a/web3/providers/websocket/websocket_connection.py
+++ b/web3/providers/websocket/websocket_connection.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
         _PersistentConnectionWeb3,
     )
     from web3.manager import (  # noqa: F401
-        _AsyncPersistentRecvStream,
+        _AsyncPersistentMessageStream,
     )
 
 
@@ -36,7 +36,7 @@ class WebsocketConnection:
         return await self._manager.ws_send(method, params)
 
     async def recv(self) -> Any:
-        return await self._manager._ws_recv()
+        return await self._manager._get_next_ws_message()
 
-    def listen_to_websocket(self) -> "_AsyncPersistentRecvStream":
-        return self._manager._persistent_recv_stream()
+    def listen_to_websocket(self) -> "_AsyncPersistentMessageStream":
+        return self._manager._persistent_message_stream()

--- a/web3/providers/websocket/websocket_connection.py
+++ b/web3/providers/websocket/websocket_connection.py
@@ -38,5 +38,5 @@ class WebsocketConnection:
     async def recv(self) -> Any:
         return await self._manager._get_next_ws_message()
 
-    def listen_to_websocket(self) -> "_AsyncPersistentMessageStream":
+    def process_subscriptions(self) -> "_AsyncPersistentMessageStream":
         return self._manager._persistent_message_stream()

--- a/web3/providers/websocket/websocket_connection.py
+++ b/web3/providers/websocket/websocket_connection.py
@@ -27,6 +27,7 @@ class WebsocketConnection:
     def __init__(self, w3: "_PersistentConnectionWeb3"):
         self._manager = w3.manager
 
+    # -- public methods -- #
     @property
     def subscriptions(self) -> Dict[str, Any]:
         return self._manager._request_processor.active_subscriptions
@@ -35,7 +36,7 @@ class WebsocketConnection:
         return await self._manager.ws_send(method, params)
 
     async def recv(self) -> Any:
-        return await self._manager.ws_recv()
+        return await self._manager._ws_recv()
 
     def listen_to_websocket(self) -> "_AsyncPersistentRecvStream":
         return self._manager._persistent_recv_stream()

--- a/web3/providers/websocket/websocket_v2.py
+++ b/web3/providers/websocket/websocket_v2.py
@@ -67,6 +67,7 @@ class WebsocketProviderV2(PersistentConnectionProvider):
         endpoint_uri: Optional[Union[URI, str]] = None,
         websocket_kwargs: Optional[Dict[str, Any]] = None,
         request_timeout: Optional[float] = DEFAULT_PERSISTENT_CONNECTION_TIMEOUT,
+        listener_task_exceptions_limit: Optional[int] = None,
     ) -> None:
         self.endpoint_uri = URI(endpoint_uri)
         if self.endpoint_uri is None:
@@ -77,7 +78,7 @@ class WebsocketProviderV2(PersistentConnectionProvider):
             for prefix in VALID_WEBSOCKET_URI_PREFIXES
         ):
             raise Web3ValidationError(
-                f"Websocket endpoint uri must begin with 'ws://' or 'wss://': "
+                "Websocket endpoint uri must begin with 'ws://' or 'wss://': "
                 f"{self.endpoint_uri}"
             )
 
@@ -92,6 +93,7 @@ class WebsocketProviderV2(PersistentConnectionProvider):
                 )
 
         self.websocket_kwargs = merge(DEFAULT_WEBSOCKET_KWARGS, websocket_kwargs or {})
+        self.listener_task_exceptions_limit = listener_task_exceptions_limit
 
         super().__init__(endpoint_uri, request_timeout=request_timeout)
 
@@ -122,6 +124,7 @@ class WebsocketProviderV2(PersistentConnectionProvider):
             try:
                 _connection_attempts += 1
                 self._ws = await connect(self.endpoint_uri, **self.websocket_kwargs)
+                self._message_listener = asyncio.create_task(self._ws_listener_task())
                 break
             except WebSocketException as e:
                 if _connection_attempts == self._max_connection_retries:
@@ -144,6 +147,12 @@ class WebsocketProviderV2(PersistentConnectionProvider):
             self.logger.debug(
                 f'Successfully disconnected from endpoint: "{self.endpoint_uri}'
             )
+
+        try:
+            self._message_listener.cancel()
+            await self._message_listener
+        except (asyncio.CancelledError, StopAsyncIteration):
+            pass
 
         self._request_processor.clear_caches()
 
@@ -170,53 +179,18 @@ class WebsocketProviderV2(PersistentConnectionProvider):
 
             while True:
                 # sleep(0) here seems to be the most efficient way to yield control
-                # back to the event loop while waiting for the response to be cached
-                # or received on the websocket.
+                # back to the event loop while waiting for the response to be in the
+                # queue.
                 await asyncio.sleep(0)
 
                 if request_cache_key in self._request_processor._request_response_cache:
-                    # if response is already cached, pop it from cache
                     self.logger.debug(
-                        f"Response for id {request_id} is already cached, pop it "
-                        "from the cache."
+                        f"Popping response for id {request_id} from cache."
                     )
-                    return self._request_processor.pop_raw_response(
+                    popped_response = self._request_processor.pop_raw_response(
                         cache_key=request_cache_key,
                     )
-
-                else:
-                    if not self._ws_lock.locked():
-                        async with self._ws_lock:
-                            self.logger.debug(
-                                f"Response for id {request_id} is not cached, calling "
-                                "`recv()` on websocket."
-                            )
-                            try:
-                                # keep timeout low but reasonable to check both the
-                                # cache and the websocket connection for new responses
-                                response = await self._ws_recv(timeout=0.5)
-                            except asyncio.TimeoutError:
-                                # keep the request timeout around the whole of this
-                                # while loop in case the response sneaks into the cache
-                                # from another call.
-                                continue
-
-                        response_id = response.get("id")
-
-                        if response_id == request_id:
-                            self.logger.debug(
-                                f"Received and returning response for id {request_id}."
-                            )
-                            return response
-                        else:
-                            # cache all responses that are not the desired response
-                            self.logger.debug("Undesired response received, caching.")
-                            is_subscription = (
-                                response.get("method") == "eth_subscription"
-                            )
-                            self._request_processor.cache_raw_response(
-                                response, subscription=is_subscription
-                            )
+                    return popped_response
 
         try:
             # Add the request timeout around the while loop that checks the request
@@ -234,5 +208,34 @@ class WebsocketProviderV2(PersistentConnectionProvider):
                 "allowed to continue."
             )
 
-    async def _ws_recv(self, timeout: float = None) -> RPCResponse:
-        return json.loads(await asyncio.wait_for(self._ws.recv(), timeout=timeout))
+    async def _ws_listener_task(self) -> None:
+        self.logger.info(
+            "Websocket listener background task started. Storing all messages in "
+            "appropriate request processor queues / caches to be processed."
+        )
+        _exceptions = 0
+
+        try:
+            async for raw_message in self._ws:
+                # sleep(0) here seems to be the most efficient way to yield control
+                # back to the event loop to share the loop with other tasks.
+                await asyncio.sleep(0)
+
+                response = json.loads(raw_message)
+                subscription = response.get("method") == "eth_subscription"
+                await self._request_processor.cache_raw_response(
+                    response, subscription=subscription
+                )
+        except Exception as e:
+            if (
+                self.listener_task_exceptions_limit
+                and _exceptions == self.listener_task_exceptions_limit
+            ):
+                # If exceptions limit reached, raise; else, error log & keep task alive
+                raise e
+
+            _exceptions += 1
+            self.logger.error(
+                "Exception caught in listener, error logging and keeping listener "
+                f"background task alive.\n    error={e}"
+            )

--- a/web3/providers/websocket/websocket_v2.py
+++ b/web3/providers/websocket/websocket_v2.py
@@ -31,7 +31,6 @@ from web3.exceptions import (
     Web3ValidationError,
 )
 from web3.providers.persistent import (
-    DEFAULT_PERSISTENT_CONNECTION_TIMEOUT,
     PersistentConnectionProvider,
 )
 from web3.types import (
@@ -66,8 +65,9 @@ class WebsocketProviderV2(PersistentConnectionProvider):
         self,
         endpoint_uri: Optional[Union[URI, str]] = None,
         websocket_kwargs: Optional[Dict[str, Any]] = None,
-        request_timeout: Optional[float] = DEFAULT_PERSISTENT_CONNECTION_TIMEOUT,
         raise_listener_task_exceptions: bool = False,
+        # `PersistentConnectionProvider` kwargs can be passed through
+        **kwargs: Any,
     ) -> None:
         self.endpoint_uri = URI(endpoint_uri)
         if self.endpoint_uri is None:
@@ -95,7 +95,7 @@ class WebsocketProviderV2(PersistentConnectionProvider):
         self.websocket_kwargs = merge(DEFAULT_WEBSOCKET_KWARGS, websocket_kwargs or {})
         self.raise_listener_task_exceptions = raise_listener_task_exceptions
 
-        super().__init__(endpoint_uri, request_timeout=request_timeout)
+        super().__init__(endpoint_uri, **kwargs)
 
     def __str__(self) -> str:
         return f"Websocket connection: {self.endpoint_uri}"

--- a/web3/providers/websocket/websocket_v2.py
+++ b/web3/providers/websocket/websocket_v2.py
@@ -124,7 +124,9 @@ class WebsocketProviderV2(PersistentConnectionProvider):
             try:
                 _connection_attempts += 1
                 self._ws = await connect(self.endpoint_uri, **self.websocket_kwargs)
-                self._message_listener = asyncio.create_task(self._ws_listener_task())
+                self._message_listener_task = asyncio.create_task(
+                    self._ws_message_listener()
+                )
                 break
             except WebSocketException as e:
                 if _connection_attempts == self._max_connection_retries:
@@ -149,10 +151,13 @@ class WebsocketProviderV2(PersistentConnectionProvider):
             )
 
         try:
-            self._message_listener.cancel()
-            await self._message_listener
-        except (asyncio.CancelledError, StopAsyncIteration):
-            pass
+            self._message_listener_task.cancel()
+            await self._message_listener_task
+        except (asyncio.CancelledError, StopAsyncIteration) as e:
+            self.logger.info(
+                "Websocket message listener background task caught and ignored an "
+                f"exception during cancellation: {e}"
+            )
 
         self._request_processor.clear_caches()
 
@@ -208,7 +213,7 @@ class WebsocketProviderV2(PersistentConnectionProvider):
                 "allowed to continue."
             )
 
-    async def _ws_listener_task(self) -> None:
+    async def _ws_message_listener(self) -> None:
         self.logger.info(
             "Websocket listener background task started. Storing all messages in "
             "appropriate request processor queues / caches to be processed."

--- a/web3/providers/websocket/websocket_v2.py
+++ b/web3/providers/websocket/websocket_v2.py
@@ -153,12 +153,8 @@ class WebsocketProviderV2(PersistentConnectionProvider):
         try:
             self._message_listener_task.cancel()
             await self._message_listener_task
-        except (asyncio.CancelledError, StopAsyncIteration) as e:
-            self.logger.info(
-                "Websocket message listener background task caught and ignored an "
-                f"exception during cancellation: {e}"
-            )
-
+        except (asyncio.CancelledError, StopAsyncIteration):
+            pass
         self._request_processor.clear_caches()
 
     async def make_request(self, method: RPCEndpoint, params: Any) -> RPCResponse:

--- a/web3/providers/websocket/websocket_v2.py
+++ b/web3/providers/websocket/websocket_v2.py
@@ -95,7 +95,7 @@ class WebsocketProviderV2(PersistentConnectionProvider):
         self.websocket_kwargs = merge(DEFAULT_WEBSOCKET_KWARGS, websocket_kwargs or {})
         self.silence_listener_task_exceptions = silence_listener_task_exceptions
 
-        super().__init__(endpoint_uri, **kwargs)
+        super().__init__(**kwargs)
 
     def __str__(self) -> str:
         return f"Websocket connection: {self.endpoint_uri}"

--- a/web3/providers/websocket/websocket_v2.py
+++ b/web3/providers/websocket/websocket_v2.py
@@ -65,7 +65,7 @@ class WebsocketProviderV2(PersistentConnectionProvider):
         self,
         endpoint_uri: Optional[Union[URI, str]] = None,
         websocket_kwargs: Optional[Dict[str, Any]] = None,
-        raise_listener_task_exceptions: bool = False,
+        silence_listener_task_exceptions: bool = False,
         # `PersistentConnectionProvider` kwargs can be passed through
         **kwargs: Any,
     ) -> None:
@@ -93,7 +93,7 @@ class WebsocketProviderV2(PersistentConnectionProvider):
                 )
 
         self.websocket_kwargs = merge(DEFAULT_WEBSOCKET_KWARGS, websocket_kwargs or {})
-        self.raise_listener_task_exceptions = raise_listener_task_exceptions
+        self.silence_listener_task_exceptions = silence_listener_task_exceptions
 
         super().__init__(endpoint_uri, **kwargs)
 
@@ -229,11 +229,14 @@ class WebsocketProviderV2(PersistentConnectionProvider):
                         response, subscription=subscription
                     )
             except Exception as e:
-                if self.raise_listener_task_exceptions:
-                    # If ``True``, raise; else, error log & keep task alive
+                if not self.silence_listener_task_exceptions:
+                    loop = asyncio.get_event_loop()
+                    for task in asyncio.all_tasks(loop=loop):
+                        task.cancel()
                     raise e
 
                 self.logger.error(
-                    "Exception caught in listener, error logging and keeping listener "
-                    f"background task alive.\n    error={e}"
+                    "Exception caught in listener, error logging and keeping "
+                    "listener background task alive."
+                    f"\n    error={e.__class__.__name__}: {e}"
                 )

--- a/web3/providers/websocket/websocket_v2.py
+++ b/web3/providers/websocket/websocket_v2.py
@@ -67,7 +67,7 @@ class WebsocketProviderV2(PersistentConnectionProvider):
         endpoint_uri: Optional[Union[URI, str]] = None,
         websocket_kwargs: Optional[Dict[str, Any]] = None,
         request_timeout: Optional[float] = DEFAULT_PERSISTENT_CONNECTION_TIMEOUT,
-        listener_task_exceptions_limit: Optional[int] = None,
+        raise_listener_task_exceptions: bool = False,
     ) -> None:
         self.endpoint_uri = URI(endpoint_uri)
         if self.endpoint_uri is None:
@@ -93,7 +93,7 @@ class WebsocketProviderV2(PersistentConnectionProvider):
                 )
 
         self.websocket_kwargs = merge(DEFAULT_WEBSOCKET_KWARGS, websocket_kwargs or {})
-        self.listener_task_exceptions_limit = listener_task_exceptions_limit
+        self.raise_listener_task_exceptions = raise_listener_task_exceptions
 
         super().__init__(endpoint_uri, request_timeout=request_timeout)
 
@@ -213,8 +213,6 @@ class WebsocketProviderV2(PersistentConnectionProvider):
             "Websocket listener background task started. Storing all messages in "
             "appropriate request processor queues / caches to be processed."
         )
-        _exceptions = 0
-
         try:
             async for raw_message in self._ws:
                 # sleep(0) here seems to be the most efficient way to yield control
@@ -227,14 +225,10 @@ class WebsocketProviderV2(PersistentConnectionProvider):
                     response, subscription=subscription
                 )
         except Exception as e:
-            if (
-                self.listener_task_exceptions_limit
-                and _exceptions == self.listener_task_exceptions_limit
-            ):
-                # If exceptions limit reached, raise; else, error log & keep task alive
+            if self.raise_listener_task_exceptions:
+                # If ``True``, raise; else, error log & keep task alive
                 raise e
 
-            _exceptions += 1
             self.logger.error(
                 "Exception caught in listener, error logging and keeping listener "
                 f"background task alive.\n    error={e}"

--- a/web3/providers/websocket/websocket_v2.py
+++ b/web3/providers/websocket/websocket_v2.py
@@ -214,23 +214,26 @@ class WebsocketProviderV2(PersistentConnectionProvider):
             "Websocket listener background task started. Storing all messages in "
             "appropriate request processor queues / caches to be processed."
         )
-        try:
-            async for raw_message in self._ws:
-                # sleep(0) here seems to be the most efficient way to yield control
-                # back to the event loop to share the loop with other tasks.
-                await asyncio.sleep(0)
+        while True:
+            # the use of sleep(0) seems to be the most efficient way to yield control
+            # back to the event loop to share the loop with other tasks.
+            await asyncio.sleep(0)
 
-                response = json.loads(raw_message)
-                subscription = response.get("method") == "eth_subscription"
-                await self._request_processor.cache_raw_response(
-                    response, subscription=subscription
+            try:
+                async for raw_message in self._ws:
+                    await asyncio.sleep(0)
+
+                    response = json.loads(raw_message)
+                    subscription = response.get("method") == "eth_subscription"
+                    await self._request_processor.cache_raw_response(
+                        response, subscription=subscription
+                    )
+            except Exception as e:
+                if self.raise_listener_task_exceptions:
+                    # If ``True``, raise; else, error log & keep task alive
+                    raise e
+
+                self.logger.error(
+                    "Exception caught in listener, error logging and keeping listener "
+                    f"background task alive.\n    error={e}"
                 )
-        except Exception as e:
-            if self.raise_listener_task_exceptions:
-                # If ``True``, raise; else, error log & keep task alive
-                raise e
-
-            self.logger.error(
-                "Exception caught in listener, error logging and keeping listener "
-                f"background task alive.\n    error={e}"
-            )


### PR DESCRIPTION
### What was wrong?

`v6` backport for #3179 and #3202

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20231220_091455](https://github.com/ethereum/web3.py/assets/3532824/76263b8f-d1ea-4874-9404-b6bb426499dc)
