### PR TITLE
`ContractCaller` initializes without validating the `block_identifier`

### DIFF
--- a/newsfragments/3257.performance.rst
+++ b/newsfragments/3257.performance.rst
@@ -1,0 +1,1 @@
+Remove call to ``parse_block_identifier`` when initializing ``ContractCaller`` functions.

--- a/web3/_utils/contracts.py
+++ b/web3/_utils/contracts.py
@@ -438,23 +438,6 @@ def parse_block_identifier_int(w3: "Web3", block_identifier_int: int) -> BlockNu
     return BlockNumber(block_num)
 
 
-def parse_block_identifier_no_extra_call(
-    w3: Union["Web3", "AsyncWeb3"], block_identifier: BlockIdentifier
-) -> BlockIdentifier:
-    if block_identifier is None:
-        return w3.eth.default_block
-    elif isinstance(block_identifier, int) and block_identifier >= 0:
-        return block_identifier
-    elif block_identifier in ["latest", "earliest", "pending", "safe", "finalized"]:
-        return block_identifier
-    elif isinstance(block_identifier, bytes):
-        return HexBytes(block_identifier)
-    elif is_hex_encoded_block_hash(block_identifier):
-        return HexStr(str(block_identifier))
-    else:
-        raise BlockNumberOutofRange
-
-
 async def async_parse_block_identifier(
     async_w3: "AsyncWeb3", block_identifier: BlockIdentifier
 ) -> BlockIdentifier:

--- a/web3/contract/async_contract.py
+++ b/web3/contract/async_contract.py
@@ -39,7 +39,6 @@ from web3._utils.compat import (
 )
 from web3._utils.contracts import (
     async_parse_block_identifier,
-    parse_block_identifier_no_extra_call,
 )
 from web3._utils.datatypes import (
     PropertyCheckingFactory,
@@ -584,15 +583,11 @@ class AsyncContractCaller(BaseContractCaller):
                     decode_tuples=decode_tuples,
                 )
 
-                # TODO: The no_extra_call method gets around the fact that we can't call
-                #  the full async method from within a class's __init__ method. We need
-                #  to see if there's a way to account for all desired elif cases.
-                block_id = parse_block_identifier_no_extra_call(w3, block_identifier)
                 caller_method = partial(
                     self.call_function,
                     fn,
                     transaction=transaction,
-                    block_identifier=block_id,
+                    block_identifier=block_identifier,
                     ccip_read_enabled=ccip_read_enabled,
                 )
 

--- a/web3/contract/contract.py
+++ b/web3/contract/contract.py
@@ -588,12 +588,11 @@ class ContractCaller(BaseContractCaller):
                     decode_tuples=decode_tuples,
                 )
 
-                block_id = parse_block_identifier(w3, block_identifier)
                 caller_method = partial(
                     self.call_function,
                     fn,
                     transaction=transaction,
-                    block_identifier=block_id,
+                    block_identifier=block_identifier,
                     ccip_read_enabled=ccip_read_enabled,
                 )
 


### PR DESCRIPTION
### What was wrong?

Closes #2816 

### How was it fixed?

Remove call to `parse_block_identifier` when initializing `ContractCaller` functions. The validation occurs when calling the function itself.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="393" alt="Screen Shot 2024-02-26 at 4 17 26 PM" src="https://github.com/ethereum/web3.py/assets/435903/af987dde-54e6-44d2-b5a6-7badf805c2bf">
