### PR TITLE
closes #3255: fix typing for eth_signTypedData

### DIFF
--- a/newsfragments/3308.bugfix.rst
+++ b/newsfragments/3308.bugfix.rst
@@ -1,0 +1,1 @@
+Fix typing for json data argument to ``eth_signTypedData``.

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -4,6 +4,7 @@ from typing import (
     Any,
     Awaitable,
     Callable,
+    Dict,
     List,
     Optional,
     Tuple,
@@ -637,14 +638,16 @@ class AsyncEth(BaseEth):
     # eth_signTypedData
 
     _sign_typed_data: Method[
-        Callable[[Union[Address, ChecksumAddress, ENS], str], Awaitable[HexStr]]
+        Callable[
+            [Union[Address, ChecksumAddress, ENS], Dict[str, Any]], Awaitable[HexStr]
+        ]
     ] = Method(
         RPC.eth_signTypedData,
         mungers=[default_root_munger],
     )
 
     async def sign_typed_data(
-        self, account: Union[Address, ChecksumAddress, ENS], data: str
+        self, account: Union[Address, ChecksumAddress, ENS], data: Dict[str, Any]
     ) -> HexStr:
         return await self._sign_typed_data(account, data)
 

--- a/web3/eth/eth.py
+++ b/web3/eth/eth.py
@@ -2,6 +2,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Dict,
     List,
     Optional,
     Sequence,
@@ -622,7 +623,7 @@ class Eth(BaseEth):
     # eth_signTypedData
 
     sign_typed_data: Method[
-        Callable[[Union[Address, ChecksumAddress, ENS], str], HexStr]
+        Callable[[Union[Address, ChecksumAddress, ENS], Dict[str, Any]], HexStr]
     ] = Method(
         RPC.eth_signTypedData,
         mungers=[default_root_munger],


### PR DESCRIPTION
### What was wrong?

closes #3255 

### How was it fixed?

- According to the [spec](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md), and our documentation, it is the dictionary itself that is passed in, not the `str` representation.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

`0_o`
