### PR TITLE
Fix typing for eth sign typed data args

### DIFF
--- a/newsfragments/3311.bugfix.rst
+++ b/newsfragments/3311.bugfix.rst
@@ -1,0 +1,1 @@
+Fix typing for json data argument to ``eth_signTypedData``.

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -4,6 +4,7 @@ from typing import (
     Any,
     Awaitable,
     Callable,
+    Dict,
     List,
     Optional,
     Tuple,
@@ -619,14 +620,16 @@ class AsyncEth(BaseEth):
     # eth_signTypedData
 
     _sign_typed_data: Method[
-        Callable[[Union[Address, ChecksumAddress, ENS], str], Awaitable[HexStr]]
+        Callable[
+            [Union[Address, ChecksumAddress, ENS], Dict[str, Any]], Awaitable[HexStr]
+        ]
     ] = Method(
         RPC.eth_signTypedData,
         mungers=[default_root_munger],
     )
 
     async def sign_typed_data(
-        self, account: Union[Address, ChecksumAddress, ENS], data: str
+        self, account: Union[Address, ChecksumAddress, ENS], data: Dict[str, Any]
     ) -> HexStr:
         return await self._sign_typed_data(account, data)
 

--- a/web3/eth/eth.py
+++ b/web3/eth/eth.py
@@ -2,6 +2,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Dict,
     List,
     Optional,
     Sequence,
@@ -611,7 +612,7 @@ class Eth(BaseEth):
     # eth_signTypedData
 
     sign_typed_data: Method[
-        Callable[[Union[Address, ChecksumAddress, ENS], str], HexStr]
+        Callable[[Union[Address, ChecksumAddress, ENS], Dict[str, Any]], HexStr]
     ] = Method(
         RPC.eth_signTypedData,
         mungers=[default_root_munger],


### PR DESCRIPTION
### What was wrong?

v6 backport of #3308

### How was it fixed?

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

`o_0`