### PR TITLE
Add MESC

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
         "eth-utils>=2.1.0",
         "hexbytes>=0.1.0,<0.4.0",
         "jsonschema>=4.0.0",
+        "mesc>=0.2.0",
         "protobuf>=4.21.6",
         "pydantic>=2.4.0",
         "pywin32>=223;platform_system=='Windows'",

--- a/web3/_utils/request.py
+++ b/web3/_utils/request.py
@@ -22,6 +22,7 @@ from eth_typing import (
     URI,
 )
 import requests
+import mesc
 
 from web3._utils.async_caching import (
     async_lock,
@@ -39,6 +40,14 @@ DEFAULT_TIMEOUT = 10
 
 
 def get_default_http_endpoint() -> URI:
+    if mesc.is_mesc_enabled():
+        try:
+            endpoint = mesc.get_default_endpoint(profile="web3py")
+            if endpoint is not None and endpoint["url"].startswith("http"):
+                return URI(endpoint["url"])
+        except Exception as e:
+            print("MESC not configured properly: " + str(e))
+
     return URI(os.environ.get("WEB3_HTTP_PROVIDER_URI", "http://localhost:8545"))
 
 

--- a/web3/_utils/request.py
+++ b/web3/_utils/request.py
@@ -21,8 +21,8 @@ from aiohttp import (
 from eth_typing import (
     URI,
 )
-import requests
 import mesc
+import requests
 
 from web3._utils.async_caching import (
     async_lock,

--- a/web3/providers/auto.py
+++ b/web3/providers/auto.py
@@ -16,6 +16,7 @@ from urllib.parse import (
 from eth_typing import (
     URI,
 )
+import mesc
 
 from web3.exceptions import (
     CannotHandleRequest,
@@ -43,6 +44,18 @@ def load_provider_from_environment() -> BaseProvider:
     return load_provider_from_uri(uri_string)
 
 
+def load_provider_from_mesc() -> BaseProvider:
+    if not mesc.is_mesc_enabled():
+        return None
+    endpoint = mesc.get_default_endpoint(profile="web3py")
+    if endpoint is None:
+        return None
+    uri_string = URI(endpoint["url"])
+    if not uri_string:
+        return None
+    return load_provider_from_uri(uri_string)
+
+
 def load_provider_from_uri(
     uri_string: URI, headers: Optional[Dict[str, Tuple[str, str]]] = None
 ) -> BaseProvider:
@@ -62,6 +75,7 @@ def load_provider_from_uri(
 
 class AutoProvider(BaseProvider):
     default_providers = (
+        load_provider_from_mesc,
         load_provider_from_environment,
         IPCProvider,
         HTTPProvider,

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -93,7 +93,7 @@ def get_default_ipc_path() -> Optional[str]:
         try:
             endpoint = mesc.get_default_endpoint(profile="web3py_ipc")
             if endpoint is not None and endpoint["url"].endswith(".ipc"):
-                return URI(endpoint["url"])
+                return endpoint["url"]
         except Exception as e:
             print("MESC not configured properly: " + str(e))
 
@@ -130,7 +130,7 @@ def get_dev_ipc_path() -> Optional[str]:
         try:
             endpoint = mesc.get_default_endpoint(profile="web3py_ipc")
             if endpoint is not None and endpoint["url"].endswith(".ipc"):
-                return URI(endpoint["url"])
+                return endpoint["url"]
         except Exception as e:
             print("MESC not configured properly: " + str(e))
 

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -19,6 +19,8 @@ from typing import (
     Union,
 )
 
+import mesc
+
 from web3._utils.threads import (
     Timeout,
 )
@@ -87,6 +89,14 @@ class PersistantSocket:
 
 
 def get_default_ipc_path() -> Optional[str]:
+    if mesc.is_mesc_enabled():
+        try:
+            endpoint = mesc.get_default_endpoint(profile="web3py_ipc")
+            if endpoint is not None and endpoint["url"].endswith(".ipc"):
+                return URI(endpoint["url"])
+        except Exception as e:
+            print("MESC not configured properly: " + str(e))
+
     if sys.platform == "darwin":
         ipc_path = os.path.expanduser(
             os.path.join("~", "Library", "Ethereum", "geth.ipc")
@@ -115,6 +125,15 @@ def get_default_ipc_path() -> Optional[str]:
 
 
 def get_dev_ipc_path() -> Optional[str]:
+
+    if mesc.is_mesc_enabled():
+        try:
+            endpoint = mesc.get_default_endpoint(profile="web3py_ipc")
+            if endpoint is not None and endpoint["url"].endswith(".ipc"):
+                return URI(endpoint["url"])
+        except Exception as e:
+            print("MESC not configured properly: " + str(e))
+
     if os.environ.get("WEB3_PROVIDER_URI", ""):
         ipc_path = os.environ.get("WEB3_PROVIDER_URI")
         if os.path.exists(ipc_path):

--- a/web3/providers/rpc/rpc.py
+++ b/web3/providers/rpc/rpc.py
@@ -16,6 +16,7 @@ from eth_typing import (
 from eth_utils import (
     to_dict,
 )
+import mesc
 
 from web3._utils.http import (
     construct_user_agent,
@@ -65,6 +66,18 @@ class HTTPProvider(JSONBaseProvider):
             ExceptionRetryConfiguration
         ] = ExceptionRetryConfiguration(),
     ) -> None:
+
+        if endpoint_uri is not None and mesc.is_mesc_enabled():
+            try:
+                endpoint = mesc.get_endpoint_by_query(
+                    endpoint_uri,
+                    profile="web3py",
+                )
+                if endpoint is not None and endpoint["url"].startswith("http"):
+                    endpoint_uri = endpoint["url"]
+            except Exception as e:
+                print("MESC not configured properly: " + str(e))
+
         if endpoint_uri is None:
             self.endpoint_uri = get_default_http_endpoint()
         else:


### PR DESCRIPTION
## What is this?

This is a PR to add [MESC](https://github.com/paradigmxyz/mesc) to web3.py.

MESC is an RPC configuration standard that allows a user to share a single RPC configuration across all of the tools on their system. web3.py's current approach of configuring RPC with `WEB3_PROVIDER_URI`, `WEB3_HTTP_PROVIDER_URI`, and `WEB3_WS_PROVIDER_URI` is not standardized across tools, and it is not able to manage the configuration of multiple endpoints or network-specific defaults. Adopting a standardized approach will increase interoperability and make it easier to manage multiple endpoints across multiple networks.

More information about MESC can be found in the [MESC docs](https://paradigmxyz.github.io/mesc/).

## Backward Compatibility

MESC is an opt-in standard and this PR integrates it into web3.py in a backward-compatible way. MESC is only used when a user has enabled MESC in their environment. Behavior of web3.py is unchanged for users that have not enabled MESC.

## Behavioral Changes

This PR introduces two behavioral changes to web.3py:

1. If a user has enabled MESC in their environment, use the MESC provider defaults instead of `WEB3_PROVIDER_URI`, `WEB3_HTTP_PROVIDER_URI`, and `WEB3_WS_PROVIDER_URI`. If a user has not set defaults in their MESC config, web3.py falls back to previous non-MESC defaults.

| provider | provider's new default URI (when MESC is enabled) |
|---|---|
| `web3.providers.HTTPProvider()` | `mesc.get_default_endpoint(profile='web3py')` |
| `web3.providers.WebsockerProvider()` | `mesc.get_default_endpoint(profile='web3py_ws')` |
| `web3.providers.WebsockerProviderV2()` | `mesc.get_default_endpoint(profile='web3py_ws')` |
| `web3.providers.IPCProvider()` | `mesc.get_default_endpoint(profile='web3py_ipc')` |
| `web3.providers.AutoProvider()` | `mesc.get_default_endpoint(profile='web3py')` |

2. If a user has enabled MESC in their environment, allow users to initialize providers using 1) an endpoint name, 2) a network name, 3) a chain id, or 4) a URI (as before). For example, each of the following is now allowed:

| provider type |  code |
| --- | --- |
| `HTTPProvider` by endpoint name | `Web3.HTTPProvider('local_goerli')` |
| `HTTPProvider` by network name | `Web3.HTTPProvider('goerli')` |
| `HTTPProvider` by chain id | `Web3.HTTPProvider('5')` |
| `HTTPProvider` by uri | `Web3.HTTPProvider('http://localhost:8545')` |
| `WebsockerProvider` by endpoint name | `Web3.WebsockerProvider('local_goerli')` |
| `WebsockerProvider` by network name | `Web3.WebsockerProvider('goerli')` |
| `WebsockerProvider` by chain id | `Web3.WebsockerProvider('5')` |
| `WebsockerProvider` by uri | `Web3.WebsockerProvider('ws://localhost:8545')` |
| `WebsockerProviderV2` by endpoint name | `Web3.WebsockerProviderV2('local_goerli')` |
| `WebsockerProviderV2` by network name | `Web3.WebsockerProviderV2('goerli')` |
| `WebsockerProviderV2` by chain id | `Web3.WebsockerProviderV2('5')` |
| `WebsockerProviderV2` by uri | `Web3.WebsockerProviderV2('ws://localhost:8545')` |
| `IPCProvider` by endpoint name | `Web3.IPCProvider('local_goerli')` |
| `IPCProvider` by network name | `Web3.IPCProvider('goerli')` |
| `IPCProvider` by chain id | `Web3.IPCProvider('5')` |
| `IPCProvider` by uri | `Web3.IPCProvider('/path/to/socket.ipc')` |

## Dependency Changes

The [`mesc`](https://github.com/paradigmxyz/mesc/tree/main/python) python implementation has no dependencies and is compatible with python 3.7 through python 3.12.

## Code Changes

1. add `mesc` to the dependencies in `setup.py`
2. allow retrieving mesc data in `HTTPProvider` and `get_default_http_endpoint()`
3. allow retrieving mesc data in `WebsocketProvider` and `websocket.get_default_endpoint()`
4. allow retrieving mesc data in `WebsocketProviderV2` and `websocket_v2.get_default_endpoint()`
5. allow retrieving mesc data in `IPCProvider`, `get_default_ipc_path()`, and `get_dev_ipc_path()`
6. allow retrieving mesc data in `AutoProvider`

These changes are fully backward compatible and web3.py's behavior is unchanged for users that have not opted-in to MESC.

## How to set up MESC?

There are two basic steps: create a `mesc.json` and set `MESC_PATH` to the path of this file. Details can be found in the MESC [Quickstart Guide](https://paradigmxyz.github.io/mesc/quickstart.html). The setup process can also be performed interactively with the [`mesc`](https://github.com/paradigmxyz/mesc/tree/main/cli) cli tool.

## Why would web3.py integrate MESC?

- **Multi-endpoint UX**: Users will be able to easily choose between various networks and endpoints when initializing web3.py providers.
- **Easier onboarding**: As soon as a user installs web3.py, they will immediately be able to use it with all of their configured MESC endpoints, no additional configuration needed.
- **Minimize dev maintenance burden**: web3.py no longer has to maintain code for configuring multiple endpoints, this gets outsourced to MESC.
- **Minimize user maintenance burden**: Users no longer need to maintain `WEB3_PROVIDER_URI`, `WEB3_HTTP_PROVIDER_URI`, or `WEB3_WS_PROVIDER_URI` separately from the configs of their other RPC tools. MESC acts as a single source of RPC config truth system-wide.
- **Future-proof metadata**. MESC can store metadata about each endpoint to track things like rate-limits, namespaces, and endpoint groupings. Integrating MESC would give web3.py the ability to easily use this information in the future for new features. 

A longer form discussion of these advantages can be found on the [Why MESC?](https://paradigmxyz.github.io/mesc/why_mesc.html) page of the MESC docs.

## What do you think?

Let me know what you think and if you have any general questions about MESC.