### PR TITLE
V7 cleanups

### DIFF
--- a/docs/_templates/searchbox.html
+++ b/docs/_templates/searchbox.html
@@ -11,15 +11,4 @@
     <input type="hidden" name="area" value="default" />
   </form>
 </div>
-
-{# Include user survey banner under the search box #}
-<div class="search-banner-wrapper">
-  <a href="https://forms.gle/a5EedxU5FtWv1pQq5">
-    <img
-      src="{{ pathto('_static/banner/user-survey.png', 1) }}"
-      alt="Ethereum Python User Survey"
-    />
-  </a>
-</div>
-
 {%- endif %}

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,8 +1,8 @@
 Release Notes
 =============
 
-v6 Breaking Changes Summary
-   See the :ref:`v6 Migration Guide<migrating_v5_to_v6>`
+v7 Breaking Changes Summary
+   See the :ref:`v7 Migration Guide<migrating_v6_to_v7>`
 
 .. towncrier release notes start
 

--- a/newsfragments/3218.docs.rst
+++ b/newsfragments/3218.docs.rst
@@ -1,0 +1,1 @@
+Remove annual user survey prompt from docs

--- a/newsfragments/3259.misc.rst
+++ b/newsfragments/3259.misc.rst
@@ -1,0 +1,1 @@
+Tests passing for v7, doc cleanups

--- a/tests/core/web3-module/test_api.py
+++ b/tests/core/web3-module/test_api.py
@@ -1,2 +1,2 @@
 def test_web3_api(w3):
-    assert w3.api.startswith("6")
+    assert w3.api.startswith("7")


### PR DESCRIPTION
### What was wrong?

Tests were failing expecting a v6, docs still showed the link to the 2023 survey banner, docs/releases.rst linked to v6 migration guide instead of v7.

### How was it fixed?
Fixed 'em!

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.ytimg.com/vi/_yOL3t4LMUo/maxresdefault.jpg)
