### PR TITLE
Add upper pin to eth-account in anticipation of breaking changes

### DIFF
--- a/newsfragments/3339.misc.rst
+++ b/newsfragments/3339.misc.rst
@@ -1,0 +1,1 @@
+Add upper pin to eth-account so that incoming breaking changes are avoided.

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     install_requires=[
         "aiohttp>=3.7.4.post0",
         "eth-abi>=4.0.0",
-        "eth-account>=0.8.0",
+        "eth-account>=0.8.0,<0.13",
         "eth-hash[pycryptodome]>=0.5.1",
         "eth-typing>=3.0.0,<4.2.0",
         "eth-utils>=2.1.0",


### PR DESCRIPTION
### What was wrong?

`eth-account v0.13` will have some breaking changes for web3 v6 (mainly camelCase -> snake_case changes). Pinning here before 0.13 gets released so we don't run into problems.  

### How was it fixed?
Pinned it!

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcS0vUsRg7zl-_z_EMzf4FqWa_22BIlGSzmVtif4YpQvcg&s)
