### PR TITLE
[v6] Rename `Contract.encodeABI` -> `Contract.encode_abi`

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -258,7 +258,7 @@ API
 - :attr:`Contract.events <web3.contract.Contract.events>`
 - :attr:`Contract.fallback <web3.contract.Contract.fallback.call>`
 - :meth:`Contract.constructor() <web3.contract.Contract.constructor>`
-- :meth:`Contract.encodeABI() <web3.contract.Contract.encodeABI>`
+- :meth:`Contract.encode_abi() <web3.contract.Contract.encode_abi>`
 - :attr:`web3.contract.ContractFunction <web3.contract.ContractFunction>`
 - :attr:`web3.contract.ContractEvents <web3.contract.ContractEvents>`
 

--- a/docs/web3.contract.rst
+++ b/docs/web3.contract.rst
@@ -302,16 +302,21 @@ Each Contract Factory exposes the following methods.
         filter_builder.fromBlock = 0  # raises a ValueError
 
 
+.. py:classmethod:: Contract.encode_abi(fn_name, args=None, kwargs=None, data=None)
+
+    Encodes the arguments using the Ethereum ABI for the contract function that
+    matches the given ``fn_name`` and arguments ``args``. The ``data`` parameter
+    defaults to the function selector.
+
+    .. code-block:: python
+
+      >>> contract.encode_abi(fn_name="register", args=["rainbows", 10])
+      "0xea87152b0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000087261696e626f7773000000000000000000000000000000000000000000000000"
+
 .. py:classmethod:: Contract.encodeABI(fn_name, args=None, kwargs=None, data=None)
 
-   Encodes the arguments using the Ethereum ABI for the contract function that
-   matches the given ``fn_name`` and arguments ``args``. The ``data`` parameter
-   defaults to the function selector.
-
-   .. code-block:: python
-
-      >>> contract.encodeABI(fn_name="register", args=["rainbows", 10])
-      "0xea87152b0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000087261696e626f7773000000000000000000000000000000000000000000000000"
+    .. deprecated:: 7.0
+      Use :meth:`Contract.encode_abi` instead.
 
 .. py:classmethod:: Contract.all_functions()
 

--- a/ens/async_ens.py
+++ b/ens/async_ens.py
@@ -490,7 +490,7 @@ class AsyncENS(BaseENS):
         ):
             contract_func_with_args = (fn_name, [node])
 
-            calldata = resolver.encodeABI(*contract_func_with_args)
+            calldata = resolver.encode_abi(*contract_func_with_args)
             contract_call_result = await resolver.caller.resolve(
                 ens_encode_name(normal_name),
                 calldata,

--- a/ens/ens.py
+++ b/ens/ens.py
@@ -475,7 +475,7 @@ class ENS(BaseENS):
         if _resolver_supports_interface(resolver, ENS_EXTENDED_RESOLVER_INTERFACE_ID):
             contract_func_with_args = (fn_name, [node])
 
-            calldata = resolver.encodeABI(*contract_func_with_args)
+            calldata = resolver.encode_abi(*contract_func_with_args)
             contract_call_result = resolver.caller.resolve(
                 ens_encode_name(normal_name),
                 calldata,

--- a/newsfragments/3280.deprecation.rst
+++ b/newsfragments/3280.deprecation.rst
@@ -1,0 +1,1 @@
+Deprecated ``Contract.encodeABI()`` in favor of ``Contract.encode_abi()``.

--- a/tests/core/contracts/test_contract_method_abi_encoding.py
+++ b/tests/core/contracts/test_contract_method_abi_encoding.py
@@ -203,16 +203,6 @@ def test_contract_abi_encoding_strict(w3, abi, arguments, data, expected):
 
 
 def test_contract_encodeABI_deprecated(w3):
-    abi = ABI_B
-    arguments = [0]
-
-    contract = w3.eth.contract(abi=abi)
-
-    with pytest.warns(DeprecationWarning):
-        contract.encodeABI("a", arguments)
-
-
-def test_contract_encodeABI_deprecated_returns_encoded(w3):
     expected = "0xf0fdf8340000000000000000000000000000000000000000000000000000000000000000"  # noqa: E501
 
     abi = ABI_B
@@ -221,8 +211,9 @@ def test_contract_encodeABI_deprecated_returns_encoded(w3):
 
     contract = w3.eth.contract(abi=abi)
 
-    actual = contract.encodeABI("a", arguments, data=data)
-    assert actual == expected
+    with pytest.warns(DeprecationWarning):
+        actual = contract.encodeABI("a", arguments, data=data)
+        assert actual == expected
 
 
 @patch("web3.eth.Contract.encodeABI", lambda w3, *args, **kwargs: (args, kwargs))
@@ -234,6 +225,7 @@ def test_contract_encodeABI_deprecated_calls_encode_abi_with_args(w3):
 
     contract = w3.eth.contract(abi=abi)
 
+    # DeprecationWarning raised inside patched function
     passed_on_args, passed_on_kwargs = contract.encodeABI(
         "a", arguments, kwargs, data=data
     )

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -1340,7 +1340,7 @@ class AsyncEthModuleTest:
         async_revert_contract: "Contract",
         async_unlocked_account: ChecksumAddress,
     ) -> None:
-        data = async_revert_contract.encodeABI(
+        data = async_revert_contract.encode_abi(
             fn_name="UnauthorizedWithMessage", args=["You are not authorized"]
         )
         txn_params = async_revert_contract._prepare_transaction(
@@ -1360,7 +1360,7 @@ class AsyncEthModuleTest:
         async_revert_contract: "Contract",
         async_unlocked_account: ChecksumAddress,
     ) -> None:
-        data = async_revert_contract.encodeABI(fn_name="Unauthorized")
+        data = async_revert_contract.encode_abi(fn_name="Unauthorized")
         txn_params = async_revert_contract._prepare_transaction(
             fn_name="customErrorWithoutMessage",
             transaction={
@@ -3826,7 +3826,7 @@ class EthModuleTest:
         revert_contract: "Contract",
         unlocked_account: ChecksumAddress,
     ) -> None:
-        data = revert_contract.encodeABI(
+        data = revert_contract.encode_abi(
             fn_name="UnauthorizedWithMessage", args=["You are not authorized"]
         )
         txn_params = revert_contract._prepare_transaction(
@@ -3846,7 +3846,7 @@ class EthModuleTest:
         revert_contract: "Contract",
         unlocked_account: ChecksumAddress,
     ) -> None:
-        data = revert_contract.encodeABI(fn_name="Unauthorized")
+        data = revert_contract.encode_abi(fn_name="Unauthorized")
         txn_params = revert_contract._prepare_transaction(
             fn_name="customErrorWithoutMessage",
             transaction={
@@ -4135,7 +4135,7 @@ class EthModuleTest:
         revert_contract: "Contract",
         unlocked_account: ChecksumAddress,
     ) -> None:
-        data = revert_contract.encodeABI(
+        data = revert_contract.encode_abi(
             fn_name="UnauthorizedWithMessage", args=["You are not authorized"]
         )
         txn_params = revert_contract._prepare_transaction(
@@ -4155,7 +4155,7 @@ class EthModuleTest:
         revert_contract: "Contract",
         unlocked_account: ChecksumAddress,
     ) -> None:
-        data = revert_contract.encodeABI(fn_name="Unauthorized")
+        data = revert_contract.encode_abi(fn_name="Unauthorized")
         txn_params = revert_contract._prepare_transaction(
             fn_name="customErrorWithoutMessage",
             transaction={

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -56,6 +56,9 @@ from web3._utils.contracts import (
 from web3._utils.datatypes import (
     PropertyCheckingFactory,
 )
+from web3._utils.decorators import (
+    deprecated_for,
+)
 from web3._utils.empty import (
     empty,
 )
@@ -724,7 +727,18 @@ class BaseContract:
     #  Public API
     #
     @combomethod
+    @deprecated_for("encode_abi()")
     def encodeABI(
+        cls,
+        fn_name: str,
+        args: Optional[Any] = None,
+        kwargs: Optional[Any] = None,
+        data: Optional[HexStr] = None,
+    ) -> HexStr:
+        return cls.encode_abi(fn_name, args, kwargs, data)
+
+    @combomethod
+    def encode_abi(
         cls,
         fn_name: str,
         args: Optional[Any] = None,


### PR DESCRIPTION
### What was wrong?

Related to Issue #3278 

### How was it fixed?

Updated references and deprecated the encodeABI method.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="393" alt="Screen Shot 2024-03-13 at 11 31 39 AM" src="https://github.com/ethereum/web3.py/assets/435903/eecddfd5-f41b-494a-a09f-b91578f62b7e">
