### PR TITLE
catch eth-abi DecodeError on failed tester provider make_request

### DIFF
--- a/newsfragments/3271.bugfix.rst
+++ b/newsfragments/3271.bugfix.rst
@@ -1,0 +1,2 @@
+Catch all types of ``eth-abi`` ``DecodingError`` in ``EthereumTesterProvider->_make_request()``
+

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -12,7 +12,7 @@ from eth_abi import (
     abi,
 )
 from eth_abi.exceptions import (
-    InsufficientDataBytes,
+    DecodingError,
 )
 from eth_utils import (
     is_bytes,
@@ -229,7 +229,7 @@ def _make_request(
                 if is_bytes(raw_error_msg)
                 else raw_error_msg
             )
-        except InsufficientDataBytes:
+        except DecodingError:
             reason = first_arg
         raise TransactionFailed(f"execution reverted: {reason}")
     else:


### PR DESCRIPTION
### What was wrong?

`eth-abi v5.0.1` introduced a new `InvalidPointer` exception type. In `EthereumTesterProvider->_make_request`, we catch the `InsufficientDataBytes` exception, but no other types of decoding errors. Specifically, this caused 2 vyper tests to start failing.

### How was it fixed?

Instead of catching just the `InsufficientDataBytes` exception, catch its parent `DecodingError`

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/22463c30-ef1b-4f3d-acb2-2ff53ce7771b)
