### PR TITLE
add abi.decode strictness flag and catch InsufficientDataBytes error …

### DIFF
--- a/docs/web3.contract.rst
+++ b/docs/web3.contract.rst
@@ -1040,7 +1040,7 @@ For example:
 
    In the case of an ``InsufficientDataBytes`` error, it may be possible to decode the
    log by setting the ``strict_bytes_type_checking`` flag to ``False`` on the Web3
-   instance.
+   instance before decoding.
 
     .. code-block:: python
 

--- a/docs/web3.contract.rst
+++ b/docs/web3.contract.rst
@@ -969,7 +969,7 @@ For example:
 
 .. _process_receipt:
 
-.. py:method:: ContractEvents.myEvent(*args, **kwargs).process_receipt(transaction_receipt, errors=WARN, abi_decode_strict=True)
+.. py:method:: ContractEvents.myEvent(*args, **kwargs).process_receipt(transaction_receipt, errors=WARN)
    :noindex:
 
    Extracts the pertinent logs from a transaction receipt.
@@ -1038,10 +1038,19 @@ For example:
        >>> assert processed_logs == ()
        True
        
-   In the case of an ``InsufficientDataBytes`` error, it may be possible to decode the log by passing ``abi_decode_strict=False``.
-   This will attempt to decode the log by reading only the data size specified in the ABI. This is useful when the log data is
-   not padded to the correct size, but the data is still valid. Because any data past the specified size is ignored, this may
-   result in data loss. It is not recommended for general use, but may be useful in some cases.
+   In the case of an ``InsufficientDataBytes`` error, it may be possible to decode the
+   log by setting the ``strict_bytes_type_checking`` flag to ``False`` on the Web3
+   instance.
+   
+    .. code-block:: python
+  
+        >>> w3.strict_bytes_type_checking = False
+        
+  
+   This will attempt to decode the log by reading only the data size specified in the
+   ABI. This is useful when the log data is not padded to the correct size, but the data
+   is still valid. Because any data past the specified size is ignored, this may result
+   in data loss. It is not recommended for general use, but may be useful in some cases.
 
 .. py:method:: ContractEvents.myEvent(*args, **kwargs).process_log(log)
 

--- a/docs/web3.contract.rst
+++ b/docs/web3.contract.rst
@@ -969,7 +969,7 @@ For example:
 
 .. _process_receipt:
 
-.. py:method:: ContractEvents.myEvent(*args, **kwargs).process_receipt(transaction_receipt, errors=WARN)
+.. py:method:: ContractEvents.myEvent(*args, **kwargs).process_receipt(transaction_receipt, errors=WARN, abi_decode_strict=True)
    :noindex:
 
    Extracts the pertinent logs from a transaction receipt.
@@ -1037,6 +1037,11 @@ For example:
        >>> processed_logs = contract.events.myEvent().process_receipt(tx_receipt, errors=DISCARD)
        >>> assert processed_logs == ()
        True
+       
+   In the case of an ``InsufficientDataBytes`` error, it may be possible to decode the log by passing ``abi_decode_strict=False``.
+   This will attempt to decode the log by reading only the data size specified in the ABI. This is useful when the log data is
+   not padded to the correct size, but the data is still valid. Because any data past the specified size is ignored, this may
+   result in data loss. It is not recommended for general use, but may be useful in some cases.
 
 .. py:method:: ContractEvents.myEvent(*args, **kwargs).process_log(log)
 

--- a/docs/web3.contract.rst
+++ b/docs/web3.contract.rst
@@ -1037,16 +1037,16 @@ For example:
        >>> processed_logs = contract.events.myEvent().process_receipt(tx_receipt, errors=DISCARD)
        >>> assert processed_logs == ()
        True
-       
+
    In the case of an ``InsufficientDataBytes`` error, it may be possible to decode the
    log by setting the ``strict_bytes_type_checking`` flag to ``False`` on the Web3
    instance.
-   
+
     .. code-block:: python
-  
+
         >>> w3.strict_bytes_type_checking = False
-        
-  
+
+
    This will attempt to decode the log by reading only the data size specified in the
    ABI. This is useful when the log data is not padded to the correct size, but the data
    is still valid. Because any data past the specified size is ignored, this may result

--- a/newsfragments/3256.feature.rst
+++ b/newsfragments/3256.feature.rst
@@ -1,0 +1,1 @@
+Catch ``InsufficientDataBytes`` errors and add ``abi_decode_strict`` flag to log receipt processing

--- a/newsfragments/3256.feature.rst
+++ b/newsfragments/3256.feature.rst
@@ -1,1 +1,1 @@
-Catch ``InsufficientDataBytes`` errors and add ``abi_decode_strict`` flag to log receipt processing
+Catch ``InsufficientDataBytes`` errors and respect ``w3.strict_bytes_type_checking`` flag in log receipt processing

--- a/tests/core/contracts/test_extracting_event_data.py
+++ b/tests/core/contracts/test_extracting_event_data.py
@@ -1182,7 +1182,7 @@ def test_receipt_processing_with_no_flag(indexed_event_contract, dup_txn_receipt
     with pytest.warns(UserWarning, match="Expected 1 log topics.  Got 0"):
         returned_log = event_instance.process_receipt(dup_txn_receipt)
         assert len(returned_log) == 0
-        
+
 
 def test_receipt_processing_catches_insufficientdatabytes_error(
     w3, emitter, emitter_contract_event_ids, wait_for_transaction
@@ -1190,21 +1190,27 @@ def test_receipt_processing_catches_insufficientdatabytes_error(
     txn_hash = emitter.functions.logListArgs([b"13"], [b"54"]).transact()
     txn_receipt = wait_for_transaction(w3, txn_hash)
     event_instance = emitter.events.LogListArgs()
-    
+
     # web3 doesn't generate logs with non-standard lengths, so we have to do it manually
     txn_receipt_dict = copy.deepcopy(txn_receipt)
     txn_receipt_dict["logs"][0] = dict(txn_receipt_dict["logs"][0])
     txn_receipt_dict["logs"][0]["data"] = txn_receipt_dict["logs"][0]["data"][:-8]
-    
 
     assert len(event_instance.process_receipt(txn_receipt_dict)) == 0
 
     with pytest.raises(InsufficientDataBytes):
         returned_log = event_instance.process_receipt(txn_receipt_dict, errors=STRICT)
         assert len(returned_log) == 0
-    
+
     assert len(event_instance.process_receipt(txn_receipt_dict, errors=WARN)) == 0
-    assert len(event_instance.process_receipt(txn_receipt_dict, errors=WARN, abi_decode_strict=False)) == 0
+    assert (
+        len(
+            event_instance.process_receipt(
+                txn_receipt_dict, errors=WARN, abi_decode_strict=False
+            )
+        )
+        == 0
+    )
 
     # processed_logs = event_instance.process_receipt(txn_receipt)
     # assert len(processed_logs) == 1
@@ -1212,9 +1218,9 @@ def test_receipt_processing_catches_insufficientdatabytes_error(
 
     # event_instance = indexed_event_contract.events.LogSingleWithIndex()
     # breakpoint()
-    
 
-# def test_receipt_processing_with_abi_strict_decode_flag(indexed_event_contract, dup_txn_receipt):
+
+# def test_receipt_processing_with_abi_strict_decode_flag(indexed_event_contract, dup_txn_receipt):  # noqa: E501
 
 
 def test_single_log_processing_with_errors(indexed_event_contract, dup_txn_receipt):

--- a/tests/core/contracts/test_extracting_event_data.py
+++ b/tests/core/contracts/test_extracting_event_data.py
@@ -1202,6 +1202,13 @@ def test_receipt_processing_catches_insufficientdatabytes_error(
         returned_log = event_instance.process_receipt(txn_receipt_dict, errors=STRICT)
         assert len(returned_log) == 0
 
+    w3.strict_bytes_type_checking = False
+    returned_log = event_instance.process_receipt(txn_receipt_dict, errors=STRICT)
+    assert len(returned_log) == 0
+
+    breakpoint()
+
+    assert len(event_instance.process_receipt(txn_receipt_dict, errors=IGNORE)) == 1
     assert len(event_instance.process_receipt(txn_receipt_dict, errors=WARN)) == 0
     assert (
         len(
@@ -1217,7 +1224,6 @@ def test_receipt_processing_catches_insufficientdatabytes_error(
     # rich_log = processed_logs[0]
 
     # event_instance = indexed_event_contract.events.LogSingleWithIndex()
-    # breakpoint()
 
 
 # def test_receipt_processing_with_abi_strict_decode_flag(indexed_event_contract, dup_txn_receipt):  # noqa: E501

--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -267,6 +267,7 @@ def get_event_data(
             "The following argument names are duplicated "
             f"between event inputs: '{', '.join(duplicate_names)}'"
         )
+    breakpoint()
 
     decoded_log_data = abi_codec.decode(
         log_data_types, log_data, strict=abi_decode_strict

--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -225,6 +225,7 @@ def get_event_data(
     abi_codec: ABICodec,
     event_abi: ABIEvent,
     log_entry: LogReceipt,
+    abi_decode_strict: bool = True,
 ) -> EventData:
     """
     Given an event ABI and a log entry for that event, return the decoded
@@ -267,7 +268,10 @@ def get_event_data(
             f"between event inputs: '{', '.join(duplicate_names)}'"
         )
 
-    decoded_log_data = abi_codec.decode(log_data_types, log_data)
+    # breakpoint()
+    decoded_log_data = abi_codec.decode(
+        log_data_types, log_data, strict=abi_decode_strict
+    )
     normalized_log_data = map_abi_data(
         BASE_RETURN_NORMALIZERS, log_data_types, decoded_log_data
     )
@@ -277,7 +281,7 @@ def get_event_data(
     )
 
     decoded_topic_data = [
-        abi_codec.decode([topic_type], topic_data)[0]
+        abi_codec.decode([topic_type], topic_data, strict=abi_decode_strict)[0]
         for topic_type, topic_data in zip(log_topic_types, log_topics_bytes)
     ]
     normalized_topic_data = map_abi_data(

--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -268,7 +268,6 @@ def get_event_data(
             f"between event inputs: '{', '.join(duplicate_names)}'"
         )
 
-    # breakpoint()
     decoded_log_data = abi_codec.decode(
         log_data_types, log_data, strict=abi_decode_strict
     )

--- a/web3/contract/async_contract.py
+++ b/web3/contract/async_contract.py
@@ -190,7 +190,10 @@ class AsyncContractEvent(BaseContractEvent):
 
         # convert raw binary data to Python proxy objects as described by ABI:
         all_event_logs = tuple(
-            get_event_data(self.w3.codec, event_abi, entry) for entry in logs
+            get_event_data(
+                self.w3.codec, event_abi, entry, self.w3.strict_bytes_type_checking
+            )
+            for entry in logs
         )
         filtered_logs = self._process_get_logs_argument_filters(
             event_abi,
@@ -223,7 +226,9 @@ class AsyncContractEvent(BaseContractEvent):
         )
         log_filter = await filter_builder.deploy(self.w3)
         log_filter.log_entry_formatter = get_event_data(
-            self.w3.codec, self._get_event_abi()
+            self.w3.codec,
+            self._get_event_abi(),
+            abi_decode_strict=self.w3.strict_bytes_type_checking,
         )
         log_filter.builder = filter_builder
 
@@ -234,7 +239,11 @@ class AsyncContractEvent(BaseContractEvent):
         builder = AsyncEventFilterBuilder(
             self._get_event_abi(),
             self.w3.codec,
-            formatter=get_event_data(self.w3.codec, self._get_event_abi()),
+            formatter=get_event_data(
+                self.w3.codec,
+                self._get_event_abi(),
+                abi_decode_strict=self.w3.strict_bytes_type_checking,
+            ),
         )
         builder.address = self.address
         return builder

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -164,14 +164,13 @@ class BaseContractEvent:
         errors: EventLogErrorFlags = WARN,
         abi_decode_strict: bool = True,
     ) -> Iterable[EventData]:
-        return self._parse_logs(txn_receipt, errors, abi_decode_strict)
+        return self._parse_logs(txn_receipt, errors)
 
     @to_tuple
     def _parse_logs(
         self,
         txn_receipt: TxReceipt,
         errors: EventLogErrorFlags,
-        abi_decode_strict: bool,
     ) -> Iterable[EventData]:
         try:
             errors.name
@@ -183,7 +182,10 @@ class BaseContractEvent:
         for log in txn_receipt["logs"]:
             try:
                 rich_log = get_event_data(
-                    self.w3.codec, self.abi, log, abi_decode_strict
+                    self.w3.codec,
+                    self.abi,
+                    log,
+                    abi_decode_strict=self.w3.strict_bytes_type_checking,
                 )
             except (
                 MismatchedABI,
@@ -214,7 +216,12 @@ class BaseContractEvent:
 
     @combomethod
     def process_log(self, log: HexStr) -> EventData:
-        return get_event_data(self.w3.codec, self.abi, log)
+        return get_event_data(
+            self.w3.codec,
+            self.abi,
+            log,
+            abi_decode_strict=self.w3.strict_bytes_type_checking,
+        )
 
     @combomethod
     def _get_event_filter_params(

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -162,7 +162,6 @@ class BaseContractEvent:
         self,
         txn_receipt: TxReceipt,
         errors: EventLogErrorFlags = WARN,
-        abi_decode_strict: bool = True,
     ) -> Iterable[EventData]:
         return self._parse_logs(txn_receipt, errors)
 

--- a/web3/contract/contract.py
+++ b/web3/contract/contract.py
@@ -189,7 +189,13 @@ class ContractEvent(BaseContractEvent):
 
         # convert raw binary data to Python proxy objects as described by ABI:
         all_event_logs = tuple(
-            get_event_data(self.w3.codec, event_abi, entry) for entry in logs
+            get_event_data(
+                self.w3.codec,
+                event_abi,
+                entry,
+                abi_decode_strict=self.w3.strict_bytes_type_checking,
+            )
+            for entry in logs
         )
         filtered_logs = self._process_get_logs_argument_filters(
             event_abi,
@@ -224,7 +230,9 @@ class ContractEvent(BaseContractEvent):
         )
         log_filter = filter_builder.deploy(self.w3)
         log_filter.log_entry_formatter = get_event_data(
-            self.w3.codec, self._get_event_abi()
+            self.w3.codec,
+            self._get_event_abi(),
+            abi_decode_strict=self.w3.strict_bytes_type_checking,
         )
         log_filter.builder = filter_builder
 
@@ -235,7 +243,11 @@ class ContractEvent(BaseContractEvent):
         builder = EventFilterBuilder(
             self._get_event_abi(),
             self.w3.codec,
-            formatter=get_event_data(self.w3.codec, self._get_event_abi()),
+            formatter=get_event_data(
+                self.w3.codec,
+                self._get_event_abi(),
+                abi_decode_strict=self.w3.strict_bytes_type_checking,
+            ),
         )
         builder.address = self.address
         return builder


### PR DESCRIPTION
…when parsing logs

This should use the existing global strictness flag.

### What was wrong?

Related to Issue #1441 , if a user is decoding logs with length not a multiple of 32 bytes, it throws an `eth-abi` `InsufficientBytesLength` error which is not properly caught.

### How was it fixed?
Add catching the error type `InsuffiecientDataBytes` and allow the passing of `strict` flag through to `eth_abi.decode` in `process_receipt`.

Since the flag is then passed to `get_event_data`, I considered making the flag available everywhere `get_event_data` is called, but that would greatly expand the scope and doesn't seem necessary, given the original issue.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/cac52deb-7608-4893-80dc-8901836db603)
