### PR TITLE
middlewares -> middleware

### DIFF
--- a/docs/ens_overview.rst
+++ b/docs/ens_overview.rst
@@ -44,7 +44,7 @@ Create an :class:`~ens.ENS` object (named ``ns`` below) in one of three ways:
     ns = ENS(provider)
 
     # or, with a w3 instance
-    # Note: This inherits the w3 middlewares from the w3 instance and adds a stalecheck middleware to the middleware onion.
+    # Note: This inherits the w3 middleware from the w3 instance and adds a stalecheck middleware to the middleware onion.
     # It also inherits the provider and codec from the w3 instance, as well as the ``strict_bytes_type_checking`` flag value.
     from ens import ENS
     w3 = Web3(...)

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -44,7 +44,7 @@ Each web3 RPC call passes through these layers in the following manner.
                        |                ^
                        v                |
                  +-----------------------------+
-                 |         Middlewares         |
+                 |         Middleware          |
                  +-----------------------------+
                        |                ^
                        v                |
@@ -75,7 +75,7 @@ Writing your own Provider
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Writing your own provider requires implementing two required methods as well as
-setting the middlewares the provider should use.
+setting the middleware the provider should use.
 
 
 .. py:method:: BaseProvider.make_request(method, params)
@@ -103,11 +103,11 @@ setting the middlewares the provider should use.
     not be considered *connected*.
 
 
-.. py:attribute:: BaseProvider.middlewares
+.. py:attribute:: BaseProvider.middleware
 
-    This should be an iterable of middlewares.
+    This should be an iterable of middleware.
 
-You can set a new list of middlewares by assigning to ``provider.middlewares``,
+You can set a new list of middleware by assigning to ``provider.middleware``,
 with the first middleware that processes the request at the beginning of the list.
 
 
@@ -253,7 +253,7 @@ request-to-response calls work, we have to save the request information somewher
 that, when the response is received, we can match it to the original request that was
 made (i.e. the request with a matching *id* to the response that was received). The
 stored request information is then used to process the response when it is received,
-piping it through the response formatters and middlewares internal to the *web3.py*
+piping it through the response formatters and middleware internal to the *web3.py*
 library.
 
 In order to store the request information, the ``RequestProcessor`` class has an

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -9,7 +9,7 @@ exposed by the web3 object and the backend or node that web3 is connecting to.
 
 * **Providers** are responsible for the actual communication with the
   blockchain such as sending JSON-RPC requests over HTTP or an IPC socket.
-* **Middlewares** provide hooks for monitoring and modifying requests and
+* **Middleware** provide hooks for monitoring and modifying requests and
   responses to and from the provider.
 * **Managers** provide thread safety and primitives to allow for asynchronous usage of web3.
 

--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -87,7 +87,7 @@ The middleware are maintained in ``Web3.middleware_onion``. See below for the AP
 
 When specifying middleware in a list, or retrieving the list of middleware, they will
 be returned in the order of outermost layer first and innermost layer last. In the above
-example, that means that ``w3.middleware_onion.middlewares`` would return the middleware
+example, that means that ``w3.middleware_onion.middleware`` would return the middleware
 in the order of: ``[2, 1, 0]``.
 
 
@@ -149,7 +149,7 @@ To add or remove items in different layers, use the following API:
     .. code-block:: python
 
         >>> from web3.middleware import GasPriceStrategyMiddleware, AttributeDictMiddleware
-        >>> w3 = Web3(provider, middlewares=[GasPriceStrategyMiddleware, AttributeDictMiddleware])
+        >>> w3 = Web3(provider, middleware=[GasPriceStrategyMiddleware, AttributeDictMiddleware])
 
         >>> w3.middleware_onion.replace(GasPriceStrategyMiddleware, AttributeDictMiddleware)
         # this is now referenced by the new middleware object, so to remove it:
@@ -171,7 +171,7 @@ To add or remove items in different layers, use the following API:
         >>> w3.middleware_onion.clear()
         >>> assert len(w3.middleware_onion) == 0
 
-.. py:attribute:: Web3.middleware_onion.middlewares
+.. py:attribute:: Web3.middleware_onion.middleware
 
     Return all the current middleware for the ``Web3`` instance in the appropriate order for importing into a new
     ``Web3`` instance.
@@ -182,23 +182,23 @@ To add or remove items in different layers, use the following API:
         # add uniquely named middleware:
         >>> w3_1.middleware_onion.add(web3.middleware.GasPriceStrategyMiddleware, 'test_middleware')
         # export middleware from first w3 instance
-        >>> middlewares = w3_1.middleware_onion.middlewares
+        >>> middleware = w3_1.middleware_onion.middleware
 
         # import into second instance
-        >>> w3_2 = Web3(..., middlewares=middlewares)
-        >>> assert w3_1.middleware_onion.middlewares == w3_2.middleware_onion.middlewares
+        >>> w3_2 = Web3(..., middleware=middleware)
+        >>> assert w3_1.middleware_onion.middleware == w3_2.middleware_onion.middleware
         >>> assert w3_2.middleware_onion.get('test_middleware')
 
 
 Instantiate with Custom Middleware
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        
+
 Instead of working from the default list, you can specify a custom list of
 middleware when initializing Web3:
 
 .. code-block:: python
 
-    Web3(middlewares=[my_middleware1, my_middleware2])
+    Web3(middleware=[my_middleware1, my_middleware2])
 
 .. warning::
   This will *replace* the default middleware. To keep the default functionality,
@@ -219,7 +219,7 @@ The following middleware are included by default:
 * ``validation``
 * ``gas_estimate``
 
-The defaults are defined in the ``get_default_middlewares()`` method in ``web3/manager.py``.
+The defaults are defined in the ``get_default_middleware()`` method in ``web3/manager.py``.
 
 AttributeDict
 ~~~~~~~~~~~~~

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -467,7 +467,7 @@ Interacting with the Persistent Connection
         (e.g. ``block_num = await w3.eth.block_number``)
 
         The responses from this method are formatted by *web3.py* formatters and run
-        through the middlewares that were present at the time of subscription.
+        through the middleware that were present at the time of subscription.
         Examples on how to use this method can be seen above in the
         `Using Persistent Connection Providers`_ section.
 
@@ -475,7 +475,7 @@ Interacting with the Persistent Connection
 
         The ``recv()`` method can be used to receive the next message from the
         socket. The response from this method is formatted by web3.py formatters
-        and run through the middlewares before being returned. This is not the
+        and run through the middleware before being returned. This is not the
         recommended way to receive a message as the ``process_subscriptions()`` method
         is available for listening to subscriptions and the standard API for making
         requests via the appropriate module
@@ -487,7 +487,7 @@ Interacting with the Persistent Connection
         This method is available strictly for sending raw requests to the socket,
         if desired. It is not recommended to use this method directly, as the
         responses will not be formatted by *web3.py* formatters or run through the
-        middlewares. Instead, use the methods available on the respective web3
+        middleware. Instead, use the methods available on the respective web3
         module. For example, use ``w3.eth.get_block("latest")`` instead of
         ``w3.socket.send("eth_getBlockByNumber", ["latest", True])``.
 

--- a/ens/async_ens.py
+++ b/ens/async_ens.py
@@ -100,7 +100,7 @@ class AsyncENS(BaseENS):
         self,
         provider: "AsyncBaseProvider" = cast("AsyncBaseProvider", default),
         addr: ChecksumAddress = None,
-        middlewares: Optional[Sequence[Tuple["Middleware", str]]] = None,
+        middleware: Optional[Sequence[Tuple["Middleware", str]]] = None,
     ) -> None:
         """
         :param provider: a single provider used to connect to Ethereum
@@ -108,7 +108,7 @@ class AsyncENS(BaseENS):
         :param hex-string addr: the address of the ENS registry on-chain.
             If not provided, ENS.py will default to the mainnet ENS registry address.
         """
-        self.w3 = init_async_web3(provider, middlewares)
+        self.w3 = init_async_web3(provider, middleware)
 
         ens_addr = addr if addr else ENS_MAINNET_ADDR
         self.ens = self.w3.eth.contract(abi=abis.ENS, address=ens_addr)
@@ -129,9 +129,9 @@ class AsyncENS(BaseENS):
             provided, defaults to the mainnet ENS registry address.
         """
         provider = w3.manager.provider
-        middlewares = w3.middleware_onion.middlewares
+        middleware = w3.middleware_onion.middleware
         ns = cls(
-            cast("AsyncBaseProvider", provider), addr=addr, middlewares=middlewares
+            cast("AsyncBaseProvider", provider), addr=addr, middleware=middleware
         )
 
         # inherit strict bytes checking from w3 instance

--- a/ens/async_ens.py
+++ b/ens/async_ens.py
@@ -130,9 +130,7 @@ class AsyncENS(BaseENS):
         """
         provider = w3.manager.provider
         middleware = w3.middleware_onion.middleware
-        ns = cls(
-            cast("AsyncBaseProvider", provider), addr=addr, middleware=middleware
-        )
+        ns = cls(cast("AsyncBaseProvider", provider), addr=addr, middleware=middleware)
 
         # inherit strict bytes checking from w3 instance
         ns.strict_bytes_type_checking = w3.strict_bytes_type_checking

--- a/ens/ens.py
+++ b/ens/ens.py
@@ -99,7 +99,7 @@ class ENS(BaseENS):
         self,
         provider: "BaseProvider" = cast("BaseProvider", default),
         addr: ChecksumAddress = None,
-        middlewares: Optional[Sequence[Tuple["Middleware", str]]] = None,
+        middleware: Optional[Sequence[Tuple["Middleware", str]]] = None,
     ) -> None:
         """
         :param provider: a single provider used to connect to Ethereum
@@ -108,7 +108,7 @@ class ENS(BaseENS):
             If not provided, ENS.py will default to the mainnet ENS
             registry address.
         """
-        self.w3 = init_web3(provider, middlewares)
+        self.w3 = init_web3(provider, middleware)
 
         ens_addr = addr if addr else ENS_MAINNET_ADDR
         self.ens = self.w3.eth.contract(abi=abis.ENS, address=ens_addr)
@@ -129,8 +129,8 @@ class ENS(BaseENS):
             provided, defaults to the mainnet ENS registry address.
         """
         provider = w3.manager.provider
-        middlewares = w3.middleware_onion.middlewares
-        ns = cls(cast("BaseProvider", provider), addr=addr, middlewares=middlewares)
+        middleware = w3.middleware_onion.middleware
+        ns = cls(cast("BaseProvider", provider), addr=addr, middleware=middleware)
 
         # inherit strict bytes checking from w3 instance
         ns.strict_bytes_type_checking = w3.strict_bytes_type_checking

--- a/ens/utils.py
+++ b/ens/utils.py
@@ -81,7 +81,7 @@ def Web3() -> Type["_Web3"]:
 
 def init_web3(
     provider: "BaseProvider" = cast("BaseProvider", default),
-    middlewares: Optional[Sequence[Tuple["Middleware", str]]] = None,
+    middleware: Optional[Sequence[Tuple["Middleware", str]]] = None,
 ) -> "_Web3":
     from web3 import (
         Web3 as Web3Main,
@@ -93,7 +93,7 @@ def init_web3(
     if provider is default:
         w3 = Web3Main(ens=None, modules={"eth": (EthMain)})
     else:
-        w3 = Web3Main(provider, middlewares, ens=None, modules={"eth": (EthMain)})
+        w3 = Web3Main(provider, middleware, ens=None, modules={"eth": (EthMain)})
 
     return customize_web3(w3)
 
@@ -299,7 +299,7 @@ def get_abi_output_types(abi: "ABIFunction") -> List[str]:
 
 def init_async_web3(
     provider: "AsyncBaseProvider" = cast("AsyncBaseProvider", default),
-    middlewares: Optional[Sequence[Tuple["Middleware", str]]] = (),
+    middleware: Optional[Sequence[Tuple["Middleware", str]]] = (),
 ) -> "AsyncWeb3":
     from web3 import (
         AsyncWeb3 as AsyncWeb3Main,
@@ -311,13 +311,13 @@ def init_async_web3(
         StalecheckMiddlewareBuilder,
     )
 
-    middlewares = list(middlewares)
-    for i, (middleware, name) in enumerate(middlewares):
+    middleware = list(middleware)
+    for i, (mw, name) in enumerate(middleware):
         if name == "ens_name_to_address":
-            middlewares.pop(i)
+            middleware.pop(i)
 
-    if "stalecheck" not in (name for mw, name in middlewares):
-        middlewares.append(
+    if "stalecheck" not in (name for mw, name in middleware):
+        middleware.append(
             (
                 StalecheckMiddlewareBuilder.build(ACCEPTABLE_STALE_HOURS * 3600),
                 "stalecheck",
@@ -326,12 +326,12 @@ def init_async_web3(
 
     if provider is default:
         async_w3 = AsyncWeb3Main(
-            middlewares=middlewares, ens=None, modules={"eth": (AsyncEthMain)}
+            middleware=middleware, ens=None, modules={"eth": (AsyncEthMain)}
         )
     else:
         async_w3 = AsyncWeb3Main(
             provider,
-            middlewares=middlewares,
+            middleware=middleware,
             ens=None,
             modules={"eth": (AsyncEthMain)},
         )

--- a/newsfragments/3276.breaking.rst
+++ b/newsfragments/3276.breaking.rst
@@ -1,0 +1,1 @@
+Move ``middlewares`` -> ``middleware``

--- a/tests/core/eth-module/test_eth_filter.py
+++ b/tests/core/eth-module/test_eth_filter.py
@@ -36,7 +36,7 @@ def test_eth_filter_creates_correct_filter_type(w3):
 @pytest_asyncio.fixture()
 async def async_w3():
     provider = AsyncEthereumTesterProvider()
-    w3 = Web3(provider, modules={"eth": [AsyncEth]}, middlewares=[])
+    w3 = Web3(provider, modules={"eth": [AsyncEth]}, middleware=[])
     return w3
 
 

--- a/tests/core/eth-module/test_eth_filter.py
+++ b/tests/core/eth-module/test_eth_filter.py
@@ -3,7 +3,7 @@ import pytest
 import pytest_asyncio
 
 from web3 import (
-    Web3,
+    AsyncWeb3,
 )
 from web3._utils.filters import (
     AsyncBlockFilter,
@@ -12,9 +12,6 @@ from web3._utils.filters import (
     BlockFilter,
     LogFilter,
     TransactionFilter,
-)
-from web3.eth import (
-    AsyncEth,
 )
 from web3.providers.eth_tester.main import (
     AsyncEthereumTesterProvider,
@@ -36,7 +33,7 @@ def test_eth_filter_creates_correct_filter_type(w3):
 @pytest_asyncio.fixture()
 async def async_w3():
     provider = AsyncEthereumTesterProvider()
-    w3 = Web3(provider, modules={"eth": [AsyncEth]}, middleware=[])
+    w3 = AsyncWeb3(provider)
     return w3
 
 

--- a/tests/core/eth-module/test_eth_properties.py
+++ b/tests/core/eth-module/test_eth_properties.py
@@ -15,7 +15,7 @@ from web3.providers.eth_tester.main import (
 def async_w3():
     return Web3(
         AsyncEthereumTesterProvider(),
-        middlewares=[],
+        middleware=[],
         modules={
             "eth": (AsyncEth,),
         },

--- a/tests/core/eth-module/test_eth_properties.py
+++ b/tests/core/eth-module/test_eth_properties.py
@@ -1,10 +1,7 @@
 import pytest
 
 from web3 import (
-    Web3,
-)
-from web3.eth import (
-    AsyncEth,
+    AsyncWeb3,
 )
 from web3.providers.eth_tester.main import (
     AsyncEthereumTesterProvider,
@@ -13,12 +10,8 @@ from web3.providers.eth_tester.main import (
 
 @pytest.fixture
 def async_w3():
-    return Web3(
+    return AsyncWeb3(
         AsyncEthereumTesterProvider(),
-        middleware=[],
-        modules={
-            "eth": (AsyncEth,),
-        },
     )
 
 

--- a/tests/core/manager/conftest.py
+++ b/tests/core/manager/conftest.py
@@ -26,7 +26,7 @@ def middleware_factory():
                             params.append(key)
                             method = "|".join((method, key))
                             response = make_request(method, params)
-                            response["result"]["middlewares"].append(key)
+                            response["result"]["middleware"].append(key)
                             return response
 
                         return middleware_fn

--- a/tests/core/manager/test_default_middlewares.py
+++ b/tests/core/manager/test_default_middlewares.py
@@ -10,8 +10,8 @@ from web3.middleware import (
 )
 
 
-def test_default_sync_middlewares(w3):
-    expected_middlewares = [
+def test_default_sync_middleware(w3):
+    expected_middleware = [
         (GasPriceStrategyMiddleware, "gas_price_strategy"),
         (ENSNameToAddressMiddleware, "ens_name_to_address"),
         (AttributeDictMiddleware, "attrdict"),
@@ -19,6 +19,6 @@ def test_default_sync_middlewares(w3):
         (BufferedGasEstimateMiddleware, "gas_estimate"),
     ]
 
-    default_middlewares = RequestManager.get_default_middlewares()
+    default_middleware = RequestManager.get_default_middleware()
 
-    assert default_middlewares == expected_middlewares
+    assert default_middleware == expected_middleware

--- a/tests/core/manager/test_middleware_can_be_stateful.py
+++ b/tests/core/manager/test_middleware_can_be_stateful.py
@@ -26,7 +26,7 @@ stateful_middleware = StatefulMiddleware
 def test_middleware_holds_state_across_requests():
     provider = BaseProvider()
 
-    manager = RequestManager(None, provider, middlewares=[stateful_middleware])
+    manager = RequestManager(None, provider, middleware=[stateful_middleware])
     state_a = manager.request_blocking("test_statefulness", [])
     assert len(state_a) == 1
 

--- a/tests/core/manager/test_middleware_onion_api.py
+++ b/tests/core/manager/test_middleware_onion_api.py
@@ -17,7 +17,7 @@ def test_provider_property_setter_and_getter(middleware_factory):
     assert middleware_a is not middleware_b
     assert middleware_a is not middleware_c
 
-    manager = RequestManager(None, provider, middlewares=[])
+    manager = RequestManager(None, provider, middleware=[])
 
     assert tuple(manager.middleware_onion) == tuple()
 
@@ -44,7 +44,7 @@ def test_provider_property_setter_and_getter(middleware_factory):
 
 def test_add_named_middleware(middleware_factory):
     mw = middleware_factory()
-    manager = RequestManager(None, BaseProvider(), middlewares=[(mw, "the-name")])
+    manager = RequestManager(None, BaseProvider(), middleware=[(mw, "the-name")])
     assert len(manager.middleware_onion) == 1
 
     assert tuple(manager.middleware_onion) == (mw,)
@@ -53,7 +53,7 @@ def test_add_named_middleware(middleware_factory):
 def test_add_named_duplicate_middleware(middleware_factory):
     mw = middleware_factory()
     manager = RequestManager(
-        None, BaseProvider(), middlewares=[(mw, "the-name"), (mw, "name2")]
+        None, BaseProvider(), middleware=[(mw, "the-name"), (mw, "name2")]
     )
     assert tuple(manager.middleware_onion) == (mw, mw)
 
@@ -68,9 +68,9 @@ def test_add_named_duplicate_middleware(middleware_factory):
 def test_add_duplicate_middleware(middleware_factory):
     mw = middleware_factory()
     with pytest.raises(ValueError):
-        RequestManager(None, BaseProvider(), middlewares=[mw, mw])
+        RequestManager(None, BaseProvider(), middleware=[mw, mw])
 
-    manager = RequestManager(None, BaseProvider(), middlewares=[])
+    manager = RequestManager(None, BaseProvider(), middleware=[])
     manager.middleware_onion.add(mw)
 
     with pytest.raises(ValueError):
@@ -83,7 +83,7 @@ def test_replace_middleware(middleware_factory):
     mw2 = middleware_factory()
     mw3 = middleware_factory()
 
-    manager = RequestManager(None, BaseProvider(), middlewares=[mw1, (mw2, "2nd"), mw3])
+    manager = RequestManager(None, BaseProvider(), middleware=[mw1, (mw2, "2nd"), mw3])
 
     assert tuple(manager.middleware_onion) == (mw1, mw2, mw3)
 
@@ -102,7 +102,7 @@ def test_replace_middleware_without_name(middleware_factory):
     mw2 = middleware_factory()
     mw3 = middleware_factory()
 
-    manager = RequestManager(None, BaseProvider(), middlewares=[mw1, mw2, mw3])
+    manager = RequestManager(None, BaseProvider(), middleware=[mw1, mw2, mw3])
 
     assert tuple(manager.middleware_onion) == (mw1, mw2, mw3)
 
@@ -121,7 +121,7 @@ def test_add_middleware(middleware_factory):
     mw2 = middleware_factory()
     mw3 = middleware_factory()
 
-    manager = RequestManager(None, BaseProvider(), middlewares=[mw1, mw2])
+    manager = RequestManager(None, BaseProvider(), middleware=[mw1, mw2])
 
     manager.middleware_onion.add(mw3)
 
@@ -133,7 +133,7 @@ def test_bury_middleware(middleware_factory):
     mw2 = middleware_factory()
     mw3 = middleware_factory()
 
-    manager = RequestManager(None, BaseProvider(), middlewares=[mw1, mw2])
+    manager = RequestManager(None, BaseProvider(), middleware=[mw1, mw2])
 
     manager.middleware_onion.inject(mw3, layer=0)
 
@@ -145,7 +145,7 @@ def test_bury_named_middleware(middleware_factory):
     mw2 = middleware_factory()
     mw3 = middleware_factory()
 
-    manager = RequestManager(None, BaseProvider(), middlewares=[mw1, mw2])
+    manager = RequestManager(None, BaseProvider(), middleware=[mw1, mw2])
 
     manager.middleware_onion.inject(mw3, name="middleware3", layer=0)
 
@@ -163,7 +163,7 @@ def test_remove_middleware(middleware_factory):
     mw2 = middleware_factory()
     mw3 = middleware_factory()
 
-    manager = RequestManager(None, BaseProvider(), middlewares=[mw1, mw2, mw3])
+    manager = RequestManager(None, BaseProvider(), middleware=[mw1, mw2, mw3])
 
     assert tuple(manager.middleware_onion) == (mw1, mw2, mw3)
 
@@ -172,13 +172,13 @@ def test_remove_middleware(middleware_factory):
     assert tuple(manager.middleware_onion) == (mw1, mw3)
 
 
-def test_export_middlewares(middleware_factory):
+def test_export_middleware(middleware_factory):
     mw1 = middleware_factory()
     mw2 = middleware_factory()
     manager = RequestManager(
-        None, BaseProvider(), middlewares=[(mw1, "name1"), (mw2, "name2")]
+        None, BaseProvider(), middleware=[(mw1, "name1"), (mw2, "name2")]
     )
     assert tuple(manager.middleware_onion) == (mw1, mw2)
 
-    middlewares = manager.middleware_onion.middlewares
-    assert middlewares == [(mw1, "name1"), (mw2, "name2")]
+    middleware = manager.middleware_onion.middleware
+    assert middleware == [(mw1, "name1"), (mw2, "name2")]

--- a/tests/core/manager/test_provider_request_wrapping.py
+++ b/tests/core/manager/test_provider_request_wrapping.py
@@ -12,7 +12,7 @@ class DummyProvider(BaseProvider):
             "result": {
                 "method": method,
                 "params": params,
-                "middlewares": [],
+                "middleware": [],
             },
         }
 
@@ -23,9 +23,9 @@ def test_provider_property_setter_and_getter(middleware_factory):
 
     provider = DummyProvider()
 
-    manager = RequestManager(None, provider, middlewares=[middleware_a, middleware_b])
+    manager = RequestManager(None, provider, middleware=[middleware_a, middleware_b])
     response = manager.request_blocking("init", ["init"])
 
     assert response["method"] == "init|middleware-A|middleware-B"
     assert response["params"] == ["init", "middleware-A", "middleware-B"]
-    assert response["middlewares"] == ["middleware-B", "middleware-A"]
+    assert response["middleware"] == ["middleware-B", "middleware-A"]

--- a/tests/core/method-class/test_method.py
+++ b/tests/core/method-class/test_method.py
@@ -369,7 +369,7 @@ class FakeModule(Module):
 
 @pytest.fixture
 def dummy_w3():
-    return Web3(EthereumTesterProvider(), modules={"fake": FakeModule}, middleware=[])
+    return Web3(EthereumTesterProvider(), modules={"fake": FakeModule})
 
 
 def test_munger_class_method_access_raises_friendly_error():

--- a/tests/core/method-class/test_method.py
+++ b/tests/core/method-class/test_method.py
@@ -369,7 +369,7 @@ class FakeModule(Module):
 
 @pytest.fixture
 def dummy_w3():
-    return Web3(EthereumTesterProvider(), modules={"fake": FakeModule}, middlewares=[])
+    return Web3(EthereumTesterProvider(), modules={"fake": FakeModule}, middleware=[])
 
 
 def test_munger_class_method_access_raises_friendly_error():

--- a/tests/core/middleware/test_filter_middleware.py
+++ b/tests/core/middleware/test_filter_middleware.py
@@ -83,7 +83,7 @@ def iter_block_number(start=0):
 
 @pytest.fixture(scope="function")
 def w3(request_mocker, iter_block_number):
-    w3_base = Web3(provider=DummyProvider(), middlewares=[])
+    w3_base = Web3(provider=DummyProvider(), middleware=[])
     w3_base.middleware_onion.add(AttributeDictMiddleware)
     w3_base.middleware_onion.add(LocalFilterMiddleware)
     with request_mocker(
@@ -253,7 +253,7 @@ class AsyncDummyProvider(AsyncBaseProvider):
 
 @pytest_asyncio.fixture(scope="function")
 async def async_w3(request_mocker, iter_block_number):
-    async_w3_base = AsyncWeb3(provider=AsyncDummyProvider(), middlewares=[])
+    async_w3_base = AsyncWeb3(provider=AsyncDummyProvider(), middleware=[])
     async_w3_base.middleware_onion.add(AttributeDictMiddleware)
     async_w3_base.middleware_onion.add(LocalFilterMiddleware)
 

--- a/tests/core/middleware/test_formatting_middleware.py
+++ b/tests/core/middleware/test_formatting_middleware.py
@@ -24,7 +24,7 @@ class DummyProvider(BaseProvider):
 
 @pytest.fixture
 def w3():
-    return Web3(provider=DummyProvider(), middlewares=[])
+    return Web3(provider=DummyProvider(), middleware=[])
 
 
 def test_formatting_middleware(w3, request_mocker):

--- a/tests/core/middleware/test_name_to_address_middleware.py
+++ b/tests/core/middleware/test_name_to_address_middleware.py
@@ -31,7 +31,7 @@ class TempENS:
 
 @pytest.fixture
 def _w3_setup():
-    return Web3(provider=EthereumTesterProvider(), middlewares=[])
+    return Web3(provider=EthereumTesterProvider(), middleware=[])
 
 
 @pytest.fixture
@@ -109,7 +109,7 @@ class AsyncTempENS(TempENS):
 
 @pytest_asyncio.fixture
 async def _async_w3_setup():
-    return AsyncWeb3(provider=AsyncEthereumTesterProvider(), middlewares=[])
+    return AsyncWeb3(provider=AsyncEthereumTesterProvider(), middleware=[])
 
 
 @pytest_asyncio.fixture

--- a/tests/core/middleware/test_transaction_signing.py
+++ b/tests/core/middleware/test_transaction_signing.py
@@ -95,7 +95,7 @@ class DummyProvider(BaseProvider):
 
 @pytest.fixture
 def w3_dummy(request_mocker):
-    w3_base = Web3(provider=DummyProvider(), middlewares=[])
+    w3_base = Web3(provider=DummyProvider(), middleware=[])
     with request_mocker(
         w3_base,
         mock_results={
@@ -420,7 +420,7 @@ class AsyncDummyProvider(AsyncBaseProvider):
 
 @pytest_asyncio.fixture
 async def async_w3_dummy(request_mocker):
-    w3_base = AsyncWeb3(provider=AsyncDummyProvider(), middlewares=[])
+    w3_base = AsyncWeb3(provider=AsyncDummyProvider(), middleware=[])
     async with request_mocker(
         w3_base,
         mock_results={

--- a/tests/core/providers/test_async_http_provider.py
+++ b/tests/core/providers/test_async_http_provider.py
@@ -67,7 +67,7 @@ def test_init_kwargs():
     assert w3.manager.provider == provider
 
 
-def test_web3_with_async_http_provider_has_default_middlewares_and_modules() -> None:
+def test_web3_with_async_http_provider_has_default_middleware_and_modules() -> None:
     async_w3 = AsyncWeb3(AsyncHTTPProvider(endpoint_uri=URI))
 
     # assert default modules
@@ -82,8 +82,8 @@ def test_web3_with_async_http_provider_has_default_middlewares_and_modules() -> 
     # assert default middleware
 
     # the following length check should fail and will need to be added to once more
-    # async middlewares are added to the defaults
-    assert len(async_w3.middleware_onion.middlewares) == 5
+    # async middleware are added to the defaults
+    assert len(async_w3.middleware_onion.middleware) == 5
 
     assert (
         async_w3.middleware_onion.get("gas_price_strategy")

--- a/tests/core/providers/test_http_provider.py
+++ b/tests/core/providers/test_http_provider.py
@@ -59,7 +59,7 @@ def test_init_kwargs():
     assert w3.manager.provider == provider
 
 
-def test_web3_with_http_provider_has_default_middlewares_and_modules() -> None:
+def test_web3_with_http_provider_has_default_middleware_and_modules() -> None:
     adapter = HTTPAdapter(pool_connections=20, pool_maxsize=20)
     session = Session()
     session.mount("http://", adapter)
@@ -79,8 +79,8 @@ def test_web3_with_http_provider_has_default_middlewares_and_modules() -> None:
     # assert default middleware
 
     # the following length check should fail and will need to be added to once more
-    # middlewares are added to the defaults
-    assert len(w3.middleware_onion.middlewares) == 5
+    # middleware are added to the defaults
+    assert len(w3.middleware_onion.middleware) == 5
 
     assert w3.middleware_onion.get("gas_price_strategy") == GasPriceStrategyMiddleware
     assert w3.middleware_onion.get("ens_name_to_address") == ENSNameToAddressMiddleware

--- a/tests/ens/test_ens.py
+++ b/tests/ens/test_ens.py
@@ -26,7 +26,7 @@ def _args_list_to_set(call_args_list):
     return set(call_arg.args[0] for call_arg in call_args_list)
 
 
-def test_from_web3_inherits_web3_middlewares(w3):
+def test_from_web3_inherits_web3_middleware(w3):
     test_middleware = GasPriceStrategyMiddleware
     w3.middleware_onion.add(test_middleware, "test_middleware")
 
@@ -149,7 +149,7 @@ def local_async_w3():
     return AsyncWeb3(AsyncEthereumTesterProvider())
 
 
-def test_async_from_web3_inherits_web3_middlewares(local_async_w3):
+def test_async_from_web3_inherits_web3_middleware(local_async_w3):
     test_middleware = ValidationMiddleware
     local_async_w3.middleware_onion.add(test_middleware, "test_middleware")
 

--- a/tests/ens/test_utils.py
+++ b/tests/ens/test_utils.py
@@ -37,10 +37,10 @@ from web3.providers.eth_tester import (
 )
 
 
-def test_init_web3_adds_expected_middlewares():
+def test_init_web3_adds_expected_middleware():
     w3 = init_web3()
-    middlewares = w3.middleware_onion.middlewares
-    assert middlewares[0][1] == "stalecheck"
+    middleware = w3.middleware_onion.middleware
+    assert middleware[0][1] == "stalecheck"
 
 
 @pytest.mark.parametrize(
@@ -205,10 +205,10 @@ def test_label_to_hash_normalizes_name_using_ensip15():
 
 
 @pytest.mark.asyncio
-async def test_init_async_web3_adds_expected_async_middlewares():
+async def test_init_async_web3_adds_expected_async_middleware():
     async_w3 = init_async_web3()
-    middlewares = async_w3.middleware_onion.middlewares
-    assert middlewares[0][1] == "stalecheck"
+    middleware = async_w3.middleware_onion.middleware
+    assert middleware[0][1] == "stalecheck"
 
 
 @pytest.mark.asyncio

--- a/web3/datastructures.py
+++ b/web3/datastructures.py
@@ -252,9 +252,9 @@ class NamedElementOnion(Mapping[TKey, TValue]):
         del self._queue[old_name]
 
     @property
-    def middlewares(self) -> Sequence[Any]:
+    def middleware(self) -> Sequence[Any]:
         """
-        Returns middlewares in the appropriate order to be imported into a new Web3
+        Returns middleware in the appropriate order to be imported into a new Web3
         instance (reversed _queue order) as a list of (middleware, name) tuples.
         """
         return [(val, key) for key, val in reversed(self._queue.items())]
@@ -301,24 +301,24 @@ class NamedElementOnion(Mapping[TKey, TValue]):
 
     # --- iter and tupleize methods --- #
 
-    def _reversed_middlewares(self) -> Iterator[TValue]:
+    def _reversed_middleware(self) -> Iterator[TValue]:
         elements = self._queue.values()
         if not isinstance(elements, Sequence):
             # type ignored b/c elements is set as _OrderedDictValuesView[Any] on 210
             elements = list(elements)  # type: ignore
         return reversed(elements)
 
-    def as_tuple_of_middlewares(self) -> Tuple[TValue, ...]:
+    def as_tuple_of_middleware(self) -> Tuple[TValue, ...]:
         """
         This helps with type hinting since we return `Iterator[TKey]` type, though it's
         actually a `Iterator[TValue]` type, for the `__iter__()` method. This is in
         order to satisfy the `Mapping` interface.
         """
-        return tuple(self._reversed_middlewares())
+        return tuple(self._reversed_middleware())
 
     def __iter__(self) -> Iterator[TKey]:
         # ``__iter__()`` for a ``Mapping``  returns ``Iterator[TKey]`` but this
         # implementation returns ``Iterator[TValue]`` on reversed values (not keys).
         # This leads to typing issues, so it's better to use
-        # ``as_tuple_of_middlewares()`` to achieve the same result.
-        return iter(self._reversed_middlewares())  # type: ignore
+        # ``as_tuple_of_middleware()`` to achieve the same result.
+        return iter(self._reversed_middleware())  # type: ignore

--- a/web3/main.py
+++ b/web3/main.py
@@ -352,14 +352,14 @@ class Web3(BaseWeb3):
     def __init__(
         self,
         provider: Optional[BaseProvider] = None,
-        middlewares: Optional[Sequence[Any]] = None,
+        middleware: Optional[Sequence[Any]] = None,
         modules: Optional[Dict[str, Union[Type[Module], Sequence[Any]]]] = None,
         external_modules: Optional[
             Dict[str, Union[Type[Module], Sequence[Any]]]
         ] = None,
         ens: Union[ENS, "Empty"] = empty,
     ) -> None:
-        self.manager = self.RequestManager(self, provider, middlewares)
+        self.manager = self.RequestManager(self, provider, middleware)
         self.codec = ABICodec(build_strict_registry())
 
         if modules is None:
@@ -420,14 +420,14 @@ class AsyncWeb3(BaseWeb3):
     def __init__(
         self,
         provider: Optional[AsyncBaseProvider] = None,
-        middlewares: Optional[Sequence[Any]] = None,
+        middleware: Optional[Sequence[Any]] = None,
         modules: Optional[Dict[str, Union[Type[Module], Sequence[Any]]]] = None,
         external_modules: Optional[
             Dict[str, Union[Type[Module], Sequence[Any]]]
         ] = None,
         ens: Union[AsyncENS, "Empty"] = empty,
     ) -> None:
-        self.manager = self.RequestManager(self, provider, middlewares)
+        self.manager = self.RequestManager(self, provider, middleware)
         self.codec = ABICodec(build_strict_registry())
 
         self._modules = get_async_default_modules() if modules is None else modules

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -125,7 +125,7 @@ class RequestManager:
         self,
         w3: Union["AsyncWeb3", "Web3"],
         provider: Optional[Union["BaseProvider", "AsyncBaseProvider"]] = None,
-        middlewares: Optional[Sequence[Tuple[Middleware, str]]] = None,
+        middleware: Optional[Sequence[Tuple[Middleware, str]]] = None,
     ) -> None:
         self.w3 = w3
 
@@ -134,10 +134,10 @@ class RequestManager:
         else:
             self.provider = provider
 
-        if middlewares is None:
-            middlewares = self.get_default_middlewares()
+        if middleware is None:
+            middleware = self.get_default_middleware()
 
-        self.middleware_onion = NamedElementOnion(middlewares)
+        self.middleware_onion = NamedElementOnion(middleware)
 
         if isinstance(provider, PersistentConnectionProvider):
             # set up the request processor to be able to properly process ordered
@@ -157,9 +157,9 @@ class RequestManager:
         self._provider = provider
 
     @staticmethod
-    def get_default_middlewares() -> List[Tuple[Middleware, str]]:
+    def get_default_middleware() -> List[Tuple[Middleware, str]]:
         """
-        List the default middlewares for the request manager.
+        List the default middleware for the request manager.
         Documentation should remain in sync with these defaults.
         """
         return [

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -69,9 +69,9 @@ def combine_middleware(
     the response through the response processors.
     """
     accumulator_fn = provider_request_fn
-    for middleware in reversed(middleware):
+    for mw in reversed(middleware):
         # initialize the middleware and wrap the accumulator function down the stack
-        accumulator_fn = middleware(w3).wrap_make_request(accumulator_fn)
+        accumulator_fn = mw(w3).wrap_make_request(accumulator_fn)
     return accumulator_fn
 
 
@@ -86,8 +86,8 @@ async def async_combine_middleware(
     the response through the response processors.
     """
     accumulator_fn = provider_request_fn
-    for middleware in reversed(middleware):
+    for mw in reversed(middleware):
         # initialize the middleware and wrap the accumulator function down the stack
-        initialized = middleware(async_w3)
+        initialized = mw(async_w3)
         accumulator_fn = await initialized.async_wrap_make_request(accumulator_fn)
     return accumulator_fn

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -11,6 +11,7 @@ from .attrdict import (
 )
 from .base import (
     Middleware,
+    Web3Middleware,
 )
 from .buffered_gas_estimate import (
     BufferedGasEstimateMiddleware,

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -58,8 +58,8 @@ if TYPE_CHECKING:
     )
 
 
-def combine_middlewares(
-    middlewares: Sequence[Middleware],
+def combine_middleware(
+    middleware: Sequence[Middleware],
     w3: "Web3",
     provider_request_fn: MakeRequestFn,
 ) -> Callable[..., "RPCResponse"]:
@@ -69,14 +69,14 @@ def combine_middlewares(
     the response through the response processors.
     """
     accumulator_fn = provider_request_fn
-    for middleware in reversed(middlewares):
+    for middleware in reversed(middleware):
         # initialize the middleware and wrap the accumulator function down the stack
         accumulator_fn = middleware(w3).wrap_make_request(accumulator_fn)
     return accumulator_fn
 
 
-async def async_combine_middlewares(
-    middlewares: Sequence[Middleware],
+async def async_combine_middleware(
+    middleware: Sequence[Middleware],
     async_w3: "AsyncWeb3",
     provider_request_fn: AsyncMakeRequestFn,
 ) -> Callable[..., Coroutine[Any, Any, "RPCResponse"]]:
@@ -86,7 +86,7 @@ async def async_combine_middlewares(
     the response through the response processors.
     """
     accumulator_fn = provider_request_fn
-    for middleware in reversed(middlewares):
+    for middleware in reversed(middleware):
         # initialize the middleware and wrap the accumulator function down the stack
         initialized = middleware(async_w3)
         accumulator_fn = await initialized.async_wrap_make_request(accumulator_fn)

--- a/web3/module.py
+++ b/web3/module.py
@@ -129,7 +129,7 @@ def retrieve_async_method_call_fn(
 
 #  Module should no longer have access to the full web3 api.
 #  Only the calling functions need access to the request methods.
-#  Any "re-entrant" shenanigans can go in the middlewares, which do
+#  Any "re-entrant" shenanigans can go in the middleware, which do
 #  have web3 access.
 class Module:
     is_async = False

--- a/web3/providers/async_base.py
+++ b/web3/providers/async_base.py
@@ -28,7 +28,7 @@ from web3.exceptions import (
     ProviderConnectionError,
 )
 from web3.middleware import (
-    async_combine_middlewares,
+    async_combine_middleware,
 )
 from web3.middleware.base import (
     Middleware,
@@ -95,14 +95,14 @@ class AsyncBaseProvider:
     async def request_func(
         self, async_w3: "AsyncWeb3", middleware_onion: MiddlewareOnion
     ) -> Callable[..., Coroutine[Any, Any, RPCResponse]]:
-        middlewares: Tuple[Middleware, ...] = middleware_onion.as_tuple_of_middlewares()
+        middleware: Tuple[Middleware, ...] = middleware_onion.as_tuple_of_middleware()
 
         cache_key = self._request_func_cache[0]
-        if cache_key != middlewares:
+        if cache_key != middleware:
             self._request_func_cache = (
-                middlewares,
-                await async_combine_middlewares(
-                    middlewares=middlewares,
+                middleware,
+                await async_combine_middleware(
+                    middleware=middleware,
                     async_w3=async_w3,
                     provider_request_fn=self.make_request,
                 ),

--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -25,7 +25,7 @@ from web3.exceptions import (
     ProviderConnectionError,
 )
 from web3.middleware import (
-    combine_middlewares,
+    combine_middleware,
 )
 from web3.middleware.base import (
     Middleware,
@@ -61,7 +61,7 @@ CACHEABLE_REQUESTS = cast(
 
 
 class BaseProvider:
-    # a tuple of (middlewares, request_func)
+    # a tuple of (middleware, request_func)
     _request_func_cache: Tuple[Tuple[Middleware, ...], Callable[..., RPCResponse]] = (
         None,
         None,
@@ -86,19 +86,19 @@ class BaseProvider:
     ) -> Callable[..., RPCResponse]:
         """
         @param w3 is the web3 instance
-        @param middleware_onion is an iterable of middlewares,
+        @param middleware_onion is an iterable of middleware,
             ordered by first to execute
         @returns a function that calls all the middleware and
             eventually self.make_request()
         """
-        middlewares: Tuple[Middleware, ...] = middleware_onion.as_tuple_of_middlewares()
+        middleware: Tuple[Middleware, ...] = middleware_onion.as_tuple_of_middleware()
 
         cache_key = self._request_func_cache[0]
-        if cache_key != middlewares:
+        if cache_key != middleware:
             self._request_func_cache = (
-                middlewares,
-                combine_middlewares(
-                    middlewares=middlewares,
+                middleware,
+                combine_middleware(
+                    middleware=middleware,
                     w3=w3,
                     provider_request_fn=self.make_request,
                 ),

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -34,8 +34,8 @@ from web3.types import (
 )
 
 from ...middleware import (
-    async_combine_middlewares,
-    combine_middlewares,
+    async_combine_middleware,
+    combine_middleware,
 )
 from .middleware import (
     default_transaction_fields_middleware,
@@ -58,7 +58,7 @@ if TYPE_CHECKING:
 
 
 class AsyncEthereumTesterProvider(AsyncBaseProvider):
-    _middlewares = (
+    _middleware = (
         default_transaction_fields_middleware,
         ethereum_tester_middleware,
     )
@@ -83,16 +83,16 @@ class AsyncEthereumTesterProvider(AsyncBaseProvider):
     ) -> Callable[..., Coroutine[Any, Any, RPCResponse]]:
         # override the request_func to add the ethereum_tester_middleware
 
-        middlewares = middleware_onion.as_tuple_of_middlewares() + tuple(
-            self._middlewares
+        middleware = middleware_onion.as_tuple_of_middleware() + tuple(
+            self._middleware
         )
 
         cache_key = self._request_func_cache[0]
-        if cache_key != middlewares:
+        if cache_key != middleware:
             self._request_func_cache = (
-                middlewares,
-                await async_combine_middlewares(
-                    middlewares=middlewares,
+                middleware,
+                await async_combine_middleware(
+                    middleware=middleware,
                     async_w3=async_w3,
                     provider_request_fn=self.make_request,
                 ),
@@ -107,7 +107,7 @@ class AsyncEthereumTesterProvider(AsyncBaseProvider):
 
 
 class EthereumTesterProvider(BaseProvider):
-    _middlewares = (
+    _middleware = (
         default_transaction_fields_middleware,
         ethereum_tester_middleware,
     )
@@ -159,16 +159,16 @@ class EthereumTesterProvider(BaseProvider):
     ) -> Callable[..., RPCResponse]:
         # override the request_func to add the ethereum_tester_middleware
 
-        middlewares = middleware_onion.as_tuple_of_middlewares() + tuple(
-            self._middlewares
+        middleware = middleware_onion.as_tuple_of_middleware() + tuple(
+            self._middleware
         )
 
         cache_key = self._request_func_cache[0]
-        if cache_key != middlewares:
+        if cache_key != middleware:
             self._request_func_cache = (
-                middlewares,
-                combine_middlewares(
-                    middlewares=middlewares,
+                middleware,
+                combine_middleware(
+                    middleware=middleware,
                     w3=w3,
                     provider_request_fn=self.make_request,
                 ),

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -83,9 +83,7 @@ class AsyncEthereumTesterProvider(AsyncBaseProvider):
     ) -> Callable[..., Coroutine[Any, Any, RPCResponse]]:
         # override the request_func to add the ethereum_tester_middleware
 
-        middleware = middleware_onion.as_tuple_of_middleware() + tuple(
-            self._middleware
-        )
+        middleware = middleware_onion.as_tuple_of_middleware() + tuple(self._middleware)
 
         cache_key = self._request_func_cache[0]
         if cache_key != middleware:
@@ -159,9 +157,7 @@ class EthereumTesterProvider(BaseProvider):
     ) -> Callable[..., RPCResponse]:
         # override the request_func to add the ethereum_tester_middleware
 
-        middleware = middleware_onion.as_tuple_of_middleware() + tuple(
-            self._middleware
-        )
+        middleware = middleware_onion.as_tuple_of_middleware() + tuple(self._middleware)
 
         cache_key = self._request_func_cache[0]
         if cache_key != middleware:

--- a/web3/tools/benchmark/main.py
+++ b/web3/tools/benchmark/main.py
@@ -59,7 +59,7 @@ def build_web3_http(endpoint_uri: str) -> Web3:
     wait_for_http(endpoint_uri)
     _w3 = Web3(
         HTTPProvider(endpoint_uri),
-        middlewares=[GasPriceStrategyMiddleware, BufferedGasEstimateMiddleware],
+        middleware=[GasPriceStrategyMiddleware, BufferedGasEstimateMiddleware],
     )
     return _w3
 
@@ -68,7 +68,7 @@ async def build_async_w3_http(endpoint_uri: str) -> AsyncWeb3:
     await wait_for_aiohttp(endpoint_uri)
     _w3 = AsyncWeb3(
         AsyncHTTPProvider(endpoint_uri),
-        middlewares=[GasPriceStrategyMiddleware, BufferedGasEstimateMiddleware],
+        middleware=[GasPriceStrategyMiddleware, BufferedGasEstimateMiddleware],
     )
     return _w3
 


### PR DESCRIPTION
### What was wrong?
It feels more grammatically correct to refer to more than one middleware as `middleware`.

### How was it fixed?
Find and replace

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/id/586714878/photo/cute-baby-piglet.webp?b=1&s=170667a&w=0&k=20&c=80-sgAirUOKUqG8jeq99DXEgHNxpAeJOMJppGDp0j4A=)
