### PR TITLE
Add formatters for Cancun block header fields:

### DIFF
--- a/newsfragments/3223.feature.rst
+++ b/newsfragments/3223.feature.rst
@@ -1,0 +1,1 @@
+Add formatters for new ``Cancun`` network upgrade block header fields: ``blobGasUsed``, ``excessBlobGas``, and ``parentBeaconBlockRoot``.

--- a/tests/core/eth-module/test_block_api.py
+++ b/tests/core/eth-module/test_block_api.py
@@ -43,6 +43,9 @@ def test_get_block_formatters_with_null_values(w3, request_mocker):
         "transactions": [],
         "withdrawalsRoot": None,
         "withdrawals": [],
+        "blobGasUsed": None,
+        "excessBlobGas": None,
+        "parentBeaconBlockRoot": None,
     }
     with request_mocker(w3, mock_results={"eth_getBlockByNumber": null_values_block}):
         received_block = w3.eth.get_block("pending")
@@ -101,6 +104,11 @@ def test_get_block_formatters_with_pre_formatted_values(w3, request_mocker):
                 "amount": "0x3f695",
             },
         ],
+        "blobGasUsed": "0x7ffff",
+        "excessBlobGas": "0x12c00000",
+        "parentBeaconBlockRoot": (
+            "0x6470e77f1b8a55a49a57b3f74c2a10a76185636d65122053752ea5e4bb4dac59"
+        ),
     }
 
     with request_mocker(
@@ -157,4 +165,9 @@ def test_get_block_formatters_with_pre_formatted_values(w3, request_mocker):
                 "amount": int(unformatted_values_block["withdrawals"][1]["amount"], 16),
             },
         ],
+        "blobGasUsed": int(unformatted_values_block["blobGasUsed"], 16),
+        "excessBlobGas": int(unformatted_values_block["excessBlobGas"], 16),
+        "parentBeaconBlockRoot": HexBytes(
+            unformatted_values_block["parentBeaconBlockRoot"]
+        ),
     }

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -322,6 +322,9 @@ BLOCK_FORMATTERS = {
         is_not_null, apply_list_to_array_formatter(withdrawal_result_formatter)
     ),
     "withdrawalsRoot": apply_formatter_if(is_not_null, to_hexbytes(32)),
+    "blobGasUsed": to_integer_if_hex,
+    "excessBlobGas": to_integer_if_hex,
+    "parentBeaconBlockRoot": apply_formatter_if(is_not_null, to_hexbytes(32)),
 }
 
 


### PR DESCRIPTION
- Add formatters for "blobGasUsed", "excessBlobGas", and "parentBeaconBlockRoot"
- Add fields to block api tests

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

a cute animal formatter
<img width="1024" alt="Screenshot 2024-02-06 at 13 40 38" src="https://github.com/ethereum/web3.py/assets/3532824/ab21aa9c-5e53-4bfb-afe2-23dd1d73c727">

