### PR TITLE
Upgrade eth-account to 0.12.2, fix deprecation warnings

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -635,7 +635,7 @@ And finally, send the transaction
 
 .. code-block:: python
 
-    txn_hash = w3.eth.send_raw_transaction(signed_tx.rawTransaction)
+    txn_hash = w3.eth.send_raw_transaction(signed_tx.raw_transaction)
     txn_receipt = w3.eth.wait_for_transaction_receipt(txn_hash)
 
 Tip : afterwards you can use the value stored in ``txn_hash``, in an explorer like `etherscan`_ to view the transaction's details

--- a/docs/transactions.rst
+++ b/docs/transactions.rst
@@ -129,7 +129,7 @@ if you don't opt for the middleware, you'll need to:
   signed = w3.eth.account.sign_transaction(transaction, pk)
 
   # 3. Send the signed transaction
-  tx_hash = w3.eth.send_raw_transaction(signed.rawTransaction)
+  tx_hash = w3.eth.send_raw_transaction(signed.raw_transaction)
   tx = w3.eth.get_transaction(tx_hash)
   assert tx["from"] == acct2.address
 
@@ -186,6 +186,6 @@ Executing a function on a smart contract requires sending a transaction, which i
 
   # Send the raw transaction:
   assert billboard.functions.message().call() == "gm"
-  tx_hash = w3.eth.send_raw_transaction(signed_tx.rawTransaction)
+  tx_hash = w3.eth.send_raw_transaction(signed_tx.raw_transaction)
   w3.eth.wait_for_transaction_receipt(tx_hash)
   assert billboard.functions.message().call() == "gn"

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -214,6 +214,7 @@ is provided by :meth:`w3.eth.sign() <web3.eth.Eth.sign>`.
     >>> signed_message = w3.eth.account.sign_message(message, private_key=private_key)
     >>> signed_message
     SignedMessage(messageHash=HexBytes('0x1476abb745d423bf09273f1afd887d951181d25adc66c4834a70491911b7f750'),
+     message_hash=HexBytes('0x1476abb745d423bf09273f1afd887d951181d25adc66c4834a70491911b7f750'),
      r=104389933075820307925104709181714897380569894203213074526835978196648170704563,
      s=28205917190874851400050446352651915501321657673772411533993420917949420456142,
      v=28,
@@ -251,7 +252,7 @@ You might have produced the signed_message locally, as in
     ...   return Web3.to_hex(Web3.to_bytes(val).rjust(32, b'\0'))
 
     >>> ec_recover_args = (msghash, v, r, s) = (
-    ...   Web3.to_hex(signed_message.messageHash),
+    ...   Web3.to_hex(signed_message.message_hash),
     ...   signed_message.v,
     ...   to_32byte_hex(signed_message.r),
     ...   to_32byte_hex(signed_message.s),
@@ -356,7 +357,7 @@ with :meth:`~web3.eth.Eth.send_raw_transaction`.
     ... }
     >>> key = '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318'
     >>> signed = w3.eth.account.sign_transaction(transaction, key)
-    >>> signed.rawTransaction
+    >>> signed.raw_transaction
     HexBytes('0x02f8e20180843b9aca008477359400831e848094f0109fc8df283027b6285cc889f5aa624eac1f55843b9aca0080f872f85994de0b295669a9fd93d5f28d9ec85e40f4cb697baef842a00000000000000000000000000000000000000000000000000000000000000003a00000000000000000000000000000000000000000000000000000000000000007d694bb9bc244d798123fde783fcc1c72d3bb8c189413c001a0b9ec671ccee417ff79e06e9e52bfa82b37cf1145affde486006072ca7a11cf8da0484a9beea46ff6a90ac76e7bbf3718db16a8b4b09cef477fb86cf4e123d98fde')
     >>> signed.hash
     HexBytes('0xe85ce7efa52c16cb5c469c7bde54fbd4911639fdfde08003f65525a85076d915')
@@ -368,7 +369,7 @@ with :meth:`~web3.eth.Eth.send_raw_transaction`.
     1
 
     # When you run send_raw_transaction, you get back the hash of the transaction:
-    >>> w3.eth.send_raw_transaction(signed.rawTransaction)  # doctest: +SKIP
+    >>> w3.eth.send_raw_transaction(signed.raw_transaction)  # doctest: +SKIP
     '0xe85ce7efa52c16cb5c469c7bde54fbd4911639fdfde08003f65525a85076d915'
 
 Sign a Contract Transaction
@@ -429,7 +430,7 @@ To sign a transaction locally that will invoke a smart contract:
     >>> signed_txn = w3.eth.account.sign_transaction(unicorn_txn, private_key=private_key)
     >>> signed_txn.hash
     HexBytes('0x748db062639a45e519dba934fce09c367c92043867409160c9989673439dc817')
-    >>> signed_txn.rawTransaction
+    >>> signed_txn.raw_transaction
     HexBytes('0x02f8b00180843b9aca0084773594008301117094fb6916095ca1df60bb79ce92ce3ea74c37c5d35980b844a9059cbb000000000000000000000000fb6916095ca1df60bb79ce92ce3ea74c37c5d3590000000000000000000000000000000000000000000000000000000000000001c001a0cec4150e52898cf1295cc4020ac0316cbf186071e7cdc5ec44eeb7cdda05afa2a06b0b3a09c7fb0112123c0bef1fd6334853a9dcf3cb5bab3ccd1f5baae926d449')
     >>> signed_txn.r
     93522894155654168208483453926995743737629589441154283159505514235904280342434
@@ -438,8 +439,8 @@ To sign a transaction locally that will invoke a smart contract:
     >>> signed_txn.v
     1
 
-    >>> w3.eth.send_raw_transaction(signed_txn.rawTransaction)  # doctest: +SKIP
+    >>> w3.eth.send_raw_transaction(signed_txn.raw_transaction)  # doctest: +SKIP
 
     # When you run send_raw_transaction, you get the same result as the hash of the transaction:
-    >>> w3.to_hex(w3.keccak(signed_txn.rawTransaction))
+    >>> w3.to_hex(w3.keccak(signed_txn.raw_transaction))
     '0x748db062639a45e519dba934fce09c367c92043867409160c9989673439dc817'

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -795,7 +795,7 @@ The following methods are available on the ``web3.eth`` namespace.
           ),
           private_key_for_senders_account,
         )
-        >>> w3.eth.send_raw_transaction(signed_txn.rawTransaction)
+        >>> w3.eth.send_raw_transaction(signed_txn.raw_transaction)
         HexBytes('0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331')
 
 

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     install_requires=[
         "aiohttp>=3.7.4.post0",
         "eth-abi>=5.0.1",
-        "eth-account>=0.12.0",
+        "eth-account>=0.12.2",
         "eth-hash[pycryptodome]>=0.5.1",
         "eth-typing>=4.0.0",
         "eth-utils>=4.0.0",

--- a/tests/core/eth-module/test_accounts.py
+++ b/tests/core/eth-module/test_accounts.py
@@ -265,7 +265,7 @@ def test_eth_account_sign(
     assert signed_message == expected_hash
 
     signed = acct.sign_message(message, private_key=key)
-    assert signed.messageHash == expected_hash
+    assert signed.message_hash == expected_hash
     assert signed.v == v
     assert signed.r == r
     assert signed.s == s
@@ -418,14 +418,14 @@ def test_eth_account_sign_transaction(
     assert signed.r == r
     assert signed.s == s
     assert signed.v == v
-    assert signed.rawTransaction == expected_raw_tx
+    assert signed.raw_transaction == expected_raw_tx
     assert signed.hash == tx_hash
 
     account = acct.from_key(private_key)
     assert account.sign_transaction(txn) == signed
 
     expected_sender = acct.from_key(private_key).address
-    assert acct.recover_transaction(signed.rawTransaction) == expected_sender
+    assert acct.recover_transaction(signed.raw_transaction) == expected_sender
 
 
 @pytest.mark.parametrize(
@@ -449,7 +449,7 @@ def test_eth_account_sign_transaction_from_eth_test(acct, transaction_info):
 
     # confirm that signed transaction can be recovered to the sender
     expected_sender = acct.from_key(key).address
-    assert acct.recover_transaction(signed.rawTransaction) == expected_sender
+    assert acct.recover_transaction(signed.raw_transaction) == expected_sender
 
 
 @pytest.mark.parametrize(

--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -366,7 +366,7 @@ def test_eth_send_raw_blob_transaction(w3):
 
     signed = acct.sign_transaction(tx, blobs=[blob_data])
 
-    tx_hash = w3.eth.send_raw_transaction(signed.rawTransaction)
+    tx_hash = w3.eth.send_raw_transaction(signed.raw_transaction)
     transaction = w3.eth.get_transaction(tx_hash)
 
     assert len(transaction["blobVersionedHashes"]) == 1
@@ -417,7 +417,7 @@ async def test_async_send_raw_blob_transaction(async_w3):
 
     signed = acct.sign_transaction(tx, blobs=[blob_data])
 
-    tx_hash = await async_w3.eth.send_raw_transaction(signed.rawTransaction)
+    tx_hash = await async_w3.eth.send_raw_transaction(signed.raw_transaction)
     transaction = await async_w3.eth.get_transaction(tx_hash)
 
     assert len(transaction["blobVersionedHashes"]) == 1

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -3648,7 +3648,7 @@ class EthModuleTest:
             # unlocked_account private key:
             "0x392f63a79b1ff8774845f3fa69de4a13800a59e7083f5187f1558f0797ad0f01",
         )
-        txn_hash = w3.eth.send_raw_transaction(signed_tx.rawTransaction)
+        txn_hash = w3.eth.send_raw_transaction(signed_tx.raw_transaction)
         assert txn_hash == signed_tx.hash
 
     def test_eth_call(self, w3: "Web3", math_contract: "Contract") -> None:

--- a/web3/middleware/signing.py
+++ b/web3/middleware/signing.py
@@ -182,7 +182,7 @@ class SignAndSendRawMiddlewareBuilder(Web3MiddlewareBuilder):
                 return method, params
             else:
                 account = self._accounts[to_checksum_address(tx_from)]
-                raw_tx = account.sign_transaction(filled_transaction).rawTransaction
+                raw_tx = account.sign_transaction(filled_transaction).raw_transaction
 
                 return (
                     RPCEndpoint("eth_sendRawTransaction"),
@@ -211,7 +211,7 @@ class SignAndSendRawMiddlewareBuilder(Web3MiddlewareBuilder):
                 return method, params
             else:
                 account = self._accounts[to_checksum_address(tx_from)]
-                raw_tx = account.sign_transaction(filled_transaction).rawTransaction
+                raw_tx = account.sign_transaction(filled_transaction).raw_transaction
 
                 return (
                     RPCEndpoint("eth_sendRawTransaction"),


### PR DESCRIPTION
### What was wrong?

Related to Issue #
Closes #

### How was it fixed?

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
