### PR TITLE
Pin `eth-typing` to <4.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         "eth-abi>=4.0.0",
         "eth-account>=0.8.0,<0.13",
         "eth-hash[pycryptodome]>=0.5.1",
-        "eth-typing>=3.0.0,<4.2.0",
+        "eth-typing>=3.0.0,<4.1.0",
         "eth-utils>=2.1.0",
         "hexbytes>=0.1.0,<0.4.0",
         "jsonschema>=4.0.0",


### PR DESCRIPTION
### What was wrong?

Error in pytest running web3 after removal of `ContractName` in eth-typing.

Closes #3346 

### How was it fixed?
Pin `eth-typing` to `4.1.0`

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="708" alt="Screen Shot 2024-04-16 at 9 52 06 AM" src="https://github.com/ethereum/web3.py/assets/435903/6eff8ec2-df4c-4bd3-9191-f842c3e7d5f2">

