### PR TITLE
Update ``EthereumTesterProvider`` to support cancun

### DIFF
--- a/newsfragments/3332.feature.rst
+++ b/newsfragments/3332.feature.rst
@@ -1,0 +1,1 @@
+Add Cancun support to ``EthereumTesterProvider``; update Cancun-related fields in some internal types.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import (
 
 extras_require = {
     "tester": [
-        "eth-tester[py-evm]==v0.10.0-b.3",
+        "eth-tester[py-evm]>=0.11.0b1,<0.12.0b1",
         "py-geth>=4.1.0",
     ],
     "linter": [

--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -341,6 +341,40 @@ def test_get_transaction_formatters(w3, request_mocker):
     assert received_tx == expected
 
 
+def test_eth_send_raw_blob_transaction(w3):
+    # `eth-tester` account #1's pkey is "0x00000000...01"
+    acct = w3.eth.account.from_key(f"0x{'00' * 31}01")
+
+    text = "We are the music makers and we are the dreamers of dreams."
+    encoded_text = w3.codec.encode(["string"], [text])
+    # Blobs contain 4096 32-byte field elements. Subtract the length of the encoded text
+    # divided into 32-byte chunks from 4096 and pad the rest with zeros.
+    blob_data = (b"\x00" * 32 * (4096 - len(encoded_text) // 32)) + encoded_text
+
+    tx = {
+        "type": 3,
+        "chainId": 1337,
+        "from": acct.address,
+        "to": "0xb45BEc6eeCA2a09f4689Dd308F550Ad7855051B5",
+        "value": 0,
+        "gas": 21000,
+        "maxFeePerGas": 10**10,
+        "maxPriorityFeePerGas": 10**10,
+        "maxFeePerBlobGas": 10**10,
+        "nonce": w3.eth.get_transaction_count(acct.address),
+    }
+
+    signed = acct.sign_transaction(tx, blobs=[blob_data])
+
+    tx_hash = w3.eth.send_raw_transaction(signed.rawTransaction)
+    transaction = w3.eth.get_transaction(tx_hash)
+
+    assert len(transaction["blobVersionedHashes"]) == 1
+    assert transaction["blobVersionedHashes"][0] == HexBytes(
+        "0x0127c38bcad458d932e828b580b9ad97310be01407dfa0ed88118735980a3e9a"
+    )
+
+
 # --- async --- #
 
 
@@ -355,3 +389,38 @@ async def test_async_wait_for_transaction_receipt_transaction_indexing_in_progre
     ):
         receipt = await async_w3.eth.wait_for_transaction_receipt(f"0x{'00' * 32}")
         assert receipt == {"status": 1}
+
+
+@pytest.mark.asyncio
+async def test_async_send_raw_blob_transaction(async_w3):
+    # `eth-tester` account #1's pkey is "0x00000000...01"
+    acct = async_w3.eth.account.from_key(f"0x{'00' * 31}01")
+
+    text = "We are the music makers and we are the dreamers of dreams."
+    encoded_text = async_w3.codec.encode(["string"], [text])
+    # Blobs contain 4096 32-byte field elements. Subtract the length of the encoded text
+    # divided into 32-byte chunks from 4096 and pad the rest with zeros.
+    blob_data = (b"\x00" * 32 * (4096 - len(encoded_text) // 32)) + encoded_text
+
+    tx = {
+        "type": 3,
+        "chainId": 1337,
+        "from": acct.address,
+        "to": "0xb45BEc6eeCA2a09f4689Dd308F550Ad7855051B5",
+        "value": 0,
+        "gas": 21000,
+        "maxFeePerGas": 10**10,
+        "maxPriorityFeePerGas": 10**10,
+        "maxFeePerBlobGas": 10**10,
+        "nonce": await async_w3.eth.get_transaction_count(acct.address),
+    }
+
+    signed = acct.sign_transaction(tx, blobs=[blob_data])
+
+    tx_hash = await async_w3.eth.send_raw_transaction(signed.rawTransaction)
+    transaction = await async_w3.eth.get_transaction(tx_hash)
+
+    assert len(transaction["blobVersionedHashes"]) == 1
+    assert transaction["blobVersionedHashes"][0] == HexBytes(
+        "0x0127c38bcad458d932e828b580b9ad97310be01407dfa0ed88118735980a3e9a"
+    )

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -72,7 +72,9 @@ is_not_named_block = complement(is_named_block)
 # --- Request Mapping --- #
 
 TRANSACTION_REQUEST_KEY_MAPPING = {
+    "blobVersionedHashes": "blob_versioned_hashes",
     "gasPrice": "gas_price",
+    "maxFeePerBlobGas": "max_fee_per_blob_gas",
     "maxFeePerGas": "max_fee_per_gas",
     "maxPriorityFeePerGas": "max_priority_fee_per_gas",
     "accessList": "access_list",
@@ -123,10 +125,12 @@ filter_request_transformer = compose(
 
 TRANSACTION_RESULT_KEY_MAPPING = {
     "access_list": "accessList",
+    "blob_versioned_hashes": "blobVersionedHashes",
     "block_hash": "blockHash",
     "block_number": "blockNumber",
     "chain_id": "chainId",
     "gas_price": "gasPrice",
+    "max_fee_per_blob_gas": "maxFeePerBlobGas",
     "max_fee_per_gas": "maxFeePerGas",
     "max_priority_fee_per_gas": "maxPriorityFeePerGas",
     "transaction_hash": "transactionHash",
@@ -164,6 +168,8 @@ RECEIPT_RESULT_KEY_MAPPING = {
     "effective_gas_price": "effectiveGasPrice",
     "transaction_hash": "transactionHash",
     "transaction_index": "transactionIndex",
+    "blob_gas_used": "blobGasUsed",
+    "blob_gas_price": "blobGasPrice",
 }
 receipt_result_remapper = apply_key_map(RECEIPT_RESULT_KEY_MAPPING)
 
@@ -186,6 +192,9 @@ BLOCK_RESULT_KEY_MAPPING = {
     # JSON-RPC spec still says miner
     "coinbase": "miner",
     "withdrawals_root": "withdrawalsRoot",
+    "parent_beacon_block_root": "parentBeaconBlockRoot",
+    "blob_gas_used": "blobGasUsed",
+    "excess_blob_gas": "excessBlobGas",
 }
 block_result_remapper = apply_key_map(BLOCK_RESULT_KEY_MAPPING)
 

--- a/web3/types.py
+++ b/web3/types.py
@@ -166,6 +166,7 @@ TxParams = TypedDict(
     "TxParams",
     {
         "accessList": AccessList,
+        "blobVersionedHashes": Sequence[Union[str, HexStr, bytes, HexBytes]],
         "chainId": int,
         "data": Union[bytes, HexStr],
         # addr or ens
@@ -173,6 +174,7 @@ TxParams = TypedDict(
         "gas": int,
         # legacy pricing
         "gasPrice": Wei,
+        "maxFeePerBlobGas": Union[str, Wei],
         # dynamic fee pricing
         "maxFeePerGas": Union[str, Wei],
         "maxPriorityFeePerGas": Union[str, Wei],
@@ -221,6 +223,9 @@ class BlockData(TypedDict, total=False):
     uncles: Sequence[HexBytes]
     withdrawals: Sequence[WithdrawalData]
     withdrawalsRoot: HexBytes
+    parentBeaconBlockRoot: HexBytes
+    blobGasUsed: int
+    excessBlobGas: int
 
     # ExtraDataToPOAMiddleware replaces extraData w/ proofOfAuthorityData
     proofOfAuthorityData: HexBytes


### PR DESCRIPTION
### What was wrong?

We need Cancun support for `EthereumTesterProvider`. 

---
**Note: These changes will need both ethereum/eth-tester#285 and ethereum/py-evm#2166 to be merged and released.**

### How was it fixed?

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="1097" alt="Screenshot 2024-04-04 at 15 57 55" src="https://github.com/ethereum/web3.py/assets/3532824/3962eee5-aead-42b6-b913-86620aa82ca9">
