### PR TITLE
Update `eth-utils` to v4.0.0

### DIFF
--- a/newsfragments/3248.misc.rst
+++ b/newsfragments/3248.misc.rst
@@ -1,0 +1,1 @@
+Upgrade ``eth-utils`` to ``v4.0.0``.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import (
 
 extras_require = {
     "tester": [
-        "eth-tester[py-evm]==v0.10.0-b.1",
+        "eth-tester[py-evm]==v0.10.0-b.3",
         "py-geth>=4.1.0",
     ],
     "linter": [

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         "eth-account>=0.8.0",
         "eth-hash[pycryptodome]>=0.5.1",
         "eth-typing>=3.0.0",
-        "eth-utils>=2.1.0",
+        "eth-utils>=4.0.0",
         "hexbytes>=0.1.0,<0.4.0",
         "jsonschema>=4.0.0",
         "protobuf>=4.21.6",


### PR DESCRIPTION
### What was wrong?

Closes #715

### How was it fixed?

Major version bump of `eth-utils` to make `Web3.is_address` return True for non-checksummed addresses.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="392" alt="Screen Shot 2024-02-23 at 9 08 36 AM" src="https://github.com/ethereum/web3.py/assets/435903/ddaf0809-8820-40f0-a616-1d4d44bcf2ff">

