### PR TITLE
feature: add RPC eth_getBlockReceipts

### DIFF
--- a/newsfragments/3247.feature.rst
+++ b/newsfragments/3247.feature.rst
@@ -1,0 +1,1 @@
+Add support for ``eth_getRawTransactionByHash`` RPC method

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -316,6 +316,26 @@ class TestEthereumTesterEthModule(EthModuleTest):
         EthModuleTest.test_eth_call_with_override_code,
         TypeError,
     )
+    test_eth_getBlockReceipts_hash = not_implemented(
+        EthModuleTest.test_eth_getBlockReceipts_hash,
+        MethodUnavailable,
+    )
+    test_eth_getBlockReceipts_not_found = not_implemented(
+        EthModuleTest.test_eth_getBlockReceipts_not_found,
+        MethodUnavailable,
+    )
+    test_eth_getBlockReceipts_with_integer = not_implemented(
+        EthModuleTest.test_eth_getBlockReceipts_with_integer,
+        MethodUnavailable,
+    )
+    test_eth_getBlockReceipts_safe = not_implemented(
+        EthModuleTest.test_eth_getBlockReceipts_safe,
+        MethodUnavailable,
+    )
+    test_eth_getBlockReceipts_finalized = not_implemented(
+        EthModuleTest.test_eth_getBlockReceipts_finalized,
+        MethodUnavailable,
+    )
 
     def test_eth_getBlockByHash_pending(self, w3: "Web3") -> None:
         block = w3.eth.get_block("pending")
@@ -632,26 +652,10 @@ class TestEthereumTesterEthModule(EthModuleTest):
     def test_eth_send_transaction_no_max_fee(self, eth_tester, w3, unlocked_account):
         super().test_eth_send_transaction_no_max_fee(w3, unlocked_account)
 
-    def test_eth_getBlockByNumber_safe(
-        self, w3: "Web3", empty_block: BlockData
-    ) -> None:
-        super().test_eth_getBlockByNumber_safe(w3, empty_block)
-
-    def test_eth_getBlockByNumber_finalized(
-        self, w3: "Web3", empty_block: BlockData
-    ) -> None:
-        super().test_eth_getBlockByNumber_finalized(w3, empty_block)
-
-    def test_eth_fee_history(self, w3: "Web3") -> None:
-        super().test_eth_fee_history(w3)
-
     def test_eth_fee_history_with_integer(
         self, w3: "Web3", empty_block: BlockData
     ) -> None:
         super().test_eth_fee_history_with_integer(w3, empty_block)
-
-    def test_eth_fee_history_with_no_reward_percentiles(self, w3: "Web3") -> None:
-        super().test_eth_fee_history_no_reward_percentiles(w3)
 
     def test_eth_get_balance_with_block_identifier(self, w3: "Web3") -> None:
         w3.testing.mine()

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -516,6 +516,7 @@ PYTHONIC_REQUEST_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     ),
     RPC.eth_getBalance: apply_formatter_at_index(to_hex_if_integer, 1),
     RPC.eth_getBlockByNumber: apply_formatter_at_index(to_hex_if_integer, 0),
+    RPC.eth_getBlockReceipts: apply_formatter_at_index(to_hex_if_integer, 0),
     RPC.eth_getBlockTransactionCountByNumber: apply_formatter_at_index(
         to_hex_if_integer,
         0,
@@ -723,6 +724,7 @@ PYTHONIC_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_getBalance: to_integer_if_hex,
     RPC.eth_getBlockByHash: apply_formatter_if(is_not_null, block_formatter),
     RPC.eth_getBlockByNumber: apply_formatter_if(is_not_null, block_formatter),
+    RPC.eth_getBlockReceipts: apply_formatter_to_array(receipt_formatter),
     RPC.eth_getBlockTransactionCountByHash: to_integer_if_hex,
     RPC.eth_getBlockTransactionCountByNumber: to_integer_if_hex,
     RPC.eth_getCode: HexBytes,
@@ -900,6 +902,7 @@ def raise_transaction_not_found_with_index(
 NULL_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     RPC.eth_getBlockByHash: raise_block_not_found,
     RPC.eth_getBlockByNumber: raise_block_not_found,
+    RPC.eth_getBlockReceipts: raise_block_not_found,
     RPC.eth_getBlockTransactionCountByHash: raise_block_not_found,
     RPC.eth_getBlockTransactionCountByNumber: raise_block_not_found,
     RPC.eth_getUncleCountByBlockHash: raise_block_not_found,

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -978,6 +978,39 @@ class AsyncEthModuleTest:
         assert isinstance(block["number"], int)
 
     @pytest.mark.asyncio
+    async def test_eth_getBlockReceipts_hash(
+        self, async_w3: "AsyncWeb3", async_empty_block: BlockData
+    ) -> None:
+        receipts = await async_w3.eth.get_block_receipts(async_empty_block["hash"])
+        assert isinstance(receipts, list)
+
+    @pytest.mark.asyncio
+    async def test_eth_getBlockReceipts_not_found(self, async_w3: "AsyncWeb3") -> None:
+        with pytest.raises(BlockNotFound):
+            await async_w3.eth.get_block_receipts(UNKNOWN_HASH)
+
+    @pytest.mark.asyncio
+    async def test_eth_getBlockReceipts_with_integer(
+        self, async_w3: "AsyncWeb3", async_empty_block: BlockData
+    ) -> None:
+        receipts = await async_w3.eth.get_block_receipts(async_empty_block["number"])
+        assert isinstance(receipts, list)
+
+    @pytest.mark.asyncio
+    async def test_eth_getBlockReceipts_safe(
+        self, async_w3: "AsyncWeb3", async_empty_block: BlockData
+    ) -> None:
+        receipts = await async_w3.eth.get_block_receipts("safe")
+        assert isinstance(receipts, list)
+
+    @pytest.mark.asyncio
+    async def test_eth_getBlockReceipts_finalized(
+        self, async_w3: "AsyncWeb3", async_empty_block: BlockData
+    ) -> None:
+        receipts = await async_w3.eth.get_block_receipts("finalized")
+        assert isinstance(receipts, list)
+
+    @pytest.mark.asyncio
     async def test_eth_get_block_by_number_full_transactions(
         self, async_w3: "AsyncWeb3", async_block_with_txn: BlockData
     ) -> None:
@@ -4223,6 +4256,34 @@ class EthModuleTest:
         block = w3.eth.get_block(block_with_txn["number"], True)
         transaction = block["transactions"][0]
         assert transaction["hash"] == block_with_txn["transactions"][0]  # type: ignore
+
+    def test_eth_getBlockReceipts_hash(
+        self, w3: "Web3", empty_block: BlockData
+    ) -> None:
+        receipts = w3.eth.get_block_receipts(empty_block["hash"])
+        assert isinstance(receipts, list)
+
+    def test_eth_getBlockReceipts_not_found(self, w3: "Web3") -> None:
+        with pytest.raises(BlockNotFound):
+            w3.eth.get_block_receipts(UNKNOWN_HASH)
+
+    def test_eth_getBlockReceipts_with_integer(
+        self, w3: "Web3", empty_block: BlockData
+    ) -> None:
+        receipts = w3.eth.get_block_receipts(empty_block["number"])
+        assert isinstance(receipts, list)
+
+    def test_eth_getBlockReceipts_safe(
+        self, w3: "Web3", empty_block: BlockData
+    ) -> None:
+        receipts = w3.eth.get_block_receipts("safe")
+        assert isinstance(receipts, list)
+
+    def test_eth_getBlockReceipts_finalized(
+        self, w3: "Web3", empty_block: BlockData
+    ) -> None:
+        receipts = w3.eth.get_block_receipts("finalized")
+        assert isinstance(receipts, list)
 
     def test_eth_getTransactionByHash(self, w3: "Web3", mined_txn_hash: HexStr) -> None:
         transaction = w3.eth.get_transaction(mined_txn_hash)

--- a/web3/_utils/rpc_abi.py
+++ b/web3/_utils/rpc_abi.py
@@ -57,6 +57,7 @@ class RPC:
     eth_getBalance = RPCEndpoint("eth_getBalance")
     eth_getBlockByHash = RPCEndpoint("eth_getBlockByHash")
     eth_getBlockByNumber = RPCEndpoint("eth_getBlockByNumber")
+    eth_getBlockReceipts = RPCEndpoint("eth_getBlockReceipts")
     eth_getBlockTransactionCountByHash = RPCEndpoint(
         "eth_getBlockTransactionCountByHash"
     )

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -75,6 +75,7 @@ from web3.types import (
     BlockData,
     BlockIdentifier,
     BlockParams,
+    BlockReceipts,
     CreateAccessListResponse,
     FeeHistory,
     FilterParams,
@@ -439,6 +440,20 @@ class AsyncEth(BaseEth):
         self, block_identifier: BlockIdentifier, full_transactions: bool = False
     ) -> BlockData:
         return await self._get_block(block_identifier, full_transactions)
+
+    # eth_getBlockReceipts
+
+    _get_block_receipts: Method[
+        Callable[[BlockIdentifier], Awaitable[BlockReceipts]]
+    ] = Method(
+        RPC.eth_getBlockReceipts,
+        mungers=[default_root_munger],
+    )
+
+    async def get_block_receipts(
+        self, block_identifier: BlockIdentifier
+    ) -> BlockReceipts:
+        return await self._get_block_receipts(block_identifier)
 
     # eth_getBalance
 

--- a/web3/eth/eth.py
+++ b/web3/eth/eth.py
@@ -72,6 +72,7 @@ from web3.types import (
     BlockData,
     BlockIdentifier,
     BlockParams,
+    BlockReceipts,
     CreateAccessListResponse,
     FeeHistory,
     FilterParams,
@@ -410,6 +411,16 @@ class Eth(BaseEth):
         self, block_identifier: BlockIdentifier, full_transactions: bool = False
     ) -> BlockData:
         return self._get_block(block_identifier, full_transactions)
+
+    # eth_getBlockReceipts
+
+    _get_block_receipts: Method[Callable[[BlockIdentifier], BlockReceipts]] = Method(
+        RPC.eth_getBlockReceipts,
+        mungers=[default_root_munger],
+    )
+
+    def get_block_receipts(self, block_identifier: BlockIdentifier) -> BlockReceipts:
+        return self._get_block_receipts(block_identifier)
 
     # eth_getBalance
 

--- a/web3/types.py
+++ b/web3/types.py
@@ -381,6 +381,8 @@ TxReceipt = TypedDict(
     },
 )
 
+BlockReceipts = List[TxReceipt]
+
 
 class SignedTx(TypedDict, total=False):
     raw: bytes


### PR DESCRIPTION
### What was wrong?

Related to Issue #2004

### How was it fixed?

`eth_getBlockReceipts` was introduced in the standard RPC https://github.com/ethereum/execution-apis/pull/438, we can simply implement it 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cdn.pixabay.com/photo/2023/03/27/02/12/koala-7879533_1280.jpg)
