### PR TITLE
Rename `Contract.encodeABI` -> `Contract.encode_abi`

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -269,7 +269,7 @@ API
 - :attr:`Contract.events <web3.contract.Contract.events>`
 - :attr:`Contract.fallback <web3.contract.Contract.fallback.call>`
 - :meth:`Contract.constructor() <web3.contract.Contract.constructor>`
-- :meth:`Contract.encodeABI() <web3.contract.Contract.encodeABI>`
+- :meth:`Contract.encode_abi() <web3.contract.Contract.encode_abi>`
 - :attr:`web3.contract.ContractFunction <web3.contract.ContractFunction>`
 - :attr:`web3.contract.ContractEvents <web3.contract.ContractEvents>`
 

--- a/docs/v7_migration.rst
+++ b/docs/v7_migration.rst
@@ -148,3 +148,4 @@ Miscellaneous Changes
 - ``get_default_ipc_path()`` and ``get_dev_ipc_path()`` now return the path value
   without checking if the ``geth.ipc`` file exists.
 - ``Web3.is_address()`` returns ``True`` for non-checksummed addresses.
+- ``Contract.encodeABI()`` has been renamed to ``Contract.encode_abi()``.

--- a/docs/web3.contract.rst
+++ b/docs/web3.contract.rst
@@ -302,16 +302,21 @@ Each Contract Factory exposes the following methods.
         filter_builder.fromBlock = 0  # raises a ValueError
 
 
-.. py:classmethod:: Contract.encodeABI(fn_name, args=None, kwargs=None, data=None)
+.. py:classmethod:: Contract.encode_abi(fn_name, args=None, kwargs=None, data=None)
 
-   Encodes the arguments using the Ethereum ABI for the contract function that
-   matches the given ``fn_name`` and arguments ``args``. The ``data`` parameter
-   defaults to the function selector.
+    Encodes the arguments using the Ethereum ABI for the contract function that
+    matches the given ``fn_name`` and arguments ``args``. The ``data`` parameter
+    defaults to the function selector.
 
-   .. code-block:: python
+    .. code-block:: python
 
-      >>> contract.encodeABI(fn_name="register", args=["rainbows", 10])
+      >>> contract.encode_abi(fn_name="register", args=["rainbows", 10])
       "0xea87152b0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000087261696e626f7773000000000000000000000000000000000000000000000000"
+
+.. py:classmethod:: Contract.encode_abi(fn_name, args=None, kwargs=None, data=None)
+
+    .. deprecated:: 7.0
+      Use :meth:`Contract.encode_abi` instead.
 
 .. py:classmethod:: Contract.all_functions()
 

--- a/docs/web3.contract.rst
+++ b/docs/web3.contract.rst
@@ -313,7 +313,7 @@ Each Contract Factory exposes the following methods.
       >>> contract.encode_abi(fn_name="register", args=["rainbows", 10])
       "0xea87152b0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000087261696e626f7773000000000000000000000000000000000000000000000000"
 
-.. py:classmethod:: Contract.encode_abi(fn_name, args=None, kwargs=None, data=None)
+.. py:classmethod:: Contract.encodeABI(fn_name, args=None, kwargs=None, data=None)
 
     .. deprecated:: 7.0
       Use :meth:`Contract.encode_abi` instead.

--- a/docs/web3.contract.rst
+++ b/docs/web3.contract.rst
@@ -301,7 +301,6 @@ Each Contract Factory exposes the following methods.
         filter_builder.fromBlock = "latest"
         filter_builder.fromBlock = 0  # raises a ValueError
 
-
 .. py:classmethod:: Contract.encode_abi(fn_name, args=None, kwargs=None, data=None)
 
     Encodes the arguments using the Ethereum ABI for the contract function that
@@ -313,10 +312,6 @@ Each Contract Factory exposes the following methods.
       >>> contract.encode_abi(fn_name="register", args=["rainbows", 10])
       "0xea87152b0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000087261696e626f7773000000000000000000000000000000000000000000000000"
 
-.. py:classmethod:: Contract.encodeABI(fn_name, args=None, kwargs=None, data=None)
-
-    .. deprecated:: 7.0
-      Use :meth:`Contract.encode_abi` instead.
 
 .. py:classmethod:: Contract.all_functions()
 

--- a/ens/async_ens.py
+++ b/ens/async_ens.py
@@ -490,7 +490,7 @@ class AsyncENS(BaseENS):
         ):
             contract_func_with_args = (fn_name, [node])
 
-            calldata = resolver.encodeABI(*contract_func_with_args)
+            calldata = resolver.encode_abi(*contract_func_with_args)
             contract_call_result = await resolver.caller.resolve(
                 ens_encode_name(normal_name),
                 calldata,

--- a/ens/ens.py
+++ b/ens/ens.py
@@ -477,7 +477,7 @@ class ENS(BaseENS):
         if _resolver_supports_interface(resolver, ENS_EXTENDED_RESOLVER_INTERFACE_ID):
             contract_func_with_args = (fn_name, [node])
 
-            calldata = resolver.encodeABI(*contract_func_with_args)
+            calldata = resolver.encode_abi(*contract_func_with_args)
             contract_call_result = resolver.caller.resolve(
                 ens_encode_name(normal_name),
                 calldata,

--- a/newsfragments/3281.removal.rst
+++ b/newsfragments/3281.removal.rst
@@ -1,0 +1,1 @@
+Remove ``Contract.encodeABI()`` in favor of ``Contract.encode_abi()`` to follow standard conventions.

--- a/tests/core/contracts/test_contract_method_abi_encoding.py
+++ b/tests/core/contracts/test_contract_method_abi_encoding.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import patch
 import pytest
 
 from web3 import (
@@ -64,7 +65,7 @@ ABI_D = json.loads(
 )
 def test_contract_abi_encoding(w3, abi, arguments, data, expected):
     contract = w3.eth.contract(abi=abi)
-    actual = contract.encodeABI("a", arguments, data=data)
+    actual = contract.encode_abi("a", arguments, data=data)
     assert actual == expected
 
 
@@ -116,7 +117,7 @@ def test_contract_abi_encoding_non_strict(
     w3_non_strict_abi, abi, arguments, data, expected
 ):
     contract = w3_non_strict_abi.eth.contract(abi=abi)
-    actual = contract.encodeABI("a", arguments, data=data)
+    actual = contract.encode_abi("a", arguments, data=data)
     assert actual == expected
 
 
@@ -128,7 +129,7 @@ def test_contract_abi_encoding_kwargs(w3):
             "0x6f8d2fa18448afbfe4f82143c384484ad09a0271f3a3c0eb9f629e703f883125",
         ],
     }
-    actual = contract.encodeABI("byte_array", kwargs=kwargs)
+    actual = contract.encode_abi("byte_array", kwargs=kwargs)
     assert (
         actual
         == "0xf166d6f8000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000025595c210956e7721f9b692e702708556aa9aabb14ea163e96afa56ffbe9fa8096f8d2fa18448afbfe4f82143c384484ad09a0271f3a3c0eb9f629e703f883125"  # noqa: E501
@@ -146,7 +147,7 @@ def test_contract_abi_encoding_kwargs(w3):
 def test_contract_abi_encoding_strict_with_error(w3, arguments):
     contract = w3.eth.contract(abi=ABI_C)
     with pytest.raises(Web3ValidationError):
-        contract.encodeABI("a", arguments, data=None)
+        contract.encode_abi("a", arguments, data=None)
 
 
 @pytest.mark.parametrize(
@@ -195,5 +196,43 @@ def test_contract_abi_encoding_strict_with_error(w3, arguments):
 )
 def test_contract_abi_encoding_strict(w3, abi, arguments, data, expected):
     contract = w3.eth.contract(abi=abi)
+    actual = contract.encode_abi("a", arguments, data=data)
+    assert actual == expected
+
+
+def test_contract_encodeABI_deprecated(w3):
+    abi = ABI_B
+    arguments = [0]
+
+    contract = w3.eth.contract(abi=abi)
+
+    with pytest.warns(DeprecationWarning):
+        contract.encodeABI("a", arguments)
+
+
+def test_contract_encodeABI_deprecated_returns_encoded(w3):
+    expected = "0xf0fdf8340000000000000000000000000000000000000000000000000000000000000000"
+
+    abi = ABI_B
+    arguments = [0]
+    data = None
+
+    contract = w3.eth.contract(abi=abi)
+
     actual = contract.encodeABI("a", arguments, data=data)
     assert actual == expected
+
+
+
+@patch("web3.eth.Contract.encodeABI", lambda w3, *args, **kwargs: (args, kwargs))
+def test_contract_encodeABI_deprecated_calls_encode_abi_with_args(w3):
+    abi = ABI_B
+    arguments = [0]
+    kwargs = {"x": 1}
+    data = {"secret_code": "12345"}
+
+    contract = w3.eth.contract(abi=abi)
+
+    passed_on_args, passed_on_kwargs = contract.encodeABI("a", arguments, kwargs, data=data)
+    assert passed_on_args == ([0], {"x": 1})
+    assert passed_on_kwargs == {"data": {"secret_code": "12345"}}

--- a/tests/core/contracts/test_contract_method_abi_encoding.py
+++ b/tests/core/contracts/test_contract_method_abi_encoding.py
@@ -1,5 +1,4 @@
 import json
-from unittest.mock import patch
 import pytest
 
 from web3 import (
@@ -198,41 +197,3 @@ def test_contract_abi_encoding_strict(w3, abi, arguments, data, expected):
     contract = w3.eth.contract(abi=abi)
     actual = contract.encode_abi("a", arguments, data=data)
     assert actual == expected
-
-
-def test_contract_encodeABI_deprecated(w3):
-    abi = ABI_B
-    arguments = [0]
-
-    contract = w3.eth.contract(abi=abi)
-
-    with pytest.warns(DeprecationWarning):
-        contract.encodeABI("a", arguments)
-
-
-def test_contract_encodeABI_deprecated_returns_encoded(w3):
-    expected = "0xf0fdf8340000000000000000000000000000000000000000000000000000000000000000"
-
-    abi = ABI_B
-    arguments = [0]
-    data = None
-
-    contract = w3.eth.contract(abi=abi)
-
-    actual = contract.encodeABI("a", arguments, data=data)
-    assert actual == expected
-
-
-
-@patch("web3.eth.Contract.encodeABI", lambda w3, *args, **kwargs: (args, kwargs))
-def test_contract_encodeABI_deprecated_calls_encode_abi_with_args(w3):
-    abi = ABI_B
-    arguments = [0]
-    kwargs = {"x": 1}
-    data = {"secret_code": "12345"}
-
-    contract = w3.eth.contract(abi=abi)
-
-    passed_on_args, passed_on_kwargs = contract.encodeABI("a", arguments, kwargs, data=data)
-    assert passed_on_args == ([0], {"x": 1})
-    assert passed_on_kwargs == {"data": {"secret_code": "12345"}}

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -1336,7 +1336,7 @@ class AsyncEthModuleTest:
         async_revert_contract: "Contract",
         async_unlocked_account: ChecksumAddress,
     ) -> None:
-        data = async_revert_contract.encodeABI(
+        data = async_revert_contract.encode_abi(
             fn_name="UnauthorizedWithMessage", args=["You are not authorized"]
         )
         txn_params = async_revert_contract._prepare_transaction(
@@ -1356,7 +1356,7 @@ class AsyncEthModuleTest:
         async_revert_contract: "Contract",
         async_unlocked_account: ChecksumAddress,
     ) -> None:
-        data = async_revert_contract.encodeABI(fn_name="Unauthorized")
+        data = async_revert_contract.encode_abi(fn_name="Unauthorized")
         txn_params = async_revert_contract._prepare_transaction(
             fn_name="customErrorWithoutMessage",
             transaction={
@@ -3788,7 +3788,7 @@ class EthModuleTest:
         revert_contract: "Contract",
         unlocked_account: ChecksumAddress,
     ) -> None:
-        data = revert_contract.encodeABI(
+        data = revert_contract.encode_abi(
             fn_name="UnauthorizedWithMessage", args=["You are not authorized"]
         )
         txn_params = revert_contract._prepare_transaction(
@@ -3808,7 +3808,7 @@ class EthModuleTest:
         revert_contract: "Contract",
         unlocked_account: ChecksumAddress,
     ) -> None:
-        data = revert_contract.encodeABI(fn_name="Unauthorized")
+        data = revert_contract.encode_abi(fn_name="Unauthorized")
         txn_params = revert_contract._prepare_transaction(
             fn_name="customErrorWithoutMessage",
             transaction={
@@ -4097,7 +4097,7 @@ class EthModuleTest:
         revert_contract: "Contract",
         unlocked_account: ChecksumAddress,
     ) -> None:
-        data = revert_contract.encodeABI(
+        data = revert_contract.encode_abi(
             fn_name="UnauthorizedWithMessage", args=["You are not authorized"]
         )
         txn_params = revert_contract._prepare_transaction(
@@ -4117,7 +4117,7 @@ class EthModuleTest:
         revert_contract: "Contract",
         unlocked_account: ChecksumAddress,
     ) -> None:
-        data = revert_contract.encodeABI(fn_name="Unauthorized")
+        data = revert_contract.encode_abi(fn_name="Unauthorized")
         txn_params = revert_contract._prepare_transaction(
             fn_name="customErrorWithoutMessage",
             transaction={

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -55,7 +55,6 @@ from web3._utils.contracts import (
 from web3._utils.datatypes import (
     PropertyCheckingFactory,
 )
-from web3._utils.decorators import deprecated_for
 from web3._utils.empty import (
     empty,
 )
@@ -723,17 +722,6 @@ class BaseContract:
 
     #  Public API
     #
-    @combomethod
-    @deprecated_for("encode_abi()")
-    def encodeABI(
-        cls,
-        fn_name: str,
-        args: Optional[Any] = None,
-        kwargs: Optional[Any] = None,
-        data: Optional[HexStr] = None,
-    ) -> HexStr:
-        return cls.encode_abi(fn_name, args, kwargs, data)
-
     @combomethod
     def encode_abi(
         cls,

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -55,6 +55,7 @@ from web3._utils.contracts import (
 from web3._utils.datatypes import (
     PropertyCheckingFactory,
 )
+from web3._utils.decorators import deprecated_for
 from web3._utils.empty import (
     empty,
 )
@@ -723,7 +724,18 @@ class BaseContract:
     #  Public API
     #
     @combomethod
+    @deprecated_for("encode_abi()")
     def encodeABI(
+        cls,
+        fn_name: str,
+        args: Optional[Any] = None,
+        kwargs: Optional[Any] = None,
+        data: Optional[HexStr] = None,
+    ) -> HexStr:
+        return cls.encode_abi(fn_name, args, kwargs, data)
+
+    @combomethod
+    def encode_abi(
         cls,
         fn_name: str,
         args: Optional[Any] = None,


### PR DESCRIPTION
### What was wrong?

Closes #3278 

### How was it fixed?

Updated references and removed the encodeABI method.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="395" alt="Screen Shot 2024-03-13 at 11 29 04 AM" src="https://github.com/ethereum/web3.py/assets/435903/2ff53741-502a-4c77-a64f-21cdf97f6f7e">
