### PR TITLE
Return `input` instead of `data` for `EthereumTesterProvider` (eth_getTransaction*)

### DIFF
--- a/newsfragments/3235.breaking.rst
+++ b/newsfragments/3235.breaking.rst
@@ -1,0 +1,1 @@
+``EthereumTesterProvider`` now returns ``input`` for `eth_getTransaction*` for better consistency with JSON-RPC spec.

--- a/tests/core/contracts/test_contract_constructor.py
+++ b/tests/core/contracts/test_contract_constructor.py
@@ -220,11 +220,11 @@ def test_contract_constructor_build_transaction_no_constructor(
     txn = w3.eth.get_transaction(txn_hash)
     nonce = w3.eth.get_transaction_count(w3.eth.coinbase)
     unsent_txn = math_contract_factory.constructor().build_transaction({"nonce": nonce})
-    assert txn["data"] == HexBytes(unsent_txn["data"])
+    assert txn["input"] == HexBytes(unsent_txn["data"])
 
     new_txn_hash = w3.eth.send_transaction(unsent_txn)
     new_txn = w3.eth.get_transaction(new_txn_hash)
-    assert new_txn["data"] == HexBytes(unsent_txn["data"])
+    assert new_txn["input"] == HexBytes(unsent_txn["data"])
     assert new_txn["nonce"] == nonce
 
 
@@ -237,11 +237,11 @@ def test_contract_constructor_build_transaction_without_arguments(
     txn = w3.eth.get_transaction(txn_hash)
     nonce = w3.eth.get_transaction_count(w3.eth.coinbase)
     unsent_txn = math_contract_factory.constructor().build_transaction({"nonce": nonce})
-    assert txn["data"] == HexBytes(unsent_txn["data"])
+    assert txn["input"] == HexBytes(unsent_txn["data"])
 
     new_txn_hash = w3.eth.send_transaction(unsent_txn)
     new_txn = w3.eth.get_transaction(new_txn_hash)
-    assert new_txn["data"] == HexBytes(unsent_txn["data"])
+    assert new_txn["input"] == HexBytes(unsent_txn["data"])
     assert new_txn["nonce"] == nonce
 
 
@@ -269,11 +269,11 @@ def test_contract_constructor_build_transaction_with_arguments(
     unsent_txn = non_strict_contract_with_constructor_args_factory.constructor(
         *constructor_args, **constructor_kwargs
     ).build_transaction({"nonce": nonce})
-    assert txn["data"] == HexBytes(unsent_txn["data"])
+    assert txn["input"] == HexBytes(unsent_txn["data"])
 
     new_txn_hash = w3_non_strict_abi.eth.send_transaction(unsent_txn)
     new_txn = w3_non_strict_abi.eth.get_transaction(new_txn_hash)
-    assert new_txn["data"] == HexBytes(unsent_txn["data"])
+    assert new_txn["input"] == HexBytes(unsent_txn["data"])
     assert new_txn["nonce"] == nonce
 
 
@@ -528,11 +528,11 @@ async def test_async_contract_constructor_build_transaction_no_constructor(
     unsent_txn = await async_math_contract_factory.constructor().build_transaction(
         {"nonce": nonce}
     )
-    assert txn["data"] == HexBytes(unsent_txn["data"])
+    assert txn["input"] == HexBytes(unsent_txn["data"])
 
     new_txn_hash = await async_w3.eth.send_transaction(unsent_txn)
     new_txn = await async_w3.eth.get_transaction(new_txn_hash)
-    assert new_txn["data"] == HexBytes(unsent_txn["data"])
+    assert new_txn["input"] == HexBytes(unsent_txn["data"])
     assert new_txn["nonce"] == nonce
 
 
@@ -550,11 +550,11 @@ async def test_async_contract_constructor_build_transaction_without_arguments(
     unsent_txn = await async_math_contract_factory.constructor().build_transaction(
         {"nonce": nonce}
     )
-    assert txn["data"] == HexBytes(unsent_txn["data"])
+    assert txn["input"] == HexBytes(unsent_txn["data"])
 
     new_txn_hash = await async_w3.eth.send_transaction(unsent_txn)
     new_txn = await async_w3.eth.get_transaction(new_txn_hash)
-    assert new_txn["data"] == HexBytes(unsent_txn["data"])
+    assert new_txn["input"] == HexBytes(unsent_txn["data"])
     assert new_txn["nonce"] == nonce
 
 
@@ -589,9 +589,9 @@ async def test_async_contract_constructor_build_transaction_with_arguments(
             *constructor_args, **constructor_kwargs
         ).build_transaction({"nonce": nonce})
     )
-    assert txn["data"] == HexBytes(unsent_txn["data"])
+    assert txn["input"] == HexBytes(unsent_txn["data"])
 
     new_txn_hash = await async_w3_non_strict_abi.eth.send_transaction(unsent_txn)
     new_txn = await async_w3_non_strict_abi.eth.get_transaction(new_txn_hash)
-    assert new_txn["data"] == HexBytes(unsent_txn["data"])
+    assert new_txn["input"] == HexBytes(unsent_txn["data"])
     assert new_txn["nonce"] == nonce

--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -261,7 +261,6 @@ def test_get_transaction_formatters(w3, request_mocker):
             },
         ],
         "input": "0x5b34b966",
-        "data": "0x5b34b966",
     }
 
     with request_mocker(
@@ -318,7 +317,6 @@ def test_get_transaction_formatters(w3, request_mocker):
                 ),
             ],
             "input": HexBytes(unformatted_transaction["input"]),
-            "data": HexBytes(unformatted_transaction["data"]),
         }
     )
 

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -131,6 +131,7 @@ TRANSACTION_RESULT_KEY_MAPPING = {
     "max_priority_fee_per_gas": "maxPriorityFeePerGas",
     "transaction_hash": "transactionHash",
     "transaction_index": "transactionIndex",
+    "data": "input",
 }
 transaction_result_remapper = apply_key_map(TRANSACTION_RESULT_KEY_MAPPING)
 


### PR DESCRIPTION
### What was wrong?

 closes #901

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="615" alt="Screenshot 2024-02-21 at 13 45 01" src="https://github.com/ethereum/web3.py/assets/3532824/d4609cc6-15d0-44e1-a7cc-96fadbc09035">

