### PR TITLE
Retrieve endpoint_uri or ipc_path from base persistent provider class

### DIFF
--- a/newsfragments/3319.bugfix.rst
+++ b/newsfragments/3319.bugfix.rst
@@ -1,0 +1,1 @@
+Fix misused call to `endpoint_uri` for all cases of ``PersistentConnectionProvider`` by being able to retrieve either the ``ipc_path`` or the ``endpoint_uri`` from the base class with ``endpoint_uri_or_ipc_path`` property.

--- a/tests/core/providers/test_async_ipc_provider.py
+++ b/tests/core/providers/test_async_ipc_provider.py
@@ -168,3 +168,10 @@ async def test_eth_subscription(jsonrpc_ipc_pipe_path, serve_subscription_result
             assert response == subscription_response
             break
         await w3.provider.disconnect()
+
+
+def test_get_endpoint_uri_or_ipc_path_returns_ipc_path():
+    provider = AsyncIPCProvider(pathlib.Path("/path/to/file"))
+    assert (
+        provider.get_endpoint_uri_or_ipc_path() == "/path/to/file" == provider.ipc_path
+    )

--- a/tests/core/providers/test_websocket_provider.py
+++ b/tests/core/providers/test_websocket_provider.py
@@ -262,3 +262,12 @@ async def test_listen_event_awaits_msg_processing_when_subscription_queue_is_ful
 
     # proper cleanup
     await async_w3.provider.disconnect()
+
+
+def test_get_endpoint_uri_or_ipc_path_returns_endpoint_uri():
+    provider = WebSocketProvider("ws://mocked")
+    assert (
+        provider.get_endpoint_uri_or_ipc_path()
+        == "ws://mocked"
+        == provider.endpoint_uri
+    )

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -323,8 +323,8 @@ class RequestManager:
             cast("AsyncWeb3", self.w3), cast("MiddlewareOnion", self.middleware_onion)
         )
         self.logger.debug(
-            "Making request to open socket connection - "
-            f"uri: {provider.endpoint_uri}, method: {method}"
+            "Making request to open socket connection: "
+            f"{provider.endpoint_uri_or_ipc_path}, method: {method}"
         )
         response = await request_func(method, params)
         return await self._process_response(response)

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -324,7 +324,7 @@ class RequestManager:
         )
         self.logger.debug(
             "Making request to open socket connection: "
-            f"{provider.endpoint_uri_or_ipc_path}, method: {method}"
+            f"{provider.get_endpoint_uri_or_ipc_path()}, method: {method}"
         )
         response = await request_func(method, params)
         return await self._process_response(response)

--- a/web3/providers/persistent/async_ipc.py
+++ b/web3/providers/persistent/async_ipc.py
@@ -114,11 +114,11 @@ class AsyncIPCProvider(PersistentConnectionProvider):
             except OSError as e:
                 if _connection_attempts == self._max_connection_retries:
                     raise ProviderConnectionError(
-                        f"Could not connect to endpoint: {self.endpoint_uri}. "
+                        f"Could not connect to: {self.ipc_path}. "
                         f"Retries exceeded max of {self._max_connection_retries}."
                     ) from e
                 self.logger.info(
-                    f"Could not connect to endpoint: {self.endpoint_uri}. Retrying in "
+                    f"Could not connect to: {self.ipc_path}. Retrying in "
                     f"{round(_backoff_time, 1)} seconds.",
                     exc_info=True,
                 )
@@ -130,9 +130,7 @@ class AsyncIPCProvider(PersistentConnectionProvider):
             self._writer.close()
             await self._writer.wait_closed()
             self._writer = None
-            self.logger.debug(
-                f'Successfully disconnected from endpoint: "{self.endpoint_uri}'
-            )
+            self.logger.debug(f'Successfully disconnected from : "{self.ipc_path}')
 
         try:
             self._message_listener_task.cancel()

--- a/web3/providers/persistent/persistent.py
+++ b/web3/providers/persistent/persistent.py
@@ -49,8 +49,7 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
         self.request_timeout = request_timeout
         self.silence_listener_task_exceptions = silence_listener_task_exceptions
 
-    @property
-    def endpoint_uri_or_ipc_path(self) -> str:
+    def get_endpoint_uri_or_ipc_path(self) -> str:
         if hasattr(self, "endpoint_uri"):
             return str(self.endpoint_uri)
         elif hasattr(self, "ipc_path"):

--- a/web3/providers/persistent/persistent.py
+++ b/web3/providers/persistent/persistent.py
@@ -30,7 +30,6 @@ DEFAULT_PERSISTENT_CONNECTION_TIMEOUT = 30.0
 class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
     logger = logging.getLogger("web3.providers.PersistentConnectionProvider")
     has_persistent_connection = True
-    endpoint_uri: Optional[str] = None
 
     _request_processor: RequestProcessor
     _message_listener_task: Optional["asyncio.Task[None]"] = None
@@ -49,6 +48,18 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
         )
         self.request_timeout = request_timeout
         self.silence_listener_task_exceptions = silence_listener_task_exceptions
+
+    @property
+    def endpoint_uri_or_ipc_path(self) -> str:
+        if hasattr(self, "endpoint_uri"):
+            return str(self.endpoint_uri)
+        elif hasattr(self, "ipc_path"):
+            return str(self.ipc_path)
+        else:
+            raise AttributeError(
+                "`PersistentConnectionProvider` must have either `endpoint_uri` or "
+                "`ipc_path` attribute."
+            )
 
     async def connect(self) -> None:
         raise NotImplementedError("Must be implemented by subclasses")

--- a/web3/providers/persistent/websocket.py
+++ b/web3/providers/persistent/websocket.py
@@ -71,9 +71,9 @@ class WebSocketProvider(PersistentConnectionProvider):
         # `PersistentConnectionProvider` kwargs can be passed through
         **kwargs: Any,
     ) -> None:
-        self.endpoint_uri = URI(endpoint_uri)
-        if self.endpoint_uri is None:
-            self.endpoint_uri = get_default_endpoint()
+        self.endpoint_uri = (
+            URI(endpoint_uri) if endpoint_uri is not None else get_default_endpoint()
+        )
 
         if not any(
             self.endpoint_uri.startswith(prefix)


### PR DESCRIPTION
### What was wrong?

- closes #3264

Since we defined `endpoint_uri` at the `PersistentConnectionProvider` level, we used it in the `manager.py` since it wouldn't raise any attribute errors. Rather than rename the `ipc_path` in `AsyncIPCProvider`, I think it makes sense to have this separation of paths but be able to retrieve either path from the base class as well since we may want to implement logic for the base class (as is the case in `manager.py`).

### How was it fixed?

- Implement `endpoint_uri_or_ipc_path` property in the base class to be able to return the proper path depending on the type of persistent connection provider.

### Todo:
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fwww.wired.com%2Fwp-content%2Fuploads%2F2015%2F04%2F85120553.jpg&f=1&nofb=1&ipt=538256853629d677f327a8b44059a56d9b8c6266d27817ff856774d99c7046bd&ipo=images)
