### PR TITLE
Use ``Optional[float]`` for async ``wait_for_transaction_receipt()``

### DIFF
--- a/newsfragments/3237.breaking.rst
+++ b/newsfragments/3237.breaking.rst
@@ -1,0 +1,1 @@
+Change the signature for the async version of ``wait_for_transaction_receipt()`` to use ``Optional[float]`` instead of ``float``.

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -516,7 +516,10 @@ class AsyncEth(BaseEth):
         return await self._transaction_receipt(transaction_hash)
 
     async def wait_for_transaction_receipt(
-        self, transaction_hash: _Hash32, timeout: float = 120, poll_latency: float = 0.1
+        self,
+        transaction_hash: _Hash32,
+        timeout: Optional[float] = 120,
+        poll_latency: float = 0.1,
     ) -> TxReceipt:
         async def _wait_for_tx_receipt_with_timeout(
             _tx_hash: _Hash32, _poll_latency: float


### PR DESCRIPTION
### What was wrong?

closes #2685

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="611" alt="Screenshot 2024-02-21 at 13 59 12" src="https://github.com/ethereum/web3.py/assets/3532824/36c34d2c-1e93-420d-83b0-a26f7b81927f">
