### PR TITLE
[V6] Fix internal typing for functions used by `process_log`

### DIFF
--- a/newsfragments/3301.internal.rst
+++ b/newsfragments/3301.internal.rst
@@ -1,0 +1,1 @@
+Fix internal typing for functions used by ``process_log``.


### PR DESCRIPTION
### What was wrong?

Related to #3292

Typing issues caused when removing `@curry` annotation.

### How was it fixed?

Removed annotation and fixed typing.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="663" alt="Screen Shot 2024-03-25 at 1 39 39 PM" src="https://github.com/ethereum/web3.py/assets/435903/2c39f2d4-cddb-45c2-9c9c-8df8d6c87808">
