### PR TITLE
v6 backport of #3306: async pop message from queue

### DIFF
--- a/newsfragments/3305.performance.rst
+++ b/newsfragments/3305.performance.rst
@@ -1,0 +1,1 @@
+Utilize ``async`` functionality when popping responses from request manager cache for persistent connection providers.

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from typing import (
     TYPE_CHECKING,
@@ -378,11 +377,7 @@ class RequestManager:
             raise ProviderConnectionError("No listener found for websocket connection.")
 
         while True:
-            # sleep(0) here seems to be the most efficient way to yield control
-            # back to the event loop while waiting for the response in the queue.
-            await asyncio.sleep(0)
-
-            response = self._request_processor.pop_raw_response(subscription=True)
+            response = await self._request_processor.pop_raw_response(subscription=True)
             if (
                 response is not None
                 and response.get("params", {}).get("subscription")

--- a/web3/providers/websocket/request_processor.py
+++ b/web3/providers/websocket/request_processor.py
@@ -222,19 +222,17 @@ class RequestProcessor:
             )
             self._request_response_cache.cache(cache_key, raw_response)
 
-    def pop_raw_response(
+    async def pop_raw_response(
         self, cache_key: str = None, subscription: bool = False
     ) -> Any:
         if subscription:
             qsize = self._subscription_response_queue.qsize()
-            if qsize == 0:
-                return None
+            raw_response = await self._subscription_response_queue.get()
 
             if not self._provider._listen_event.is_set():
                 self._provider._listen_event.set()
 
-            raw_response = self._subscription_response_queue.get_nowait()
-            if qsize == 1:
+            if qsize == 0:
                 if not self._subscription_queue_synced_with_ws_stream:
                     self._subscription_queue_synced_with_ws_stream = True
                     self._provider.logger.info(

--- a/web3/providers/websocket/websocket_v2.py
+++ b/web3/providers/websocket/websocket_v2.py
@@ -188,7 +188,7 @@ class WebsocketProviderV2(PersistentConnectionProvider):
                     self.logger.debug(
                         f"Popping response for id {request_id} from cache."
                     )
-                    popped_response = self._request_processor.pop_raw_response(
+                    popped_response = await self._request_processor.pop_raw_response(
                         cache_key=request_cache_key,
                     )
                     return popped_response


### PR DESCRIPTION
### What was wrong?

`v6` backport of #3306 

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.squarespace-cdn.com/content/v1/51cdafc4e4b09eb676a64e68/1470759791755-P1DBVYSIVA5V4NAWP0T6/nemo5.jpg)
