### PR TITLE
Add note about middlewares to v7 migration

### DIFF
--- a/docs/v7_migration.rst
+++ b/docs/v7_migration.rst
@@ -9,6 +9,12 @@ project depends on web3.py ``v7``, you'll probably need to make some changes.
 
 Breaking Changes:
 
+Middlewares -> Middleware
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All references to ``middlewares`` have been replaced with the more grammatically
+correct ``middleware``. Notably, this includes when a provider needs to be
+instantiated with custom middleware.
 
 Class-Based Middleware Model
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/newsfragments/3277.docs.rst
+++ b/newsfragments/3277.docs.rst
@@ -1,0 +1,1 @@
+Add note about middlewares change to v7 migration guide.


### PR DESCRIPTION
### What was wrong?
I realized I made the change, but didn't add to the migration guide. 

### How was it fixed?

Added it. Any wording tweaks would be much welcome.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://thumbs.dreamstime.com/b/adorable-fuzzy-baby-yak-playful-293464871.jpg)
