### PR TITLE
Expose `get_event_data`, `get_function_info` utilities

### DIFF
--- a/newsfragments/3268.feature.rst
+++ b/newsfragments/3268.feature.rst
@@ -1,0 +1,1 @@
+Expose ``get_event_data``, ``get_function_info`` utilities via ``web3.contract.utils``.

--- a/tests/core/contracts/test_contract_function_info.py
+++ b/tests/core/contracts/test_contract_function_info.py
@@ -1,0 +1,57 @@
+import pytest
+
+from web3.contract.utils import (
+    get_function_info,
+)
+
+
+def get_contract_fn_abi(fn_name, args, kwargs, contract_abi):
+    fn_abis_with_name = [abi for abi in contract_abi if abi["name"] == fn_name]
+
+    # match function by args
+    if len(args) > 0:
+        for abi in fn_abis_with_name:
+            if len(abi["inputs"]) == len(args):
+                return abi
+
+    # match function by kwargs
+    if len(kwargs.keys()) > 0:
+        for abi in fn_abis_with_name:
+            inputs = [input["name"] for input in abi["inputs"]]
+            if set(inputs) == kwargs.keys():
+                return abi
+
+    return fn_abis_with_name[0]
+
+
+@pytest.mark.parametrize(
+    "fn_name,args,kwargs,fn_selector,fn_arguments",
+    [
+        ("add", (1, 2), {}, "0xa5f3c23b", (1, 2)),
+        ("counter", (), {}, "0x61bc221a", ()),
+        ("incrementCounter", (), {}, "0x5b34b966", ()),
+        ("incrementCounter", (), {"amount": 1}, "0x6abbb3b4", (1,)),
+        ("incrementCounter", (1,), {}, "0x6abbb3b4", (1,)),
+        ("multiply7", (100,), {}, "0xdcf537b1", (100,)),
+        ("return13", (), {}, "0x16216f39", ()),
+    ],
+)
+def test_get_function_info_for_math_contract(
+    w3, math_contract_abi, fn_name, args, kwargs, fn_selector, fn_arguments
+):
+    fn_info_abi, fn_info_selector, fn_info_arguments = get_function_info(
+        # fn_info = get_function_info(
+        fn_name,
+        w3.codec,
+        contract_abi=math_contract_abi,
+        args=args,
+        kwargs=kwargs,
+    )
+
+    # Identify abi for fn_name from math_contract_abi
+    fn_abi = get_contract_fn_abi(fn_name, args, kwargs, math_contract_abi)
+
+    assert fn_info_abi == fn_abi
+    assert fn_info_selector == fn_selector
+    assert len(fn_info_arguments) == len(fn_arguments)
+    assert fn_info_arguments == fn_arguments

--- a/tests/core/contracts/test_contract_function_info.py
+++ b/tests/core/contracts/test_contract_function_info.py
@@ -40,7 +40,6 @@ def test_get_function_info_for_math_contract(
     w3, math_contract_abi, fn_name, args, kwargs, fn_selector, fn_arguments
 ):
     fn_info_abi, fn_info_selector, fn_info_arguments = get_function_info(
-        # fn_info = get_function_info(
         fn_name,
         w3.codec,
         contract_abi=math_contract_abi,

--- a/tests/core/contracts/test_extracting_event_data.py
+++ b/tests/core/contracts/test_extracting_event_data.py
@@ -9,6 +9,7 @@ from eth_utils.toolz import (
 )
 
 from web3.contract.utils import (
+    find_matching_event_abi,
     get_event_data,
 )
 from web3.exceptions import (
@@ -123,7 +124,8 @@ def test_event_data_extraction(
     assert len(txn_receipt["logs"]) == 1
     log_entry = txn_receipt["logs"][0]
 
-    event_abi = emitter._find_matching_event_abi(event_name)
+    contract_abi = emitter.abi
+    event_abi = find_matching_event_abi(contract_abi, event_name)
 
     event_topic = getattr(emitter_contract_log_topics, event_name)
     is_anonymous = event_abi["anonymous"]
@@ -178,7 +180,8 @@ def test_event_data_extraction_bytes(
     log_entry = txn_receipt["logs"][0]
 
     event_name = "LogListArgs"
-    event_abi = emitter._find_matching_event_abi(event_name)
+    contract_abi = emitter.abi
+    event_abi = find_matching_event_abi(contract_abi, event_name)
 
     event_topic = getattr(emitter_contract_log_topics, event_name)
 
@@ -229,7 +232,8 @@ def test_event_data_extraction_bytes_non_strict(
     log_entry = txn_receipt["logs"][0]
 
     event_name = "LogListArgs"
-    event_abi = non_strict_emitter._find_matching_event_abi(event_name)
+    contract_abi = non_strict_emitter.abi
+    event_abi = find_matching_event_abi(contract_abi, event_name)
 
     event_topic = getattr(emitter_contract_log_topics, event_name)
 
@@ -274,7 +278,9 @@ def test_dynamic_length_argument_extraction(
     assert len(txn_receipt["logs"]) == 1
     log_entry = txn_receipt["logs"][0]
 
-    event_abi = emitter._find_matching_event_abi("LogDynamicArgs")
+    event_name = "LogDynamicArgs"
+    contract_abi = emitter.abi
+    event_abi = find_matching_event_abi(contract_abi, event_name)
 
     event_topic = emitter_contract_log_topics.LogDynamicArgs
     assert event_topic in log_entry["topics"]
@@ -294,7 +300,7 @@ def test_dynamic_length_argument_extraction(
     assert event_data["blockNumber"] == txn_receipt["blockNumber"]
     assert event_data["transactionIndex"] == txn_receipt["transactionIndex"]
     assert is_same_address(event_data["address"], emitter.address)
-    assert event_data["event"] == "LogDynamicArgs"
+    assert event_data["event"] == event_name
 
 
 def test_argument_extraction_strict_bytes_types(
@@ -309,7 +315,9 @@ def test_argument_extraction_strict_bytes_types(
     log_entry = txn_receipt["logs"][0]
     assert len(log_entry["topics"]) == 2
 
-    event_abi = emitter._find_matching_event_abi("LogListArgs")
+    event_name = "LogListArgs"
+    contract_abi = emitter.abi
+    event_abi = find_matching_event_abi(contract_abi, event_name)
 
     event_topic = emitter_contract_log_topics.LogListArgs
     assert event_topic in log_entry["topics"]

--- a/tests/core/contracts/test_extracting_event_data.py
+++ b/tests/core/contracts/test_extracting_event_data.py
@@ -8,7 +8,7 @@ from eth_utils.toolz import (
     dissoc,
 )
 
-from web3._utils.events import (
+from web3.contract.utils import (
     get_event_data,
 )
 from web3.exceptions import (

--- a/tests/core/contracts/test_extracting_event_data_old.py
+++ b/tests/core/contracts/test_extracting_event_data_old.py
@@ -4,7 +4,7 @@ from eth_utils import (
     is_same_address,
 )
 
-from web3._utils.events import (
+from web3.contract.utils import (
     get_event_data,
 )
 

--- a/tests/core/contracts/test_extracting_event_data_old.py
+++ b/tests/core/contracts/test_extracting_event_data_old.py
@@ -5,6 +5,7 @@ from eth_utils import (
 )
 
 from web3.contract.utils import (
+    find_matching_event_abi,
     get_event_data,
 )
 
@@ -97,7 +98,8 @@ def test_event_data_extraction(
     assert len(txn_receipt["logs"]) == 1
     log_entry = txn_receipt["logs"][0]
 
-    event_abi = emitter._find_matching_event_abi(event_name)
+    contract_abi = emitter.abi
+    event_abi = find_matching_event_abi(contract_abi, event_name)
 
     event_topic = getattr(emitter_contract_log_topics, event_name)
     is_anonymous = event_abi["anonymous"]
@@ -122,7 +124,6 @@ def test_dynamic_length_argument_extraction(
     emitter,
     wait_for_transaction,
     emitter_contract_log_topics,
-    emitter_contract_event_ids,
 ):
     string_0 = "this-is-the-first-string-which-exceeds-32-bytes-in-length"
     string_1 = "this-is-the-second-string-which-exceeds-32-bytes-in-length"
@@ -132,7 +133,8 @@ def test_dynamic_length_argument_extraction(
     assert len(txn_receipt["logs"]) == 1
     log_entry = txn_receipt["logs"][0]
 
-    event_abi = emitter._find_matching_event_abi("LogDynamicArgs")
+    contract_abi = emitter.abi
+    event_abi = find_matching_event_abi(contract_abi, "LogDynamicArgs")
 
     event_topic = emitter_contract_log_topics.LogDynamicArgs
     assert event_topic in log_entry["topics"]

--- a/tests/core/utilities/test_construct_event_filter_params.py
+++ b/tests/core/utilities/test_construct_event_filter_params.py
@@ -1,6 +1,6 @@
 import pytest
 
-from web3._utils.filters import (
+from web3.contract.utils import (
     construct_event_filter_params,
 )
 

--- a/web3/_utils/contracts.py
+++ b/web3/_utils/contracts.py
@@ -43,10 +43,8 @@ from web3._utils.abi import (
     abi_to_signature,
     check_if_arguments_can_be_encoded,
     filter_by_argument_count,
-    filter_by_argument_name,
     filter_by_encodability,
     filter_by_name,
-    filter_by_type,
     get_abi_input_types,
     get_aligned_abi_inputs,
     get_fallback_func_abi,
@@ -80,7 +78,6 @@ from web3.exceptions import (
 )
 from web3.types import (
     ABI,
-    ABIEvent,
     ABIFunction,
     BlockIdentifier,
     BlockNumber,
@@ -114,31 +111,6 @@ def extract_argument_types(*args: Sequence[Any]) -> str:
             collapsed_args.append(_get_argument_readable_type(arg))
 
     return ",".join(collapsed_args)
-
-
-def find_matching_event_abi(
-    abi: ABI,
-    event_name: Optional[str] = None,
-    argument_names: Optional[Sequence[str]] = None,
-) -> ABIEvent:
-    filters = [
-        functools.partial(filter_by_type, "event"),
-    ]
-
-    if event_name is not None:
-        filters.append(functools.partial(filter_by_name, event_name))
-
-    if argument_names is not None:
-        filters.append(functools.partial(filter_by_argument_name, argument_names))
-
-    event_abi_candidates = pipe(abi, *filters)
-
-    if len(event_abi_candidates) == 1:
-        return event_abi_candidates[0]
-    elif not event_abi_candidates:
-        raise ValueError("No matching events found")
-    else:
-        raise ValueError("Multiple events found")
 
 
 def find_matching_fn_abi(

--- a/web3/_utils/filters.py
+++ b/web3/_utils/filters.py
@@ -3,11 +3,9 @@ from typing import (
     Any,
     Callable,
     Collection,
-    Dict,
     Iterator,
     List,
     Optional,
-    Sequence,
     Tuple,
     Union,
 )
@@ -19,13 +17,11 @@ from eth_abi.grammar import (
     parse as parse_type_string,
 )
 from eth_typing import (
-    ChecksumAddress,
     HexStr,
     TypeStr,
 )
 from eth_utils import (
     is_hex,
-    is_list_like,
     is_string,
     is_text,
 )
@@ -43,18 +39,11 @@ from hexbytes import (
 from web3._utils.events import (
     AsyncEventFilterBuilder,
     EventFilterBuilder,
-    construct_event_data_set,
-    construct_event_topic_set,
-)
-from web3._utils.validation import (
-    validate_address,
 )
 from web3.exceptions import (
     Web3ValidationError,
 )
 from web3.types import (
-    ABIEvent,
-    BlockIdentifier,
     FilterParams,
     LogReceipt,
     RPCEndpoint,
@@ -63,72 +52,6 @@ from web3.types import (
 if TYPE_CHECKING:
     from web3.eth import AsyncEth  # noqa: F401
     from web3.eth import Eth  # noqa: F401
-
-
-def construct_event_filter_params(
-    event_abi: ABIEvent,
-    abi_codec: ABICodec,
-    contract_address: Optional[ChecksumAddress] = None,
-    argument_filters: Optional[Dict[str, Any]] = None,
-    topics: Optional[Sequence[HexStr]] = None,
-    fromBlock: Optional[BlockIdentifier] = None,
-    toBlock: Optional[BlockIdentifier] = None,
-    address: Optional[ChecksumAddress] = None,
-) -> Tuple[List[List[Optional[HexStr]]], FilterParams]:
-    filter_params: FilterParams = {}
-    topic_set: Sequence[HexStr] = construct_event_topic_set(
-        event_abi, abi_codec, argument_filters
-    )
-
-    if topics is not None:
-        if len(topic_set) > 1:
-            raise TypeError(
-                "Merging the topics argument with topics generated "
-                "from argument_filters is not supported."
-            )
-        topic_set = topics
-
-    if len(topic_set) == 1 and is_list_like(topic_set[0]):
-        # type ignored b/c list-like check on line 88
-        filter_params["topics"] = topic_set[0]  # type: ignore
-    else:
-        filter_params["topics"] = topic_set
-
-    if address and contract_address:
-        if is_list_like(address):
-            filter_params["address"] = [address] + [contract_address]
-        elif is_string(address):
-            filter_params["address"] = (
-                [address, contract_address]
-                if address != contract_address
-                else [address]
-            )
-        else:
-            raise ValueError(
-                f"Unsupported type for `address` parameter: {type(address)}"
-            )
-    elif address:
-        filter_params["address"] = address
-    elif contract_address:
-        filter_params["address"] = contract_address
-
-    if "address" not in filter_params:
-        pass
-    elif is_list_like(filter_params["address"]):
-        for addr in filter_params["address"]:
-            validate_address(addr)
-    else:
-        validate_address(filter_params["address"])
-
-    if fromBlock is not None:
-        filter_params["fromBlock"] = fromBlock
-
-    if toBlock is not None:
-        filter_params["toBlock"] = toBlock
-
-    data_filters_set = construct_event_data_set(event_abi, abi_codec, argument_filters)
-
-    return data_filters_set, filter_params
 
 
 class BaseFilter:

--- a/web3/contract/async_contract.py
+++ b/web3/contract/async_contract.py
@@ -45,7 +45,6 @@ from web3._utils.datatypes import (
 )
 from web3._utils.events import (
     AsyncEventFilterBuilder,
-    get_event_data,
 )
 from web3._utils.filters import (
     AsyncLogFilter,
@@ -76,6 +75,7 @@ from web3.contract.utils import (
     async_estimate_gas_for_function,
     async_transact_with_contract_function,
     find_functions_by_identifier,
+    get_event_data,
     get_function_by_identifier,
 )
 from web3.exceptions import (

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -47,7 +47,6 @@ from web3._utils.abi import (
 from web3._utils.contracts import (
     decode_transaction_data,
     encode_abi,
-    find_matching_event_abi,
     find_matching_fn_abi,
     get_function_info,
     prepare_transaction,
@@ -67,9 +66,6 @@ from web3._utils.events import (
     EventFilterBuilder,
     is_dynamic_sized_type,
 )
-from web3._utils.filters import (
-    construct_event_filter_params,
-)
 from web3._utils.function_identifiers import (
     FallbackFn,
     ReceiveFn,
@@ -78,6 +74,8 @@ from web3._utils.normalizers import (
     BASE_RETURN_NORMALIZERS,
 )
 from web3.contract.utils import (
+    construct_event_filter_params,
+    find_matching_event_abi,
     get_event_data,
 )
 from web3.datastructures import (
@@ -863,16 +861,6 @@ class BaseContract:
     ) -> ABIFunction:
         return find_matching_fn_abi(
             cls.abi, cls.w3.codec, fn_identifier=fn_identifier, args=args, kwargs=kwargs
-        )
-
-    @classmethod
-    def _find_matching_event_abi(
-        cls,
-        event_name: Optional[str] = None,
-        argument_names: Optional[Sequence[str]] = None,
-    ) -> ABIEvent:
-        return find_matching_event_abi(
-            abi=cls.abi, event_name=event_name, argument_names=argument_names
         )
 
     @combomethod

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -65,7 +65,6 @@ from web3._utils.encoding import (
 from web3._utils.events import (
     AsyncEventFilterBuilder,
     EventFilterBuilder,
-    get_event_data,
     is_dynamic_sized_type,
 )
 from web3._utils.filters import (
@@ -77,6 +76,9 @@ from web3._utils.function_identifiers import (
 )
 from web3._utils.normalizers import (
     BASE_RETURN_NORMALIZERS,
+)
+from web3.contract.utils import (
+    get_event_data,
 )
 from web3.datastructures import (
     AttributeDict,

--- a/web3/contract/contract.py
+++ b/web3/contract/contract.py
@@ -41,7 +41,6 @@ from web3._utils.datatypes import (
 )
 from web3._utils.events import (
     EventFilterBuilder,
-    get_event_data,
 )
 from web3._utils.filters import (
     LogFilter,
@@ -74,6 +73,7 @@ from web3.contract.utils import (
     call_contract_function,
     estimate_gas_for_function,
     find_functions_by_identifier,
+    get_event_data,
     get_function_by_identifier,
     transact_with_contract_function,
 )

--- a/web3/contract/utils.py
+++ b/web3/contract/utils.py
@@ -11,11 +11,18 @@ from typing import (
     Union,
 )
 
+from eth_abi.codec import (
+    ABICodec,
+)
 from eth_abi.exceptions import (
     DecodingError,
 )
 from eth_typing import (
     ChecksumAddress,
+    HexStr,
+)
+from eth_utils.toolz import (
+    curry,
 )
 from hexbytes import (
     HexBytes,
@@ -33,7 +40,11 @@ from web3._utils.async_transactions import (
 )
 from web3._utils.contracts import (
     find_matching_fn_abi,
+    get_function_info as _get_function_info,
     prepare_transaction,
+)
+from web3._utils.events import (
+    get_event_data as _get_event_data,
 )
 from web3._utils.normalizers import (
     BASE_RETURN_NORMALIZERS,
@@ -46,9 +57,12 @@ from web3.exceptions import (
 )
 from web3.types import (
     ABI,
+    ABIEvent,
     ABIFunction,
     BlockIdentifier,
+    EventData,
     FunctionIdentifier,
+    LogReceipt,
     StateOverride,
     TContractFn,
     TxParams,
@@ -267,6 +281,26 @@ def get_function_by_identifier(
     elif len(fns) == 0:
         raise ValueError(f"Could not find any function with matching {identifier}")
     return fns[0]
+
+
+def get_function_info(
+    fn_name: str,
+    abi_codec: ABICodec,
+    contract_abi: Optional[ABI] = None,
+    fn_abi: Optional[ABIFunction] = None,
+    args: Optional[Sequence[Any]] = None,
+    kwargs: Optional[Any] = None,
+) -> Tuple[ABIFunction, HexStr, Tuple[Any, ...]]:
+    return _get_function_info(fn_name, abi_codec, contract_abi, fn_abi, args, kwargs)
+
+
+@curry
+def get_event_data(
+    abi_codec: ABICodec,
+    event_abi: ABIEvent,
+    log_entry: LogReceipt,
+) -> EventData:
+    return _get_event_data(abi_codec, event_abi, log_entry)
 
 
 # --- async --- #


### PR DESCRIPTION
### What was wrong?

Closes #1596
Relates to #3036

`get_event_data`, `get_function_info` utilities were inaccessible for public use even though many people have the need to use these functions without instantiating a `Contract`.

Further refactoring to be covered in #3279 

### How was it fixed?

Expose these functions via `web3.contract.utils`.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="398" alt="Screen Shot 2024-03-05 at 2 50 20 PM" src="https://github.com/ethereum/web3.py/assets/435903/b8236aeb-a432-4ab1-84f6-85e6430f1bc8">
