### PR TITLE
docs: remove ENS breaking change banner in v7

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,17 +1,6 @@
 .. meta::
    :description: Python Web3 SDK for Ethereum and EVM blockchains
 
-.. important::
-
-    For **ENS (Ethereum Name Service)** users, web3.py ``v6.6.0`` introduced ENS name
-    normalization standard
-    `ENSIP-15 <https://docs.ens.domains/ens-improvement-proposals/ensip-15-normalization-standard>`_.
-    This update to ENS name validation and normalization won't affect ~99%
-    of names but may prevent invalid names from being created and from interacting with
-    the ENS contracts via web3.py. We feel strongly that this change, though breaking,
-    is in the best interest of our users as it ensures compatibility with the latest ENS
-    standards.
-
 gm
 ==
 

--- a/newsfragments/3254.docs.rst
+++ b/newsfragments/3254.docs.rst
@@ -1,0 +1,1 @@
+Remove ENS v6 breaking change warning from v7


### PR DESCRIPTION
### What was wrong?

this ENS banner was added to describe a breaking change outside of a major version update. removing for v7.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/o9ivpl19s0m31.jpg)
