### PR TITLE
Defer importing ens._normalization to speed up web3 import by 27%

### DIFF
--- a/ens/utils.py
+++ b/ens/utils.py
@@ -35,9 +35,6 @@ from hexbytes import (
     HexBytes,
 )
 
-from ._normalization import (
-    normalize_name_ensip15,
-)
 from .constants import (
     ACCEPTABLE_STALE_HOURS,
     AUCTION_START_GAS_CONSTANT,
@@ -124,6 +121,11 @@ def normalize_name(name: str) -> str:
     :param str name: the dot-separated ENS name
     :raises InvalidName: if ``name`` has invalid syntax
     """
+    # Defer import because module initialization takes > 0.1 ms
+    from ._normalization import (
+        normalize_name_ensip15,
+    )
+
     if is_empty_name(name):
         return ""
     elif isinstance(name, (bytes, bytearray)):

--- a/newsfragments/3285.performance.rst
+++ b/newsfragments/3285.performance.rst
@@ -1,0 +1,1 @@
+Importing ``ens._normalization`` is deferred until the first call of ``ens.utils.normalize_name`` in order to speed up ``import web3``.

--- a/tests/ens/test_ens.py
+++ b/tests/ens/test_ens.py
@@ -118,7 +118,9 @@ def test_ens_methods_normalize_name(
     # normalizes the full name and each label
     expected_call_args = {"tester.eth", "tester", "eth"}
 
-    with patch("ens.utils.normalize_name_ensip15") as mock_normalize_name_ensip15:
+    with patch(
+        "ens._normalization.normalize_name_ensip15"
+    ) as mock_normalize_name_ensip15:
         mock_normalize_name_ensip15.side_effect = normalize_name_ensip15
 
         # test setup address while appropriately setting up the test
@@ -243,7 +245,9 @@ async def test_async_ens_methods_normalize_name_with_ensip15(
     # normalizes the full name and each label
     expected_call_args = {"tester.eth", "tester", "eth"}
 
-    with patch("ens.utils.normalize_name_ensip15") as mock_normalize_name_ensip15:
+    with patch(
+        "ens._normalization.normalize_name_ensip15"
+    ) as mock_normalize_name_ensip15:
         mock_normalize_name_ensip15.side_effect = normalize_name_ensip15
 
         # test setup address while appropriately setting up the test

--- a/tests/ens/test_utils.py
+++ b/tests/ens/test_utils.py
@@ -174,7 +174,9 @@ def test_normal_name_to_hash(name, hashed):
 def test_name_utility_methods_normalize_the_name_using_ensip15(utility_method):
     # we already have tests for `normalize_name_ensip15` so we just need to make sure
     # the utility methods call it under the hood with the correct arguments
-    with patch("ens.utils.normalize_name_ensip15") as normalize_name_ensip15_mock:
+    with patch(
+        "ens._normalization.normalize_name_ensip15"
+    ) as normalize_name_ensip15_mock:
         utility_method("foo.eth")
         normalize_name_ensip15_mock.assert_called_once_with("foo.eth")
 
@@ -188,7 +190,9 @@ def test_label_to_hash_normalizes_name_using_ensip15():
     )
     assert normalized_name.as_text == "foo.eth"
 
-    with patch("ens.utils.normalize_name_ensip15") as mock_normalize_name_ensip15:
+    with patch(
+        "ens._normalization.normalize_name_ensip15"
+    ) as mock_normalize_name_ensip15:
         for label in normalized_name.labels:
             mock_normalize_name_ensip15.return_value = ENSNormalizedName([label])
 


### PR DESCRIPTION
### What was wrong?

As of version 7.0.0-beta.2 the `import web3` command takes 375 ms to run*, which is quite long for a library import operation. This affects the usability of command-line tools built around web3.py, where import times are critical.

### How was it fixed?

By deferring the import of `ens._normalization` until the first call of the `ens.utils.normalize_name` function, the execution time of `import web3` is reduced to 275 ms* i.e. by 27%.

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

---

### Details

Profiling* showed that the `ens._normalization` module performs two lengthy operations at import time:

- Loading `ens/spec/normalization_spec.json` that is 3 Mbytes in size takes 7% of the total web3 import time
- Executing the `_extract_valid_codepoints()` function that performs transformations on the loaded data takes 16% of the total web3 import time

These are very costly operations to perform at every single import, with the sole purpose of initializing the `ens.utils.normalize_name` function.

*: Measurements were taken with `timeit` and `pyinstrument` on an AMD Ryzen 7 machine with M.2 SSD using Python 3.10.12:
   ```py
   >>> timeit.timeit("import web3")
   ```
   and
   ```bash
   $ pyinstrument --show-regex '.*(eth|web3|ens).*' -c 'import web3'
   ```