### PR TITLE
add upperpin for eth-typing for removal of ethpm types

### DIFF
--- a/newsfragments/3324.internal.rst
+++ b/newsfragments/3324.internal.rst
@@ -1,0 +1,1 @@
+Add an upperpin at ``eth-typing<4.2.0`` due to removal of EthPM types in that lib

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         "eth-abi>=4.0.0",
         "eth-account>=0.8.0",
         "eth-hash[pycryptodome]>=0.5.1",
-        "eth-typing>=3.0.0",
+        "eth-typing>=3.0.0,<4.2.0",
         "eth-utils>=2.1.0",
         "hexbytes>=0.1.0,<0.4.0",
         "jsonschema>=4.0.0",


### PR DESCRIPTION
### What was wrong?

The next release of `eth-typing` will remove types related to the EthPM module which is removed in v7 here. This adds an upper pin to `eth-typing` at it's current release of `4.1.0` so (in the unlikely event anyone uses it) types will be available for EthPM.

### How was it fixed?

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/fce706ef-c40c-461a-8257-fde8b910a973)
