### PR TITLE
bump to hexbytes>=1.2.0

### DIFF
--- a/newsfragments/3295.internal.rst
+++ b/newsfragments/3295.internal.rst
@@ -1,0 +1,1 @@
+Bump to ``hexbytes>=1.2.0``

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         "eth-hash[pycryptodome]>=0.5.1",
         "eth-typing>=3.0.0",
         "eth-utils>=4.0.0",
-        "hexbytes>=0.1.0,<0.4.0",
+        "hexbytes>=1.2.0",
         "pydantic>=2.4.0",
         "pywin32>=223;platform_system=='Windows'",
         "requests>=2.16.0",


### PR DESCRIPTION
### What was wrong?

Hexbytes had breaking changes at v1.0.0, and small improvements since. web3 v6 is pinned to <0.4.0.

### How was it fixed?

Move lower hexbytes pin to >=1.2.0

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/5d13384e-2b12-4338-9f60-da2d4aedd1bf)
