### PR TITLE
Optimize `parse_block_identifier`

### DIFF
--- a/web3/_utils/contracts.py
+++ b/web3/_utils/contracts.py
@@ -419,10 +419,10 @@ def parse_block_identifier(
         return parse_block_identifier_int(w3, block_identifier)
     elif block_identifier in ["latest", "earliest", "pending", "safe", "finalized"]:
         return block_identifier
-    elif isinstance(block_identifier, bytes) or is_hex_encoded_block_hash(
-        block_identifier
-    ):
-        return w3.eth.get_block(block_identifier)["number"]
+    elif is_hex_encoded_block_hash(block_identifier):
+        return block_identifier
+    elif isinstance(block_identifier, bytes):
+        return add_0x_prefix(block_identifier.hex())
     else:
         raise BlockNumberOutofRange
 


### PR DESCRIPTION
### What was wrong?

* Case `elif isinstance(block_identifier, bytes) or is_hex_encoded_block_hash(block_identifier)` was making multiple calls when it was not necessary
* Return value was using [`w3.eth.get_block(block_identifier)["number"]`](https://github.com/ethereum/web3.py/blob/main/web3/_utils/contracts.py#L425)

Closes #2816

### How was it fixed?

* Separate each case to short circuit when possible
* Returns `block_identifier` when `is_hex_encoded_block_hash` is true or returns `add_0x_prefix(block_identifier.hex())` when the `block_identifier` is `bytes`.

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="394" alt="Screen Shot 2024-02-22 at 9 53 17 AM" src="https://github.com/ethereum/web3.py/assets/435903/fe36f494-8509-4de0-ad94-d195c1696828">
