### PR TITLE
#3241 Add web3 value error from Web3Exception for exceptions within the library

### DIFF
--- a/tests/core/manager/test_exceptions.py
+++ b/tests/core/manager/test_exceptions.py
@@ -1,19 +1,32 @@
 import pytest
-from unittest.mock import patch
-from web3 import Web3
-from web3.manager import RequestManager
-from web3.exceptions import Web3ValueError
+from unittest.mock import (
+    patch,
+)
+
+from web3 import (
+    Web3,
+)
+from web3.exceptions import (
+    Web3ValueError,
+)
+from web3.manager import (
+    RequestManager,
+)
 
 
 def test_formatted_response_with_missing_trie_node_exception():
     # Simulated error response mimicking what might come from an RPC call
+    message = (
+        "missing trie node "
+        "7a8d16362e6dbe9cd83ec5c1b865f687e66aaa704eb7e2fdc823518a650174af"
+    )
     error_response = {
         "jsonrpc": "2.0",
         "id": 1,
         "error": {
             "code": -32000,
-            "message": "missing trie node 7a8d16362e6dbe9cd83ec5c1b865f687e66aaa704eb7e2fdc823518a650174af"
-        }
+            "message": message,
+        },
     }
 
     # Initialize a RequestManager instance
@@ -21,11 +34,13 @@ def test_formatted_response_with_missing_trie_node_exception():
     manager = RequestManager(w3=web3_instance)
 
     # Mock _make_request to return the error response
-    with patch.object(RequestManager, '_make_request', return_value=error_response):
-        # Verify that calling request_blocking raises a Web3ValueError due to the error in the response
+    with patch.object(RequestManager, "_make_request", return_value=error_response):
+        # Verify that calling request_blocking raises
+        # a Web3ValueError due to the error in the response
         with pytest.raises(Web3ValueError) as exc_info:
             manager.request_blocking("eth_getBalance", ["0x0", "latest"])
 
-        # Check that the exception message contains the expected error message and Web3ValueError type
+        # Check that the exception message contains the
+        # expected error message and Web3ValueError type
         assert "missing trie node" in str(exc_info.value)
         assert exc_info.type == Web3ValueError

--- a/tests/core/manager/test_exceptions.py
+++ b/tests/core/manager/test_exceptions.py
@@ -1,0 +1,31 @@
+import pytest
+from unittest.mock import patch
+from web3 import Web3
+from web3.manager import RequestManager
+from web3.exceptions import Web3ValueError
+
+
+def test_formatted_response_with_missing_trie_node_exception():
+    # Simulated error response mimicking what might come from an RPC call
+    error_response = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "error": {
+            "code": -32000,
+            "message": "missing trie node 7a8d16362e6dbe9cd83ec5c1b865f687e66aaa704eb7e2fdc823518a650174af"
+        }
+    }
+
+    # Initialize a RequestManager instance
+    web3_instance = Web3()
+    manager = RequestManager(w3=web3_instance)
+
+    # Mock _make_request to return the error response
+    with patch.object(RequestManager, '_make_request', return_value=error_response):
+        # Verify that calling request_blocking raises a Web3ValueError due to the error in the response
+        with pytest.raises(Web3ValueError) as exc_info:
+            manager.request_blocking("eth_getBalance", ["0x0", "latest"])
+
+        # Check that the exception message contains the expected error message and Web3ValueError type
+        assert "missing trie node" in str(exc_info.value)
+        assert exc_info.type == Web3ValueError

--- a/tests/core/providers/test_ipc_provider.py
+++ b/tests/core/providers/test_ipc_provider.py
@@ -120,7 +120,6 @@ def test_get_dev_ipc_path_(provider_env_uri, platform, expected_result, expected
                 "WEB3_PROVIDER_URI": provider_env_uri,
             },
         ):
-
             if provider_env_uri:
                 assert get_dev_ipc_path() == provider_env_uri
             elif expected_error:

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -43,15 +43,17 @@ class Web3Exception(Exception):
 
 class Web3ValueError(Web3Exception):
     """
-    Exception raised when an invalid value is encountered by the Web3 library. This error is typically
-    thrown in situations where the provided value does not meet the required format, type, or range expected
-    by a Web3 method or operation. For instance, this could occur when an incorrect address format is used,
-    when parameters do not match an expected pattern, or when a response from the blockchain is not in the
-    anticipated format or structure. It serves as an indicator that user input or the response content needs
-    to be reviewed and corrected.
+    Exception raised when an invalid value is encountered by the Web3 library.
+    This error is typically thrown in situations where the provided value does
+    not meet the required format, type, or range expected by a Web3 method or
+    operation. For instance, this could occur when an incorrect address format is
+    used, when parameters do not match an expected pattern, or when a response from
+    the blockchain is not in the anticipated format or structure. It serves as an
+    indicator that user input or the response content needs to be reviewed
+    and corrected.
     """
-    pass
 
+    pass
 
 
 class BadFunctionCallOutput(Web3Exception):

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -41,6 +41,19 @@ class Web3Exception(Exception):
         self.user_message = user_message
 
 
+class Web3ValueError(Web3Exception):
+    """
+    Exception raised when an invalid value is encountered by the Web3 library. This error is typically
+    thrown in situations where the provided value does not meet the required format, type, or range expected
+    by a Web3 method or operation. For instance, this could occur when an incorrect address format is used,
+    when parameters do not match an expected pattern, or when a response from the blockchain is not in the
+    anticipated format or structure. It serves as an indicator that user input or the response content needs
+    to be reviewed and corrected.
+    """
+    pass
+
+
+
 class BadFunctionCallOutput(Web3Exception):
     """
     We failed to decode ABI output.

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -34,8 +34,9 @@ from web3.datastructures import (
 )
 from web3.exceptions import (
     BadResponseFormat,
-    MethodUnavailable, Web3ValueError,
-
+    MethodUnavailable,
+    ProviderConnectionError,
+    Web3ValueError,
 )
 from web3.middleware import (
     AttributeDictMiddleware,

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -34,8 +34,8 @@ from web3.datastructures import (
 )
 from web3.exceptions import (
     BadResponseFormat,
-    MethodUnavailable,
-    ProviderConnectionError,
+    MethodUnavailable, Web3ValueError,
+
 )
 from web3.middleware import (
     AttributeDictMiddleware,
@@ -239,7 +239,7 @@ class RequestManager:
             error = response.get("error")
             # Raise the error when the value is a string
             if error is None or isinstance(error, str):
-                raise ValueError(error)
+                raise Web3ValueError(error)
 
             # Errors must include an integer code
             code = error.get("code")
@@ -260,7 +260,7 @@ class RequestManager:
 
             apply_error_formatters(error_formatters, response)
 
-            raise ValueError(error)
+            raise Web3ValueError(error)
 
         # Format and validate results
         elif "result" in response:


### PR DESCRIPTION
### What was wrong?
The issue was identified in the RequestManager class of the Web3.py library, where error responses were not being handled as expected, leading to ambiguity in error handling. The exception `ValueError` is making it difficult for developers to understand the context and use case of the error they are currently getting.

Related to Issue [#3241 ](https://github.com/ethereum/web3.py/issues/3241)

### How was it fixed?
   - Added the `Web3ValueError` exception class to explicitly represent errors related to invalid values within the Web3.py context. This class enhances the granularity of error handling by distinctly addressing value-related issues.

   - Integrated the `Web3ValueError` within the `formatted_response` method of the `RequestManager`. Now, when `formatted_response` encounters an error condition indicative of a value issue, it raises `Web3ValueError`, thereby providing a more specific and meaningful error to the developer.

### Todo:
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->]()
