### PR TITLE
docs: remove 2023 survey banner

### DIFF
--- a/docs/_templates/searchbox.html
+++ b/docs/_templates/searchbox.html
@@ -11,15 +11,4 @@
     <input type="hidden" name="area" value="default" />
   </form>
 </div>
-
-{# Include user survey banner under the search box #}
-<div class="search-banner-wrapper">
-  <a href="https://forms.gle/a5EedxU5FtWv1pQq5">
-    <img
-      src="{{ pathto('_static/banner/user-survey.png', 1) }}"
-      alt="Ethereum Python User Survey"
-    />
-  </a>
-</div>
-
 {%- endif %}

--- a/newsfragments/3218.docs.rst
+++ b/newsfragments/3218.docs.rst
@@ -1,0 +1,1 @@
+Remove annual user survey prompt from docs


### PR DESCRIPTION
### What was wrong?

annual survey closing; remove banner prompt from docs

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/3621728/4369dcfb-f5e1-4dab-a5fe-da57f78d221a)
