### PR TITLE
clear new abi lint errors

### DIFF
--- a/newsfragments/3269.bugfix.rst
+++ b/newsfragments/3269.bugfix.rst
@@ -1,0 +1,1 @@
+Fix/update methods and decorators in ``web3/_utils/abi.py`` to address issues raised by ``mypy``


### PR DESCRIPTION
### What was wrong?

Some lint errors have appeared in `web3._utils.abi.py`. Possibly related to recent `eth-abi` releases, but same lint errors after installing older `eth-abi` versions. :shrug:

### How was it fixed?
Three main mypy complaints:
 - The `def is_dynamic` attempts to overwrite the class attribute `is_dynamic` with the `@property` function `is_dynamic`. I changed it to be a regular class attribute, as is standard across `eth-abi`
 - `validate_value`'s signature was being altered by the `combomethod` decorator so it didn't match the parent ABC function sig. I determined that because the function uses `subencoder`, which only exists if the class has been instantiated, it cannot be a `classmethod` or a `combomethod`. Removing the decorator removes the mypy error. Removed the `return` as well - the function is supposed to either not return or throw an error.
 - `from_type_str` returns an instance of an encoder class, with the `cls(...)` calling the `__init__` function of the parent class. But (I think) because the `@parse_type_str` decorator turns `from_type_str` into a `classmethod`, mypy thinks `cls(...)` is calling the `__call__` method, so the args are wrong (as is the return type of `bytes`, so I updated that here too.)

I'll make a note to come back and see if `@parse_type_str` can be removed, but for now I think ignoring the last error is the best (most timely) option.


### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/2e50451a-757a-4af4-9451-d495011f5d3a)
