### PR TITLE
return default ipc path whether it exists or not

### DIFF
--- a/newsfragments/3245.breaking.rst
+++ b/newsfragments/3245.breaking.rst
@@ -1,0 +1,1 @@
+``get_default_ipc_path()`` and ``get_dev_ipc_path()`` now return the path value without checking if the ``geth.ipc`` file exists.

--- a/tests/core/providers/test_ipc_provider.py
+++ b/tests/core/providers/test_ipc_provider.py
@@ -2,11 +2,15 @@ import os
 import pathlib
 import pytest
 import socket
+import sys
 import tempfile
 from threading import (
     Thread,
 )
 import time
+from unittest.mock import (
+    patch,
+)
 
 from web3.auto.gethdev import (
     w3,
@@ -16,6 +20,8 @@ from web3.exceptions import (
 )
 from web3.providers.ipc import (
     IPCProvider,
+    get_default_ipc_path,
+    get_dev_ipc_path,
 )
 from web3.types import (
     RPCEndpoint,
@@ -47,6 +53,83 @@ def test_ipc_tilda_in_path():
     expectedPath = str(pathlib.Path.home()) + "/foo"
     assert IPCProvider("~/foo").ipc_path == expectedPath
     assert IPCProvider(pathlib.Path("~/foo")).ipc_path == expectedPath
+
+
+@pytest.mark.parametrize(
+    "platform, expected_result, expected_error",
+    [
+        ("darwin", "/Library/Ethereum/geth.ipc", None),
+        ("linux", "/.ethereum/geth.ipc", None),
+        ("freebsd", "/.ethereum/geth.ipc", None),
+        ("win32", r"\\.\pipe\geth.ipc", None),
+        (
+            "unknown",
+            None,
+            {
+                "error": ValueError,
+                "match": (
+                    "Unsupported platform 'unknown'. Only darwin/linux/win32/"
+                    "freebsd are supported.  You must specify the ipc_path"
+                ),
+            },
+        ),
+    ],
+)
+def test_get_default_ipc_path(platform, expected_result, expected_error):
+    with patch.object(sys, "platform", platform):
+        if expected_error:
+            with pytest.raises(expected_error["error"], match=expected_error["match"]):
+                get_default_ipc_path()
+        else:
+            assert get_default_ipc_path().endswith(expected_result)
+
+
+@pytest.mark.parametrize(
+    "provider_env_uri",
+    [
+        "/sample/path/to/ipc/geth.ipc",
+        "",
+    ],
+)
+@pytest.mark.parametrize(
+    "platform, expected_result, expected_error",
+    [
+        ("darwin", "/var/path/to/tmp/T/geth.ipc", None),
+        ("linux", "/tmp/geth.ipc", None),
+        ("freebsd", "/tmp/geth.ipc", None),
+        ("win32", r"\\.\pipe\geth.ipc", None),
+        (
+            "unknown",
+            None,
+            {
+                "error": ValueError,
+                "match": (
+                    "Unsupported platform 'unknown'. Only darwin/linux/win32/"
+                    "freebsd are supported.  You must specify the ipc_path"
+                ),
+            },
+        ),
+    ],
+)
+def test_get_dev_ipc_path_(provider_env_uri, platform, expected_result, expected_error):
+    with patch.object(sys, "platform", platform):
+        with patch.dict(
+            os.environ,
+            {
+                "TMPDIR": "/var/path/to/tmp/T/",
+                "WEB3_PROVIDER_URI": provider_env_uri,
+            },
+        ):
+
+            if provider_env_uri:
+                assert get_dev_ipc_path() == provider_env_uri
+            elif expected_error:
+                with pytest.raises(
+                    expected_error["error"], match=expected_error["match"]
+                ):
+                    get_dev_ipc_path()
+            else:
+                assert get_dev_ipc_path().endswith(expected_result)
 
 
 @pytest.fixture

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -14,7 +14,6 @@ from types import (
 )
 from typing import (
     Any,
-    Optional,
     Type,
     Union,
 )
@@ -86,20 +85,15 @@ class PersistantSocket:
         return self.sock
 
 
-def get_default_ipc_path() -> Optional[str]:
+def get_default_ipc_path() -> str:
     if sys.platform == "darwin":
-        ipc_path = os.path.expanduser(
-            os.path.join("~", "Library", "Ethereum", "geth.ipc")
-        )
-        return ipc_path
+        return os.path.expanduser(os.path.join("~", "Library", "Ethereum", "geth.ipc"))
 
     elif sys.platform.startswith("linux") or sys.platform.startswith("freebsd"):
-        ipc_path = os.path.expanduser(os.path.join("~", ".ethereum", "geth.ipc"))
-        return ipc_path
+        return os.path.expanduser(os.path.join("~", ".ethereum", "geth.ipc"))
 
     elif sys.platform == "win32":
-        ipc_path = r"\\.\pipe\geth.ipc"
-        return ipc_path
+        return r"\\.\pipe\geth.ipc"
 
     else:
         raise ValueError(
@@ -108,23 +102,19 @@ def get_default_ipc_path() -> Optional[str]:
         )
 
 
-def get_dev_ipc_path() -> Optional[str]:
+def get_dev_ipc_path() -> str:
     if os.environ.get("WEB3_PROVIDER_URI", ""):
-        ipc_path = os.environ.get("WEB3_PROVIDER_URI")
-        return ipc_path
+        return os.environ.get("WEB3_PROVIDER_URI")
 
     elif sys.platform == "darwin":
         tmpdir = os.environ.get("TMPDIR", "")
-        ipc_path = os.path.expanduser(os.path.join(tmpdir, "geth.ipc"))
-        return ipc_path
+        return os.path.expanduser(os.path.join(tmpdir, "geth.ipc"))
 
     elif sys.platform.startswith("linux") or sys.platform.startswith("freebsd"):
-        ipc_path = os.path.expanduser(os.path.join("/tmp", "geth.ipc"))
-        return ipc_path
+        return os.path.expanduser(os.path.join("/tmp", "geth.ipc"))
 
     elif sys.platform == "win32":
-        ipc_path = os.path.join("\\\\", ".", "pipe", "geth.ipc")
-        return ipc_path
+        return os.path.join("\\\\", ".", "pipe", "geth.ipc")
 
     else:
         raise ValueError(

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -91,21 +91,15 @@ def get_default_ipc_path() -> Optional[str]:
         ipc_path = os.path.expanduser(
             os.path.join("~", "Library", "Ethereum", "geth.ipc")
         )
-        if os.path.exists(ipc_path):
-            return ipc_path
-        return None
+        return ipc_path
 
     elif sys.platform.startswith("linux") or sys.platform.startswith("freebsd"):
         ipc_path = os.path.expanduser(os.path.join("~", ".ethereum", "geth.ipc"))
-        if os.path.exists(ipc_path):
-            return ipc_path
-        return None
+        return ipc_path
 
     elif sys.platform == "win32":
         ipc_path = r"\\.\pipe\geth.ipc"
-        if os.path.exists(ipc_path):
-            return ipc_path
-        return None
+        return ipc_path
 
     else:
         raise ValueError(
@@ -117,27 +111,20 @@ def get_default_ipc_path() -> Optional[str]:
 def get_dev_ipc_path() -> Optional[str]:
     if os.environ.get("WEB3_PROVIDER_URI", ""):
         ipc_path = os.environ.get("WEB3_PROVIDER_URI")
-        if os.path.exists(ipc_path):
-            return ipc_path
-        return None
+        return ipc_path
 
     elif sys.platform == "darwin":
         tmpdir = os.environ.get("TMPDIR", "")
         ipc_path = os.path.expanduser(os.path.join(tmpdir, "geth.ipc"))
-        if os.path.exists(ipc_path):
-            return ipc_path
-        return None
+        return ipc_path
 
     elif sys.platform.startswith("linux") or sys.platform.startswith("freebsd"):
         ipc_path = os.path.expanduser(os.path.join("/tmp", "geth.ipc"))
-        if os.path.exists(ipc_path):
-            return ipc_path
-        return None
+        return ipc_path
 
     elif sys.platform == "win32":
         ipc_path = os.path.join("\\\\", ".", "pipe", "geth.ipc")
-        if os.path.exists(ipc_path):
-            return ipc_path
+        return ipc_path
 
     else:
         raise ValueError(

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -97,7 +97,7 @@ def get_default_ipc_path() -> str:
 
     else:
         raise ValueError(
-            f"Unsupported platform '{sys.platform}'.  Only darwin/linux/win32/"
+            f"Unsupported platform '{sys.platform}'. Only darwin/linux/win32/"
             "freebsd are supported.  You must specify the ipc_path"
         )
 
@@ -114,11 +114,11 @@ def get_dev_ipc_path() -> str:
         return os.path.expanduser(os.path.join("/tmp", "geth.ipc"))
 
     elif sys.platform == "win32":
-        return os.path.join("\\\\", ".", "pipe", "geth.ipc")
+        return r"\\.\pipe\geth.ipc"
 
     else:
         raise ValueError(
-            f"Unsupported platform '{sys.platform}'.  Only darwin/linux/win32/"
+            f"Unsupported platform '{sys.platform}'. Only darwin/linux/win32/"
             "freebsd are supported.  You must specify the ipc_path"
         )
 


### PR DESCRIPTION
### What was wrong?

Related to Issue #2911 
Related to Issue #2854


### How was it fixed?

Remove check to see if the `.ipc` file exists and just return the default value. Add tests.
Also, the default path for `get_default_ipc_path` was fixed in #3060, but doesn't look like it was for `get_dev_ipc_path`, so updated that too.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/da90e4fd-8641-4b1b-9999-c599c57c10b2)
