### PR TITLE
V6 ethereum tester provider cancun support

### DIFF
--- a/newsfragments/3338.feature.rst
+++ b/newsfragments/3338.feature.rst
@@ -1,0 +1,1 @@
+Add Cancun support to ``EthereumTesterProvider``; update Cancun-related fields in some internal types.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ from setuptools import (
 
 extras_require = {
     "tester": [
-        "eth-tester[py-evm]>=0.11.0b1,<0.12.0b1",
+        "eth-tester[py-evm]>=0.9.0b1,<0.10.0b1; python_version <= '3.7'",
+        "eth-tester[py-evm]>=0.11.0b1,<0.12.0b1; python_version > '3.7'",
         "py-geth>=3.14.0",
     ],
     "linter": [

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import (
 
 extras_require = {
     "tester": [
-        "eth-tester[py-evm]==v0.9.1-b.2",
+        "eth-tester[py-evm]>=0.11.0b1,<0.12.0b1",
         "py-geth>=3.14.0",
     ],
     "linter": [

--- a/tests/core/middleware/test_eth_tester_middleware.py
+++ b/tests/core/middleware/test_eth_tester_middleware.py
@@ -1,4 +1,5 @@
 import pytest
+import sys
 from unittest.mock import (
     Mock,
 )
@@ -25,6 +26,13 @@ def test_get_transaction_count_formatters(w3, block_number):
     assert tx_counts == 0
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason=(
+        "There is no version of eth-tester that supports both python 3.7 and blob "
+        "transactions / Cancun network upgrade."
+    ),
+)
 def test_get_block_formatters(w3):
     all_block_keys = BlockData.__annotations__.keys()
     all_non_poa_block_keys = set(

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -75,7 +75,9 @@ is_not_named_block = complement(is_named_block)
 # --- Request Mapping --- #
 
 TRANSACTION_REQUEST_KEY_MAPPING = {
+    "blobVersionedHashes": "blob_versioned_hashes",
     "gasPrice": "gas_price",
+    "maxFeePerBlobGas": "max_fee_per_blob_gas",
     "maxFeePerGas": "max_fee_per_gas",
     "maxPriorityFeePerGas": "max_priority_fee_per_gas",
     "accessList": "access_list",
@@ -126,10 +128,12 @@ filter_request_transformer = compose(
 
 TRANSACTION_RESULT_KEY_MAPPING = {
     "access_list": "accessList",
+    "blob_versioned_hashes": "blobVersionedHashes",
     "block_hash": "blockHash",
     "block_number": "blockNumber",
     "chain_id": "chainId",
     "gas_price": "gasPrice",
+    "max_fee_per_blob_gas": "maxFeePerBlobGas",
     "max_fee_per_gas": "maxFeePerGas",
     "max_priority_fee_per_gas": "maxPriorityFeePerGas",
     "transaction_hash": "transactionHash",
@@ -166,6 +170,8 @@ RECEIPT_RESULT_KEY_MAPPING = {
     "effective_gas_price": "effectiveGasPrice",
     "transaction_hash": "transactionHash",
     "transaction_index": "transactionIndex",
+    "blob_gas_used": "blobGasUsed",
+    "blob_gas_price": "blobGasPrice",
 }
 receipt_result_remapper = apply_key_map(RECEIPT_RESULT_KEY_MAPPING)
 
@@ -188,6 +194,9 @@ BLOCK_RESULT_KEY_MAPPING = {
     # JSON-RPC spec still says miner
     "coinbase": "miner",
     "withdrawals_root": "withdrawalsRoot",
+    "parent_beacon_block_root": "parentBeaconBlockRoot",
+    "blob_gas_used": "blobGasUsed",
+    "excess_blob_gas": "excessBlobGas",
 }
 block_result_remapper = apply_key_map(BLOCK_RESULT_KEY_MAPPING)
 

--- a/web3/types.py
+++ b/web3/types.py
@@ -169,6 +169,7 @@ TxParams = TypedDict(
     "TxParams",
     {
         "accessList": AccessList,
+        "blobVersionedHashes": Sequence[Union[str, HexStr, bytes, HexBytes]],
         "chainId": int,
         "data": Union[bytes, HexStr],
         # addr or ens
@@ -176,6 +177,7 @@ TxParams = TypedDict(
         "gas": int,
         # legacy pricing
         "gasPrice": Wei,
+        "maxFeePerBlobGas": Union[str, Wei],
         # dynamic fee pricing
         "maxFeePerGas": Union[str, Wei],
         "maxPriorityFeePerGas": Union[str, Wei],
@@ -224,6 +226,9 @@ class BlockData(TypedDict, total=False):
     uncles: Sequence[HexBytes]
     withdrawals: Sequence[WithdrawalData]
     withdrawalsRoot: HexBytes
+    parentBeaconBlockRoot: HexBytes
+    blobGasUsed: int
+    excessBlobGas: int
 
     # geth_poa_middleware replaces extraData w/ proofOfAuthorityData
     proofOfAuthorityData: HexBytes


### PR DESCRIPTION
### What was wrong?

Cancun support for ``EthereumTesterProvider`` is missing

### How was it fixed?

- Keep `eth-tester` dependency within the minor beta versions that support Cancun only.
- Add relevant fields on types and eth-tester middleware formatters

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="1097" alt="Screenshot 2024-04-04 at 15 57 55" src="https://github.com/ethereum/web3.py/assets/3532824/3962eee5-aead-42b6-b913-86620aa82ca9">
