### PR TITLE
Set all call timeout defaults on providers to ``30``:

### DIFF
--- a/newsfragments/3262.misc.rst
+++ b/newsfragments/3262.misc.rst
@@ -1,0 +1,1 @@
+Set all provider default timeouts to ``30``, effectively increasing HTTP timeouts to better match those of certain clients.

--- a/tests/core/utilities/test_request.py
+++ b/tests/core/utilities/test_request.py
@@ -99,7 +99,7 @@ def test_json_make_get_request(mocker):
     assert len(request._session_cache) == 1
     cache_key = generate_cache_key(f"{threading.get_ident()}:{TEST_URI}")
     session = request._session_cache.get_cache_entry(cache_key)
-    session.get.assert_called_once_with(TEST_URI, timeout=10)
+    session.get.assert_called_once_with(TEST_URI, timeout=30)
 
     # Ensure the adapter was created with default values
     check_adapters_mounted(session)
@@ -119,7 +119,7 @@ def test_make_post_request_no_args(mocker):
     assert len(request._session_cache) == 1
     cache_key = generate_cache_key(f"{threading.get_ident()}:{TEST_URI}")
     session = request._session_cache.get_cache_entry(cache_key)
-    session.post.assert_called_once_with(TEST_URI, data=b"request", timeout=10)
+    session.post.assert_called_once_with(TEST_URI, data=b"request", timeout=30)
 
     # Ensure the adapter was created with default values
     check_adapters_mounted(session)
@@ -267,7 +267,7 @@ async def test_async_json_make_get_request(mocker):
     session.get.assert_called_once_with(
         TEST_URI,
         timeout=ClientTimeout(
-            total=10, connect=None, sock_read=None, sock_connect=None
+            total=30, connect=None, sock_read=None, sock_connect=None
         ),
     )
     await session.close()
@@ -289,7 +289,7 @@ async def test_async_make_post_request(mocker):
         TEST_URI,
         data=b"request",
         timeout=ClientTimeout(
-            total=10, connect=None, sock_read=None, sock_connect=None
+            total=30, connect=None, sock_read=None, sock_connect=None
         ),
     )
     await session.close()

--- a/web3/_utils/module_testing/module_testing_utils.py
+++ b/web3/_utils/module_testing/module_testing_utils.py
@@ -104,7 +104,7 @@ def mock_offchain_lookup_request_response(
 
         # mock response only to specified url while validating appropriate fields
         if url_from_args == mocked_request_url:
-            assert kwargs["timeout"] == 10
+            assert kwargs["timeout"] == 30
             if http_method.upper() == "POST":
                 assert kwargs["data"] == {"data": calldata, "sender": sender}
             return MockedResponse()
@@ -154,7 +154,7 @@ def async_mock_offchain_lookup_request_response(
 
         # mock response only to specified url while validating appropriate fields
         if url_from_args == mocked_request_url:
-            assert kwargs["timeout"] == ClientTimeout(10)
+            assert kwargs["timeout"] == ClientTimeout(30)
             if http_method.upper() == "post":
                 assert kwargs["data"] == {"data": calldata, "sender": sender}
             return AsyncMockedResponse()

--- a/web3/_utils/request.py
+++ b/web3/_utils/request.py
@@ -35,7 +35,7 @@ from web3.utils.caching import (
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_TIMEOUT = 10
+DEFAULT_TIMEOUT = 30
 
 
 def get_default_http_endpoint() -> URI:

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -130,7 +130,7 @@ class IPCProvider(JSONBaseProvider):
     def __init__(
         self,
         ipc_path: Union[str, Path] = None,
-        timeout: int = 10,
+        timeout: int = 30,
         *args: Any,
         **kwargs: Any,
     ) -> None:

--- a/web3/providers/legacy_websocket.py
+++ b/web3/providers/legacy_websocket.py
@@ -37,7 +37,7 @@ from web3.types import (
 )
 
 RESTRICTED_WEBSOCKET_KWARGS = {"uri", "loop"}
-DEFAULT_WEBSOCKET_TIMEOUT = 10
+DEFAULT_WEBSOCKET_TIMEOUT = 30
 
 
 def _start_event_loop(loop: asyncio.AbstractEventLoop) -> None:

--- a/web3/providers/persistent/persistent.py
+++ b/web3/providers/persistent/persistent.py
@@ -24,7 +24,7 @@ from web3.types import (
     RPCResponse,
 )
 
-DEFAULT_PERSISTENT_CONNECTION_TIMEOUT = 50.0
+DEFAULT_PERSISTENT_CONNECTION_TIMEOUT = 30.0
 
 
 class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):


### PR DESCRIPTION
### What was wrong?

- In the HTTP cases, this actually increases the timeout which matches the timeouts in some clients (like Geth); closes #1939.
- This commit also sets the persistent connection timeout to be the same as the HTTP timeout for a request which seems reasonable and keeps consistency.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20240304_083729~2](https://github.com/ethereum/web3.py/assets/3532824/ac8c2813-5e1f-42a8-ae51-ed17546e04d7)

