### PR TITLE
Revert `eth-typing` pin at <4.2.0

### DIFF
--- a/newsfragments/3347.bugfix.rst
+++ b/newsfragments/3347.bugfix.rst
@@ -1,1 +1,0 @@
-`eth-typing` pinned below `4.1.0` to fix type references.

--- a/newsfragments/3347.bugfix.rst
+++ b/newsfragments/3347.bugfix.rst
@@ -1,0 +1,1 @@
+`eth-typing` pinned below `4.1.0` to fix type references.

--- a/newsfragments/3349.bugfix.rst
+++ b/newsfragments/3349.bugfix.rst
@@ -1,0 +1,1 @@
+Revert pin of `eth-typing` to utilize `EthPM` types.

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         "eth-abi>=4.0.0",
         "eth-account>=0.8.0,<0.13",
         "eth-hash[pycryptodome]>=0.5.1",
-        "eth-typing>=3.0.0,<4.2.0",
+        "eth-typing>=3.0.0",
         "eth-utils>=2.1.0",
         "hexbytes>=0.1.0,<0.4.0",
         "jsonschema>=4.0.0",

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         "eth-abi>=4.0.0",
         "eth-account>=0.8.0,<0.13",
         "eth-hash[pycryptodome]>=0.5.1",
-        "eth-typing>=3.0.0",
+        "eth-typing>=3.0.0,!=4.2.0",
         "eth-utils>=2.1.0",
         "hexbytes>=0.1.0,<0.4.0",
         "jsonschema>=4.0.0",


### PR DESCRIPTION
### What was wrong?

EthPM removals from eth-typing were reverted. Those will be done again and released as a major.

Related to Issue #
Closes #

### How was it fixed?

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
