### PR TITLE
Replace `ipc_path` variable with `endpoint_uri`

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -254,19 +254,19 @@ Persistent Connection Base Class
 AsyncIPCProvider
 ++++++++++++++++
 
-.. py:class:: web3.providers.persistent.AsyncIPCProvider(ipc_path=None, max_connection_retries=5)
+.. py:class:: web3.providers.persistent.AsyncIPCProvider(endpoint_uri=None, max_connection_retries=5)
 
     This provider handles asynchronous, persistent interaction with an IPC Socket based
     JSON-RPC server.
 
-    *  ``ipc_path`` is the filesystem path to the IPC socket:
+    *  ``endpoint_uri`` is the filesystem path to the IPC socket:
 
     This provider inherits from the
     :class:`~web3.providers.persistent.PersistentConnectionProvider` class. Refer to
     the :class:`~web3.providers.persistent.PersistentConnectionProvider` documentation
     for details on additional configuration options available for this provider.
 
-    If no ``ipc_path`` is specified, it will use a default depending on your operating
+    If no ``endpoint_uri`` is specified, it will use a default depending on your operating
     system.
 
     - On Linux and FreeBSD: ``~/.ethereum/geth.ipc``

--- a/tests/core/providers/test_async_ipc_provider.py
+++ b/tests/core/providers/test_async_ipc_provider.py
@@ -108,8 +108,8 @@ def serve_subscription_result(simple_ipc_server):
 
 def test_ipc_tilde_in_path():
     expected_path = str(pathlib.Path.home()) + "/foo"
-    assert AsyncIPCProvider("~/foo").ipc_path == expected_path
-    assert AsyncIPCProvider(pathlib.Path("~/foo")).ipc_path == expected_path
+    assert AsyncIPCProvider("~/foo").endpoint_uri == expected_path
+    assert AsyncIPCProvider(pathlib.Path("~/foo")).endpoint_uri == expected_path
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### What was wrong?

The `AsyncIPCProvider` class was using `ipc_path` instead of `endpoint_uri` from its super class, `PersistentConnectionProvider`. 

### How was it fixed?

Remove the usage of `ipc_path` and replaced it with `endpoint_uri` in the `PersistentConnectionProvider` class.