### PR TITLE
Lint non-inclusive language with `blocklint`

### DIFF
--- a/ens/async_ens.py
+++ b/ens/async_ens.py
@@ -89,7 +89,7 @@ class AsyncENS(BaseENS):
     like getting the address for a name.
 
     Unless otherwise specified, all addresses are assumed to be a `str` in
-    `checksum format <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md>`_,
+    `checksum format <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md>`_,  # blocklint: pragma # noqa: E501
     like: ``"0x314159265dD8dbb310642f98f50C066173C1259b"``
     """
 

--- a/ens/ens.py
+++ b/ens/ens.py
@@ -88,7 +88,7 @@ class ENS(BaseENS):
     like getting the address for a name.
 
     Unless otherwise specified, all addresses are assumed to be a `str` in
-    `checksum format <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md>`_,
+    `checksum format <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md>`_,  # blocklint: pragma # noqa: E501
     like: ``"0x314159265dD8dbb310642f98f50C066173C1259b"``
     """
 

--- a/ens/utils.py
+++ b/ens/utils.py
@@ -117,7 +117,7 @@ def customize_web3(w3: "_Web3") -> "_Web3":
 def normalize_name(name: str) -> str:
     """
     Clean the fully qualified name, as defined in ENS `EIP-137
-    <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-137.md#name-syntax>`_
+    <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-137.md#name-syntax>`_  # blocklint: pragma # noqa: E501
 
     This does *not* enforce whether ``name`` is a label or fully qualified domain.
 
@@ -169,7 +169,7 @@ def ens_encode_name(name: str) -> bytes:
 def is_valid_name(name: str) -> bool:
     """
     Validate whether the fully qualified name is valid, as defined in ENS `EIP-137
-    <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-137.md#name-syntax>`_
+    <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-137.md#name-syntax>`_  # blocklint: pragma # noqa: E501
 
     :param str name: the dot-separated ENS name
     :returns: True if ``name`` is set, and :meth:`~ens.ENS.nameprep` will not
@@ -229,7 +229,7 @@ def raw_name_to_hash(name: str) -> HexBytes:
     behind the scenes. For advanced usage, it is a helpful utility.
 
     This normalizes the name with `nameprep
-    <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-137.md#name-syntax>`_
+    <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-137.md#name-syntax>`_  # blocklint: pragma # noqa: E501
     before hashing.
 
     :param str name: ENS name to hash

--- a/newsfragments/3275.internal.rst
+++ b/newsfragments/3275.internal.rst
@@ -1,0 +1,1 @@
+Add linting for non-inclusive language with ``blocklint``.

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ extras_require = {
     ],
     "linter": [
         "black>=22.1.0",
+        "blocklint>=0.2.4",
         "flake8==3.8.3",
         "isort>=5.11.0",
         "mypy==1.4.1",

--- a/tox.ini
+++ b/tox.ini
@@ -52,20 +52,34 @@ basepython =
     py310: python3.10
     py311: python3.11
 
+[blocklint]
+max_issue_threshold=1
+
+[common-lint-args]
+files={toxinidir}/web3 {toxinidir}/ens {toxinidir}/tests
+blocklint_files={toxinidir}/web3/* {toxinidir}/ens/* {toxinidir}/tests/*
+blocklint_skip_files="docs/Makefile,docs/releases.rst,tox.ini"
+
 [common-lint]
 extras=linter
+allowlist_externals=
+    ; bash passes args to blocklint with *
+    /bin/bash
 commands=
-    flake8 {toxinidir}/web3 {toxinidir}/ens {toxinidir}/tests
-    black {toxinidir}/ens {toxinidir}/web3 {toxinidir}/tests {toxinidir}/setup.py --check
-    isort --check-only --diff {toxinidir}/web3/ {toxinidir}/ens/ {toxinidir}/tests/
+    flake8 {[common-lint-args]files}
+    black {[common-lint-args]files} {toxinidir}/setup.py --check
+    isort --check-only --diff {[common-lint-args]files}
     mypy -p web3 -p ens --config-file {toxinidir}/mypy.ini
+    /bin/bash -c "blocklint {[common-lint-args]blocklint_files} --skip-files {[common-lint-args]blocklint_skip_files}"
 
 [testenv:lint]
 basepython: python
+allowlist_externals: {[common-lint]allowlist_externals}
 extras: {[common-lint]extras}
 commands: {[common-lint]commands}
 
 [testenv:py{38,39,310,311}-lint]
+allowlist_externals: {[common-lint]allowlist_externals}
 extras: {[common-lint]extras}
 commands: {[common-lint]commands}
 


### PR DESCRIPTION
### What was wrong?

Related to Issue #3119

Our codebase should eliminate language that can be offensive.

### How was it fixed?

`blocklint` is a tool which checks for words that are configured as a `blocklist`. If found, the linter will fail and output the errors.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture
<img width="397" alt="Screen Shot 2024-03-08 at 4 10 41 PM" src="https://github.com/ethereum/web3.py/assets/435903/2ace815d-261d-4c50-8ab8-4163e364bd8e">



