### PR TITLE
Eth tester fee history

### DIFF
--- a/newsfragments/3222.internal.rst
+++ b/newsfragments/3222.internal.rst
@@ -1,0 +1,1 @@
+Add eth-tester version that supports ``eth_feeHistory``

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import (
 
 extras_require = {
     "tester": [
-        "eth-tester[py-evm]==v0.9.1-b.1",
+        "eth-tester[py-evm]==v0.9.1-b.2",
         "py-geth>=3.14.0",
     ],
     "linter": [

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -269,14 +269,6 @@ def disable_auto_mine(func):
 
 
 class TestEthereumTesterEthModule(EthModuleTest):
-    test_eth_max_priority_fee_with_fee_history_calculation = not_implemented(
-        EthModuleTest.test_eth_max_priority_fee_with_fee_history_calculation,
-        MethodUnavailable,
-    )
-    test_eth_max_priority_fee_with_fee_history_calculation_error_dict = not_implemented(
-        EthModuleTest.test_eth_max_priority_fee_with_fee_history_calculation_error_dict,
-        ValueError,
-    )
     test_eth_sign = not_implemented(EthModuleTest.test_eth_sign, MethodUnavailable)
     test_eth_sign_ens_names = not_implemented(
         EthModuleTest.test_eth_sign_ens_names, MethodUnavailable
@@ -636,26 +628,10 @@ class TestEthereumTesterEthModule(EthModuleTest):
     def test_eth_send_transaction_no_max_fee(self, eth_tester, w3, unlocked_account):
         super().test_eth_send_transaction_no_max_fee(w3, unlocked_account)
 
-    def test_eth_getBlockByNumber_safe(
-        self, w3: "Web3", empty_block: BlockData
-    ) -> None:
-        super().test_eth_getBlockByNumber_safe(w3, empty_block)
-
-    def test_eth_getBlockByNumber_finalized(
-        self, w3: "Web3", empty_block: BlockData
-    ) -> None:
-        super().test_eth_getBlockByNumber_finalized(w3, empty_block)
-
-    def test_eth_fee_history(self, w3: "Web3") -> None:
-        super().test_eth_fee_history(w3)
-
     def test_eth_fee_history_with_integer(
         self, w3: "Web3", empty_block: BlockData
     ) -> None:
         super().test_eth_fee_history_with_integer(w3, empty_block)
-
-    def test_eth_fee_history_with_no_reward_percentiles(self, w3: "Web3") -> None:
-        super().test_eth_fee_history_no_reward_percentiles(w3)
 
     def test_eth_get_balance_with_block_identifier(self, w3: "Web3") -> None:
         w3.testing.mine()

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -312,15 +312,6 @@ class TestEthereumTesterEthModule(EthModuleTest):
         EthModuleTest.test_eth_call_with_override_param_type_check,
         TypeError,
     )
-    test_eth_fee_history = not_implemented(
-        EthModuleTest.test_eth_fee_history, MethodUnavailable
-    )
-    test_eth_fee_history_with_integer = not_implemented(
-        EthModuleTest.test_eth_fee_history_with_integer, MethodUnavailable
-    )
-    test_eth_fee_history_no_reward_percentiles = not_implemented(
-        EthModuleTest.test_eth_fee_history_no_reward_percentiles, MethodUnavailable
-    )
     test_eth_create_access_list = not_implemented(
         EthModuleTest.test_eth_create_access_list,
         MethodUnavailable,
@@ -654,6 +645,17 @@ class TestEthereumTesterEthModule(EthModuleTest):
         self, w3: "Web3", empty_block: BlockData
     ) -> None:
         super().test_eth_getBlockByNumber_finalized(w3, empty_block)
+
+    def test_eth_fee_history(self, w3: "Web3") -> None:
+        super().test_eth_fee_history(w3)
+
+    def test_eth_fee_history_with_integer(
+        self, w3: "Web3", empty_block: BlockData
+    ) -> None:
+        super().test_eth_fee_history_with_integer(w3, empty_block)
+
+    def test_eth_fee_history_with_no_reward_percentiles(self, w3: "Web3") -> None:
+        super().test_eth_fee_history_no_reward_percentiles(w3)
 
     def test_eth_get_balance_with_block_identifier(self, w3: "Web3") -> None:
         w3.testing.mine()

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -821,7 +821,8 @@ class AsyncEthModuleTest:
         assert is_integer(fee_history["oldestBlock"])
         assert fee_history["oldestBlock"] >= 0
         assert is_list_like(fee_history["reward"])
-        assert is_list_like(fee_history["reward"][0])
+        if len(fee_history["reward"]) > 0:
+            assert is_list_like(fee_history["reward"][0])
 
     @pytest.mark.asyncio
     async def test_eth_fee_history_with_integer(
@@ -835,7 +836,8 @@ class AsyncEthModuleTest:
         assert is_integer(fee_history["oldestBlock"])
         assert fee_history["oldestBlock"] >= 0
         assert is_list_like(fee_history["reward"])
-        assert is_list_like(fee_history["reward"][0])
+        if len(fee_history["reward"]) > 0:
+            assert is_list_like(fee_history["reward"][0])
 
     @pytest.mark.asyncio
     async def test_eth_fee_history_no_reward_percentiles(
@@ -2451,7 +2453,8 @@ class EthModuleTest:
         assert is_integer(fee_history["oldestBlock"])
         assert fee_history["oldestBlock"] >= 0
         assert is_list_like(fee_history["reward"])
-        assert is_list_like(fee_history["reward"][0])
+        if len(fee_history["reward"]) > 0:
+            assert is_list_like(fee_history["reward"][0])
 
     def test_eth_fee_history_with_integer(
         self, w3: "Web3", empty_block: BlockData
@@ -2462,7 +2465,8 @@ class EthModuleTest:
         assert is_integer(fee_history["oldestBlock"])
         assert fee_history["oldestBlock"] >= 0
         assert is_list_like(fee_history["reward"])
-        assert is_list_like(fee_history["reward"][0])
+        if len(fee_history["reward"]) > 0:
+            assert is_list_like(fee_history["reward"][0])
 
     def test_eth_fee_history_no_reward_percentiles(self, w3: "Web3") -> None:
         fee_history = w3.eth.fee_history(1, "latest")

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -263,7 +263,7 @@ API_ENDPOINTS = {
         "mining": static_return(False),
         "hashrate": static_return(0),
         "chainId": static_return(131277322940537),  # from fixture generation file
-        "feeHistory": not_implemented,
+        "feeHistory": call_eth_tester("get_fee_history"),
         "maxPriorityFeePerGas": static_return(10**9),
         "gasPrice": static_return(10**9),  # must be >= base fee post-London
         "accounts": call_eth_tester("get_accounts"),

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -205,6 +205,16 @@ RECEIPT_RESULT_FORMATTERS = {
 }
 receipt_result_formatter = apply_formatters_to_dict(RECEIPT_RESULT_FORMATTERS)
 
+
+fee_history_result_remapper = apply_key_map(
+    {
+        "oldest_block": "oldestBlock",
+        "base_fee_per_gas": "baseFeePerGas",
+        "gas_used_ratio": "gasUsedRatio",
+    }
+)
+
+
 request_formatters = {
     # Eth
     RPCEndpoint("eth_getBlockByNumber"): apply_formatters_to_args(
@@ -263,6 +273,10 @@ request_formatters = {
         identity,
         apply_formatter_if(is_not_named_block, to_integer_if_hex),
     ),
+    RPCEndpoint("eth_feeHistory"): apply_formatters_to_args(
+        to_integer_if_hex,
+        apply_formatter_if(is_not_named_block, to_integer_if_hex),
+    ),
     # EVM
     RPCEndpoint("evm_revert"): apply_formatters_to_args(hex_to_integer),
     # Personal
@@ -271,6 +285,7 @@ request_formatters = {
         identity,
     ),
 }
+
 result_formatters: Optional[Dict[RPCEndpoint, Callable[..., Any]]] = {
     RPCEndpoint("eth_getBlockByHash"): apply_formatter_if(
         is_dict,
@@ -310,6 +325,9 @@ result_formatters: Optional[Dict[RPCEndpoint, Callable[..., Any]]] = {
     RPCEndpoint("eth_getFilterLogs"): apply_formatter_if(
         is_array_of_dicts,
         apply_list_to_array_formatter(log_result_remapper),
+    ),
+    RPCEndpoint("eth_feeHistory"): apply_formatter_if(
+        is_dict, fee_history_result_remapper
     ),
     # EVM
     RPCEndpoint("evm_snapshot"): integer_to_hex,


### PR DESCRIPTION
### What was wrong?
Now that we have an eth-tester version compatible with web3.py v6 that includes `feeHistory`, we can add it here.

Related to Issue #

### How was it fixed?
Bumped eth-tester to a compatible version, then cherry picked the commit from @fselmo that actually made the changes. I noticed there were a few tests that were unneeded, so removed those.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.nrcm.org/wp-content/uploads/2016/12/ermine-1024x819.jpg)
