### PR TITLE
remove code that was needed for py<=37

### DIFF
--- a/newsfragments/3317.internal.rst
+++ b/newsfragments/3317.internal.rst
@@ -1,0 +1,1 @@
+Remove code conditionally necessary for ``python<=3.7``

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ extras_require = {
         "bumpversion",
         "flaky>=3.7.0",
         "hypothesis>=3.31.2",
-        "importlib-metadata<5.0;python_version<'3.8'",
         "pytest>=7.0.0",
         "pytest-asyncio>=0.18.1,<0.23",
         "pytest-mock>=1.10",

--- a/web3/__init__.py
+++ b/web3/__init__.py
@@ -1,14 +1,9 @@
 from eth_account import Account  # noqa: E402
 import sys
 
-if sys.version_info.major == 3 and sys.version_info.minor < 8:
-    import pkg_resources
+from importlib.metadata import version
 
-    __version__ = pkg_resources.get_distribution("web3").version
-else:
-    from importlib.metadata import version
-
-    __version__ = version("web3")
+__version__ = version("web3")
 
 
 from web3.main import (

--- a/web3/_utils/compat/__init__.py
+++ b/web3/_utils/compat/__init__.py
@@ -9,9 +9,6 @@
 # imported from `typing`
 
 from typing_extensions import (
-    Literal,  # py38
     NotRequired,  # py311
-    Protocol,  # py38
-    TypedDict,  # py38
     Self,  # py311
 )

--- a/web3/_utils/empty.py
+++ b/web3/_utils/empty.py
@@ -1,4 +1,4 @@
-from web3._utils.compat import (
+from typing import (
     Literal,
 )
 

--- a/web3/_utils/module_testing/module_testing_utils.py
+++ b/web3/_utils/module_testing/module_testing_utils.py
@@ -7,6 +7,7 @@ from typing import (
     Collection,
     Dict,
     Generator,
+    Literal,
     Sequence,
     Union,
 )
@@ -28,9 +29,6 @@ from hexbytes import (
     HexBytes,
 )
 
-from web3._utils.compat import (
-    Literal,
-)
 from web3._utils.request import (
     async_cache_and_return_session,
     cache_and_return_session,

--- a/web3/_utils/threads.py
+++ b/web3/_utils/threads.py
@@ -12,12 +12,10 @@ from typing import (
     Any,
     Callable,
     Generic,
+    Literal,
     Type,
 )
 
-from web3._utils.compat import (
-    Literal,
-)
 from web3.types import (
     TReturn,
 )

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -2,6 +2,7 @@ import math
 from typing import (
     TYPE_CHECKING,
     List,
+    Literal,
     Optional,
     Union,
     cast,
@@ -19,9 +20,6 @@ from hexbytes import (
     HexBytes,
 )
 
-from web3._utils.compat import (
-    Literal,
-)
 from web3._utils.utility_methods import (
     all_in_dict,
     any_in_dict,

--- a/web3/geth.py
+++ b/web3/geth.py
@@ -5,6 +5,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Protocol,
     Tuple,
 )
 
@@ -18,9 +19,6 @@ from hexbytes.main import (
     HexBytes,
 )
 
-from web3._utils.compat import (
-    Protocol,
-)
 from web3._utils.rpc_abi import (
     RPC,
 )

--- a/web3/middleware/formatting.py
+++ b/web3/middleware/formatting.py
@@ -3,6 +3,7 @@ from typing import (
     Any,
     Callable,
     Coroutine,
+    Literal,
     Optional,
     Union,
     cast,
@@ -21,7 +22,6 @@ from web3.types import (
     EthSubscriptionParams,
     Formatters,
     FormattersDict,
-    Literal,
     RPCEndpoint,
     RPCResponse,
 )

--- a/web3/providers/eth_tester/main.py
+++ b/web3/providers/eth_tester/main.py
@@ -4,6 +4,7 @@ from typing import (
     Callable,
     Coroutine,
     Dict,
+    Literal,
     Optional,
     Union,
 )
@@ -18,9 +19,6 @@ from eth_utils import (
     is_bytes,
 )
 
-from web3._utils.compat import (
-    Literal,
-)
 from web3.providers import (
     BaseProvider,
 )

--- a/web3/types.py
+++ b/web3/types.py
@@ -5,10 +5,12 @@ from typing import (
     Coroutine,
     Dict,
     List,
+    Literal,
     NewType,
     Optional,
     Sequence,
     Type,
+    TypedDict,
     TypeVar,
     Union,
 )
@@ -25,9 +27,7 @@ from hexbytes import (
 )
 
 from web3._utils.compat import (
-    Literal,
     NotRequired,
-    TypedDict,
 )
 from web3._utils.function_identifiers import (
     FallbackFn,


### PR DESCRIPTION
### What was wrong?

Removing code that was conditionally needed for `python<=3.7`

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/800a76e8-91fc-4e00-acdf-375edbef25d1)
