### PR TITLE
Allow for configuring the request information cache size on wsV2

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -236,6 +236,10 @@ Persistent Connection Providers
       connection and waiting for a response to be received from the listener task.
       Defaults to ``50.0``.
 
+    * ``request_information_cache_size`` is the size of the cache used to store
+      request information so that when a response is received, the provider knows
+      how to process it based on the original request. Defaults to ``500``.
+
     * ``subscription_response_queue_size`` is the size of the queue used to store
       subscription responses, defaults to ``500``. While messages are being consumed,
       this queue should never fill up as it is a transient queue and meant to handle

--- a/newsfragments/3226.feature.rst
+++ b/newsfragments/3226.feature.rst
@@ -1,0 +1,1 @@
+Allow for configuring the ``request_information_cache_size`` for ``PersistentConnectionProvider`` classes. Issue a warning when the cache is full and unexpected behavior may occur.

--- a/web3/providers/persistent.py
+++ b/web3/providers/persistent.py
@@ -34,11 +34,13 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
     def __init__(
         self,
         request_timeout: float = DEFAULT_PERSISTENT_CONNECTION_TIMEOUT,
+        request_information_cache_size: int = 500,
         subscription_response_queue_size: int = 500,
     ) -> None:
         super().__init__()
         self._request_processor = RequestProcessor(
             self,
+            request_information_cache_size=request_information_cache_size,
             subscription_response_queue_size=subscription_response_queue_size,
         )
         self.request_timeout = request_timeout

--- a/web3/utils/caching.py
+++ b/web3/utils/caching.py
@@ -15,6 +15,15 @@ class SimpleCache:
         self._size = size
         self._data: OrderedDict[str, Any] = OrderedDict()
 
+    def __contains__(self, key: str) -> bool:
+        return key in self._data
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def is_full(self) -> bool:
+        return len(self._data) >= self._size
+
     def cache(self, key: str, value: Any) -> Tuple[Any, Dict[str, Any]]:
         evicted_items = None
         # If the key is already in the OrderedDict just update it
@@ -47,9 +56,3 @@ class SimpleCache:
             return None
 
         return self._data.pop(key)
-
-    def __contains__(self, key: str) -> bool:
-        return key in self._data
-
-    def __len__(self) -> int:
-        return len(self._data)


### PR DESCRIPTION
### What was wrong?

Along with a PR to `v7`, once #3225 is merged, will close #3219

### How was it fixed?

- Allow for configuring the `request_information_cache` size so users making a high number of requests do not run into the request information being lost for responses.
- Add a test that uses the configuration to set the size to `1` and checks a warning is issued when full.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![](https://www.bowmanvet.com/blog/wp-content/uploads/2022/03/iStock-1205919904-2000x1335.jpg)
