### PR TITLE
[V6] Estimate Gas with State Override

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -1053,7 +1053,7 @@ The following methods are available on the ``web3.eth`` namespace.
         })
 
 
-.. py:method:: Eth.estimate_gas(transaction, block_identifier=None)
+.. py:method:: Eth.estimate_gas(transaction, block_identifier=None, state_override=None)
 
     * Delegates to ``eth_estimateGas`` RPC Method
 
@@ -1063,6 +1063,10 @@ The following methods are available on the ``web3.eth`` namespace.
 
     The ``transaction`` and ``block_identifier`` parameters are handled in the
     same manner as the :meth:`~web3.eth.Eth.send_transaction()` method.
+
+    The ``state_override`` parameter allows gas estimation for cases when there
+    are multiple calls that require a specific state as a side effect of the
+    earlier transaction, such as an `approve` followed by a `transfer` call.
 
     .. code-block:: python
 

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -1064,9 +1064,9 @@ The following methods are available on the ``web3.eth`` namespace.
     The ``transaction`` and ``block_identifier`` parameters are handled in the
     same manner as the :meth:`~web3.eth.Eth.send_transaction()` method.
 
-    The ``state_override`` parameter allows gas estimation for cases when there
-    are multiple calls that require a specific state as a side effect of the
-    earlier transaction, such as an `approve` followed by a `transfer` call.
+    The ``state_override`` is useful when there is a chain of transaction calls.
+    It overrides state so that the gas estimate of a transaction is accurate in
+    cases where prior calls produce side effects.
 
     .. code-block:: python
 

--- a/newsfragments/3164.feature.rst
+++ b/newsfragments/3164.feature.rst
@@ -1,0 +1,1 @@
+Implement ``state_override`` parameter for ``eth_estimateGas`` method.

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -304,6 +304,10 @@ class TestEthereumTesterEthModule(EthModuleTest):
         EthModuleTest.test_eth_call_with_override_param_type_check,
         TypeError,
     )
+    test_eth_estimate_gas_with_override_param_type_check = not_implemented(
+        EthModuleTest.test_eth_estimate_gas_with_override_param_type_check,
+        TypeError,
+    )
     test_eth_create_access_list = not_implemented(
         EthModuleTest.test_eth_create_access_list,
         MethodUnavailable,

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -814,6 +814,39 @@ class AsyncEthModuleTest:
         assert gas_estimate > 0
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "params",
+        (
+            {
+                "nonce": 1,  # int
+                "balance": 1,  # int
+                "code": HexStr("0x"),  # HexStr
+                # with state
+                "state": {HexStr(f"0x{'00' * 32}"): HexStr(f"0x{'00' * 32}")},
+            },
+            {
+                "nonce": HexStr("0x1"),  # HexStr
+                "balance": HexStr("0x1"),  # HexStr
+                "code": b"\x00",  # bytes
+                # with stateDiff
+                "stateDiff": {HexStr(f"0x{'00' * 32}"): HexStr(f"0x{'00' * 32}")},
+            },
+        ),
+    )
+    async def test_eth_estimate_gas_with_override_param_type_check(
+        self,
+        async_w3: "AsyncWeb3",
+        async_math_contract: "Contract",
+        params: CallOverrideParams,
+    ) -> None:
+        txn_params: TxParams = {"from": await async_w3.eth.coinbase}
+
+        # assert does not raise
+        await async_w3.eth.estimate_gas(
+            txn_params, None, {async_math_contract.address: params}
+        )
+
+    @pytest.mark.asyncio
     async def test_eth_fee_history(self, async_w3: "AsyncWeb3") -> None:
         fee_history = await async_w3.eth.fee_history(1, "latest", [50])
         assert is_list_like(fee_history["baseFeePerGas"])
@@ -4189,7 +4222,7 @@ class EthModuleTest:
         txn_params: TxParams = {"from": w3.eth.coinbase}
 
         # assert does not raise
-        w3.eth.estimate_gas(txn_params, "latest", {math_contract.address: params})
+        w3.eth.estimate_gas(txn_params, None, {math_contract.address: params})
 
     def test_eth_getBlockByHash(self, w3: "Web3", empty_block: BlockData) -> None:
         block = w3.eth.get_block(empty_block["hash"])

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -4161,6 +4161,36 @@ class EthModuleTest:
         assert is_integer(gas_estimate)
         assert gas_estimate > 0
 
+    @pytest.mark.parametrize(
+        "params",
+        (
+            {
+                "nonce": 1,  # int
+                "balance": 1,  # int
+                "code": HexStr("0x"),  # HexStr
+                # with state
+                "state": {HexStr(f"0x{'00' * 32}"): HexStr(f"0x{'00' * 32}")},
+            },
+            {
+                "nonce": HexStr("0x1"),  # HexStr
+                "balance": HexStr("0x1"),  # HexStr
+                "code": b"\x00",  # bytes
+                # with stateDiff
+                "stateDiff": {HexStr(f"0x{'00' * 32}"): HexStr(f"0x{'00' * 32}")},
+            },
+        ),
+    )
+    def test_eth_estimate_gas_with_override_param_type_check(
+        self,
+        w3: "Web3",
+        math_contract: "Contract",
+        params: CallOverrideParams,
+    ) -> None:
+        txn_params: TxParams = {"from": w3.eth.coinbase}
+
+        # assert does not raise
+        w3.eth.estimate_gas(txn_params, "latest", {math_contract.address: params})
+
     def test_eth_getBlockByHash(self, w3: "Web3", empty_block: BlockData) -> None:
         block = w3.eth.get_block(empty_block["hash"])
         assert block["hash"] == empty_block["hash"]

--- a/web3/contract/async_contract.py
+++ b/web3/contract/async_contract.py
@@ -337,6 +337,7 @@ class AsyncContractFunction(BaseContractFunction):
         self,
         transaction: Optional[TxParams] = None,
         block_identifier: Optional[BlockIdentifier] = None,
+        state_override: Optional[CallOverride] = None,
     ) -> int:
         setup_transaction = self._estimate_gas(transaction)
         return await async_estimate_gas_for_function(
@@ -347,6 +348,7 @@ class AsyncContractFunction(BaseContractFunction):
             self.contract_abi,
             self.abi,
             block_identifier,
+            state_override,
             *self.args,
             **self.kwargs,
         )

--- a/web3/contract/contract.py
+++ b/web3/contract/contract.py
@@ -335,6 +335,7 @@ class ContractFunction(BaseContractFunction):
         self,
         transaction: Optional[TxParams] = None,
         block_identifier: Optional[BlockIdentifier] = None,
+        state_override: Optional[CallOverride] = None,
     ) -> int:
         setup_transaction = self._estimate_gas(transaction)
         return estimate_gas_for_function(
@@ -345,6 +346,7 @@ class ContractFunction(BaseContractFunction):
             self.contract_abi,
             self.abi,
             block_identifier,
+            state_override,
             *self.args,
             **self.kwargs,
         )

--- a/web3/contract/utils.py
+++ b/web3/contract/utils.py
@@ -181,6 +181,7 @@ def estimate_gas_for_function(
     contract_abi: Optional[ABI] = None,
     fn_abi: Optional[ABIFunction] = None,
     block_identifier: Optional[BlockIdentifier] = None,
+    state_override: Optional[CallOverride] = None,
     *args: Any,
     **kwargs: Any,
 ) -> int:
@@ -200,7 +201,7 @@ def estimate_gas_for_function(
         fn_kwargs=kwargs,
     )
 
-    return w3.eth.estimate_gas(estimate_transaction, block_identifier)
+    return w3.eth.estimate_gas(estimate_transaction, block_identifier, state_override)
 
 
 def build_transaction_for_function(
@@ -389,6 +390,7 @@ async def async_estimate_gas_for_function(
     contract_abi: Optional[ABI] = None,
     fn_abi: Optional[ABIFunction] = None,
     block_identifier: Optional[BlockIdentifier] = None,
+    state_override: Optional[CallOverride] = None,
     *args: Any,
     **kwargs: Any,
 ) -> int:
@@ -408,7 +410,9 @@ async def async_estimate_gas_for_function(
         fn_kwargs=kwargs,
     )
 
-    return await async_w3.eth.estimate_gas(estimate_transaction, block_identifier)
+    return await async_w3.eth.estimate_gas(
+        estimate_transaction, block_identifier, state_override
+    )
 
 
 async def async_build_transaction_for_function(

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -316,13 +316,19 @@ class AsyncEth(BaseEth):
     # eth_estimateGas
 
     _estimate_gas: Method[
-        Callable[[TxParams, Optional[BlockIdentifier]], Awaitable[int]]
+        Callable[
+            [TxParams, Optional[BlockIdentifier], Optional[CallOverride]],
+            Awaitable[int],
+        ]
     ] = Method(RPC.eth_estimateGas, mungers=[BaseEth.estimate_gas_munger])
 
     async def estimate_gas(
-        self, transaction: TxParams, block_identifier: Optional[BlockIdentifier] = None
+        self,
+        transaction: TxParams,
+        block_identifier: Optional[BlockIdentifier] = None,
+        state_override: Optional[CallOverride] = None,
     ) -> int:
-        return await self._estimate_gas(transaction, block_identifier)
+        return await self._estimate_gas(transaction, block_identifier, state_override)
 
     # eth_getTransactionByHash
 

--- a/web3/eth/base_eth.py
+++ b/web3/eth/base_eth.py
@@ -95,17 +95,28 @@ class BaseEth(Module):
         self._gas_price_strategy = gas_price_strategy
 
     def estimate_gas_munger(
-        self, transaction: TxParams, block_identifier: Optional[BlockIdentifier] = None
-    ) -> Sequence[Union[TxParams, BlockIdentifier]]:
+        self,
+        transaction: TxParams,
+        block_identifier: Optional[BlockIdentifier] = None,
+        state_override: Optional[CallOverride] = None,
+    ) -> Sequence[Union[TxParams, BlockIdentifier, CallOverride]]:
         if "from" not in transaction and is_checksum_address(self.default_account):
             transaction = assoc(transaction, "from", self.default_account)
 
         if block_identifier is None:
-            params: Sequence[Union[TxParams, BlockIdentifier]] = [transaction]
-        else:
-            params = [transaction, block_identifier]
+            return [transaction]
 
-        return params
+        if state_override is None:
+            return [
+                transaction,
+                block_identifier,
+            ]
+        else:
+            return [
+                transaction,
+                block_identifier,
+                state_override,
+            ]
 
     def get_block_munger(
         self, block_identifier: BlockIdentifier, full_transactions: bool = False

--- a/web3/eth/base_eth.py
+++ b/web3/eth/base_eth.py
@@ -3,7 +3,6 @@ from typing import (
     List,
     NoReturn,
     Optional,
-    Sequence,
     Tuple,
     Union,
 )
@@ -94,29 +93,38 @@ class BaseEth(Module):
     ) -> None:
         self._gas_price_strategy = gas_price_strategy
 
+    def _eth_call_and_estimate_gas_munger(
+        self,
+        transaction: TxParams,
+        block_identifier: Optional[BlockIdentifier] = None,
+        state_override: Optional[CallOverride] = None,
+    ) -> Union[
+        Tuple[TxParams, BlockIdentifier], Tuple[TxParams, BlockIdentifier, CallOverride]
+    ]:
+        # TODO: move to middleware
+        if "from" not in transaction and is_checksum_address(self.default_account):
+            transaction = assoc(transaction, "from", self.default_account)
+
+        # TODO: move to middleware
+        if block_identifier is None:
+            block_identifier = self.default_block
+
+        if state_override is None:
+            return (transaction, block_identifier)
+        else:
+            return (transaction, block_identifier, state_override)
+
     def estimate_gas_munger(
         self,
         transaction: TxParams,
         block_identifier: Optional[BlockIdentifier] = None,
         state_override: Optional[CallOverride] = None,
-    ) -> Sequence[Union[TxParams, BlockIdentifier, CallOverride]]:
-        if "from" not in transaction and is_checksum_address(self.default_account):
-            transaction = assoc(transaction, "from", self.default_account)
-
-        if block_identifier is None:
-            return [transaction]
-
-        if state_override is None:
-            return [
-                transaction,
-                block_identifier,
-            ]
-        else:
-            return [
-                transaction,
-                block_identifier,
-                state_override,
-            ]
+    ) -> Union[
+        Tuple[TxParams, BlockIdentifier], Tuple[TxParams, BlockIdentifier, CallOverride]
+    ]:
+        return self._eth_call_and_estimate_gas_munger(
+            transaction, block_identifier, state_override
+        )
 
     def get_block_munger(
         self, block_identifier: BlockIdentifier, full_transactions: bool = False
@@ -150,18 +158,9 @@ class BaseEth(Module):
     ) -> Union[
         Tuple[TxParams, BlockIdentifier], Tuple[TxParams, BlockIdentifier, CallOverride]
     ]:
-        # TODO: move to middleware
-        if "from" not in transaction and is_checksum_address(self.default_account):
-            transaction = assoc(transaction, "from", self.default_account)
-
-        # TODO: move to middleware
-        if block_identifier is None:
-            block_identifier = self.default_block
-
-        if state_override is None:
-            return (transaction, block_identifier)
-        else:
-            return (transaction, block_identifier, state_override)
+        return self._eth_call_and_estimate_gas_munger(
+            transaction, block_identifier, state_override
+        )
 
     def create_access_list_munger(
         self, transaction: TxParams, block_identifier: Optional[BlockIdentifier] = None

--- a/web3/eth/eth.py
+++ b/web3/eth/eth.py
@@ -302,14 +302,17 @@ class Eth(BaseEth):
 
     # eth_estimateGas
 
-    _estimate_gas: Method[Callable[[TxParams, Optional[BlockIdentifier]], int]] = (
-        Method(RPC.eth_estimateGas, mungers=[BaseEth.estimate_gas_munger])
-    )
+    _estimate_gas: Method[
+        Callable[[TxParams, Optional[BlockIdentifier], Optional[CallOverride]], int]
+    ] = Method(RPC.eth_estimateGas, mungers=[BaseEth.estimate_gas_munger])
 
     def estimate_gas(
-        self, transaction: TxParams, block_identifier: Optional[BlockIdentifier] = None
+        self,
+        transaction: TxParams,
+        block_identifier: Optional[BlockIdentifier] = None,
+        state_override: Optional[CallOverride] = None,
     ) -> int:
-        return self._estimate_gas(transaction, block_identifier)
+        return self._estimate_gas(transaction, block_identifier, state_override)
 
     # eth_getTransactionByHash
 


### PR DESCRIPTION
### What was wrong?

Related to Issue #3164

### How was it fixed?

Adds `state_override` param to `estimate_gas` method.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="394" alt="Screen Shot 2024-02-05 at 9 53 55 AM" src="https://github.com/ethereum/web3.py/assets/435903/c020e1a7-6776-4faf-9375-1160953d07f6">
