### PR TITLE
[v6] backport of #3322

### DIFF
--- a/newsfragments/3323.feature.rst
+++ b/newsfragments/3323.feature.rst
@@ -1,0 +1,1 @@
+Add request formatter for ``maxFeePerBlobGas`` when sending blob transactions. Add formatters for ``blobGasPrice`` and ``blobGasUsed`` for *eth_getTransactionReceipt*.

--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -231,6 +231,11 @@ def test_eth_wait_for_transaction_receipt_transaction_indexing_in_progress(w3):
 def test_get_transaction_formatters(w3):
     non_checksummed_addr = "0xB2930B35844A230F00E51431ACAE96FE543A0347"  # all uppercase
     unformatted_transaction = {
+        "blobVersionedHashes": [
+            "0x01b8c5b09810b5fc07355d3da42e2c3a3e200c1d9a678491b7e8e256fc50cc4f",
+            "0x015b4c8cc4f86aa2d2cf9e9ce97fca704a11a6c20f6b1d6c00a6e15f6d60a6df",
+            "0x01878f80eaf10be1a6f618e6f8c071b10a6c14d9b89a3bf2a3f3cf2db6c5681d",
+        ],
         "blockHash": (
             "0x849044202a39ae36888481f90d62c3826bca8269c2716d7a38696b4f45e61d83"
         ),
@@ -239,6 +244,7 @@ def test_get_transaction_formatters(w3):
         "nonce": "0x0",
         "gas": "0x4c4b40",
         "gasPrice": "0x1",
+        "maxFeePerBlobGas": "0x1",
         "maxFeePerGas": "0x1",
         "maxPriorityFeePerGas": "0x1",
         "value": "0x1",
@@ -286,12 +292,24 @@ def test_get_transaction_formatters(w3):
 
     expected = AttributeDict(
         {
+            "blobVersionedHashes": [
+                HexBytes(
+                    "0x01b8c5b09810b5fc07355d3da42e2c3a3e200c1d9a678491b7e8e256fc50cc4f"
+                ),
+                HexBytes(
+                    "0x015b4c8cc4f86aa2d2cf9e9ce97fca704a11a6c20f6b1d6c00a6e15f6d60a6df"
+                ),
+                HexBytes(
+                    "0x01878f80eaf10be1a6f618e6f8c071b10a6c14d9b89a3bf2a3f3cf2db6c5681d"
+                ),
+            ],
             "blockHash": HexBytes(unformatted_transaction["blockHash"]),
             "blockNumber": to_int(hexstr=unformatted_transaction["blockNumber"]),
             "transactionIndex": 0,
             "nonce": 0,
             "gas": to_int(hexstr=unformatted_transaction["gas"]),
             "gasPrice": 1,
+            "maxFeePerBlobGas": 1,
             "maxFeePerGas": 1,
             "maxPriorityFeePerGas": 1,
             "value": 1,

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -285,6 +285,8 @@ RECEIPT_FORMATTERS = {
     "to": apply_formatter_if(is_address, to_checksum_address),
     "effectiveGasPrice": to_integer_if_hex,
     "type": to_integer_if_hex,
+    "blobGasPrice": to_integer_if_hex,
+    "blobGasUsed": to_integer_if_hex,
 }
 
 

--- a/web3/_utils/rpc_abi.py
+++ b/web3/_utils/rpc_abi.py
@@ -167,6 +167,7 @@ TRANSACTION_PARAMS_ABIS = {
     "from": "address",
     "gas": "uint",
     "gasPrice": "uint",
+    "maxFeePerBlobGas": "uint",
     "maxFeePerGas": "uint",
     "maxPriorityFeePerGas": "uint",
     "nonce": "uint",


### PR DESCRIPTION
### What was wrong?

back port of #3322 

### Todo:

- [x] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20240401_090626](https://github.com/ethereum/web3.py/assets/3532824/4bdaebed-88ad-42ad-9e91-00590468fd19)
