### PR TITLE
Catch newly raised geth errors when tx indexing in progress

### DIFF
--- a/newsfragments/3216.bugfix.rst
+++ b/newsfragments/3216.bugfix.rst
@@ -1,0 +1,1 @@
+Handle new geth errors related to waiting for a transaction receipt while transactions are still being indexed.

--- a/tests/core/contracts/test_contract_panic_errors.py
+++ b/tests/core/contracts/test_contract_panic_errors.py
@@ -4,11 +4,11 @@ import re
 from tests.core.contracts.utils import (
     deploy,
 )
-from web3._utils.contract_error_handling import (
-    PANIC_ERROR_CODES,
-)
 from web3._utils.contract_sources.contract_data.panic_errors_contract import (
     PANIC_ERRORS_CONTRACT_DATA,
+)
+from web3._utils.error_formatters_utils import (
+    PANIC_ERROR_CODES,
 )
 from web3.exceptions import (
     ContractPanicError,

--- a/web3/_utils/error_formatters_utils.py
+++ b/web3/_utils/error_formatters_utils.py
@@ -169,7 +169,7 @@ def raise_contract_logic_error_on_revert(response: RPCResponse) -> RPCResponse:
 
 def raise_transaction_indexing_error_if_indexing(response: RPCResponse) -> RPCResponse:
     """
-    Raise an error if ``eth_getTransactionReceipt`` returns a response indicating that
+    Raise an error if ``eth_getTransactionReceipt`` returns an error indicating that
     transactions are still being indexed.
     """
 

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -52,12 +52,13 @@ from hexbytes import (
 from web3._utils.abi import (
     is_length,
 )
-from web3._utils.contract_error_handling import (
-    raise_contract_logic_error_on_revert,
-)
 from web3._utils.encoding import (
     hexstr_if_str,
     to_hex,
+)
+from web3._utils.error_formatters_utils import (
+    raise_contract_logic_error_on_revert,
+    raise_transaction_indexing_error_if_indexing,
 )
 from web3._utils.filters import (
     AsyncBlockFilter,
@@ -791,6 +792,7 @@ ABI_REQUEST_FORMATTERS: Formatters = abi_request_formatters(
 ERROR_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_estimateGas: raise_contract_logic_error_on_revert,
     RPC.eth_call: raise_contract_logic_error_on_revert,
+    RPC.eth_getTransactionReceipt: raise_transaction_indexing_error_if_indexing,
 }
 
 

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -41,14 +41,14 @@ from hexbytes import (
     HexBytes,
 )
 
-from web3._utils.contract_error_handling import (
-    PANIC_ERROR_CODES,
-)
 from web3._utils.empty import (
     empty,
 )
 from web3._utils.ens import (
     ens_addresses,
+)
+from web3._utils.error_formatters_utils import (
+    PANIC_ERROR_CODES,
 )
 from web3._utils.fee_utils import (
     PRIORITY_FEE_MIN,

--- a/web3/_utils/module_testing/utils.py
+++ b/web3/_utils/module_testing/utils.py
@@ -49,16 +49,21 @@ class RequestMocker:
 
         async def test_my_w3(async_w3, request_mocker):
             def _iter_responses():
-                 yield {"error": {"code": -32000, "message": "indexing in progress"}}
-                 yield {"error": {"code": -32000, "message": "indexing in progress"}}
-                 yield {"result": "0x1"}
+                    while True:
+                        yield {"error": {"message": "transaction indexing in progress"}}
+                        yield {"error": {"message": "transaction indexing in progress"}}
+                        yield {"result": {"status": "0x1"}}
 
             iter_responses = _iter_responses()
 
             async with request_mocker(
                 async_w3,
-                mock_responses={"eth_getTransactionReceipt": next(iter_responses)}
+                mock_responses={
+                    "eth_getTransactionReceipt": lambda *_: next(iter_responses)
+                },
             ):
+                # assert that the first two error responses are handled and the result
+                # is eventually returned when present
                 assert await w3.eth.get_transaction_receipt("0x1") == "0x1"
 
 

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -60,6 +60,7 @@ from web3.exceptions import (
     OffchainLookup,
     TimeExhausted,
     TooManyRequests,
+    TransactionIndexingInProgress,
     TransactionNotFound,
 )
 from web3.method import (
@@ -517,7 +518,7 @@ class AsyncEth(BaseEth):
             while True:
                 try:
                     tx_receipt = await self._transaction_receipt(_tx_hash)
-                except TransactionNotFound:
+                except (TransactionNotFound, TransactionIndexingInProgress):
                     tx_receipt = None
                 if tx_receipt is not None:
                     break

--- a/web3/eth/eth.py
+++ b/web3/eth/eth.py
@@ -60,6 +60,7 @@ from web3.exceptions import (
     OffchainLookup,
     TimeExhausted,
     TooManyRequests,
+    TransactionIndexingInProgress,
     TransactionNotFound,
 )
 from web3.method import (
@@ -485,7 +486,7 @@ class Eth(BaseEth):
                 while True:
                     try:
                         tx_receipt = self._transaction_receipt(transaction_hash)
-                    except TransactionNotFound:
+                    except (TransactionNotFound, TransactionIndexingInProgress):
                         tx_receipt = None
                     if tx_receipt is not None:
                         break

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -223,6 +223,15 @@ class TransactionNotFound(Web3Exception):
     pass
 
 
+class TransactionIndexingInProgress(Web3Exception):
+    """
+    Raised when a transaction receipt is not yet available due to transaction indexing
+    still being in progress.
+    """
+
+    pass
+
+
 class BlockNotFound(Web3Exception):
     """
     Raised when the block id used to lookup a block in a jsonrpc call cannot be found.

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -45,7 +45,7 @@ from eth_utils.toolz import (
 from web3 import (
     Web3,
 )
-from web3._utils.contract_error_handling import (
+from web3._utils.error_formatters_utils import (
     OFFCHAIN_LOOKUP_FIELDS,
     PANIC_ERROR_CODES,
 )


### PR DESCRIPTION
### What was wrong?

Related to Issue #3212

- Geth ``1.13.11`` started to return an error when transaction indexing is in progress and a ``eth_getTransactionReceipt`` call is made.

### How was it fixed?

- Handle this in the ``wait_for_transaction_receipt`` method by catching the error in order to continue waiting.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.unsplash.com/photo-1560114928-40f1f1eb26a0?q=80&w=1000&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8Y3V0ZSUyMGFuaW1hbHxlbnwwfHwwfHx8MA%3D%3D)
