### PR TITLE
[V6] cancun tx field formatters

### DIFF
--- a/newsfragments/3315.feature.rst
+++ b/newsfragments/3315.feature.rst
@@ -1,0 +1,1 @@
+Add formatters for type 3 transaction fields ``maxFeePerBlobGas`` and ``blobVersionedHashes``.

--- a/tests/core/utilities/test_valid_transaction_params.py
+++ b/tests/core/utilities/test_valid_transaction_params.py
@@ -82,6 +82,10 @@ FULL_TXN_DICT = {
         },
         {"address": "0xbb9bc244d798123fde783fcc1c72d3bb8c189413", "storageKeys": ()},
     ),
+    "maxFeePerBlobGas": 2000000000,
+    "blobVersionedHashes": (
+        "0x01a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+    ),
 }
 
 

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -233,6 +233,10 @@ TRANSACTION_RESULT_FORMATTERS = {
     ),
     "input": HexBytes,
     "data": HexBytes,  # Nethermind, for example, returns both `input` and `data`
+    "maxFeePerBlobGas": to_integer_if_hex,
+    "blobVersionedHashes": apply_formatter_if(
+        is_not_null, apply_formatter_to_array(to_hexbytes(32))
+    ),
 }
 
 

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -49,6 +49,8 @@ TX_PARAM_LITERALS = Literal[
     "nonce",
     "chainId",
     "accessList",
+    "maxFeePerBlobGas",
+    "blobVersionedHashes",
 ]
 
 VALID_TRANSACTION_PARAMS: List[TX_PARAM_LITERALS] = [
@@ -64,6 +66,8 @@ VALID_TRANSACTION_PARAMS: List[TX_PARAM_LITERALS] = [
     "data",
     "nonce",
     "chainId",
+    "maxFeePerBlobGas",
+    "blobVersionedHashes",
 ]
 
 TRANSACTION_DEFAULTS = {

--- a/web3/types.py
+++ b/web3/types.py
@@ -138,6 +138,7 @@ TxData = TypedDict(
     "TxData",
     {
         "accessList": AccessList,
+        "blobVersionedHashes": Sequence[HexBytes],
         "blockHash": HexBytes,
         "blockNumber": BlockNumber,
         "chainId": int,
@@ -145,6 +146,7 @@ TxData = TypedDict(
         "from": ChecksumAddress,
         "gas": int,
         "gasPrice": Wei,
+        "maxFeePerBlobGas": Wei,
         "maxFeePerGas": Wei,
         "maxPriorityFeePerGas": Wei,
         "hash": HexBytes,


### PR DESCRIPTION
### What was wrong?

`v6` backport of #3314

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="618" alt="Screenshot 2024-03-28 at 12 56 18" src="https://github.com/ethereum/web3.py/assets/3532824/91c27e4a-c149-48ce-9d81-575a65bb5661">
