### PR TITLE
Snake case the remaining camels

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1117,8 +1117,8 @@ The script can be run with: ``python ./eventscanner.py <your JSON-RPC API URL>``
             codec,
             address=argument_filters.get("address"),
             argument_filters=argument_filters,
-            fromBlock=from_block,
-            toBlock=to_block
+            from_block=from_block,
+            to_block=to_block
         )
 
         logger.debug(f"Querying eth_getLogs with the following parameters: {event_filter_params}")

--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -32,7 +32,7 @@ If you're on this page, you're likely looking for an answer to this question:
    weth_contract = w3.eth.contract(address=WETH_ADDRESS, abi=WETH_ABI)
 
    # fetch transfer events in the last block
-   logs = weth_contract.events.Transfer().get_logs(fromBlock=w3.eth.block_number)
+   logs = weth_contract.events.Transfer().get_logs(from_block=w3.eth.block_number)
 
    for log in logs:
       print(f"Transfer of {w3.from_wei(log.args.wad, 'ether')} WETH from {log.args.src} to {log.args.dst}")
@@ -62,7 +62,7 @@ The :meth:`web3.eth.Eth.filter` method can be used to set up filters for:
 
     .. code-block:: python
 
-        event_filter = mycontract.events.myEvent.create_filter(fromBlock='latest', argument_filters={'arg1':10})
+        event_filter = my_contract.events.myEvent.create_filter(from_block='latest', argument_filters={'arg1':10})
 
     Or built manually by supplying `valid filter params <https://github.com/ethereum/execution-apis/blob/bea0266c42919a2fb3ee524fb91e624a23bc17c5/src/schemas/filter.json#L28>`_:
 
@@ -169,7 +169,7 @@ creating event log filters. Refer to the following example:
 
     .. code-block:: python
 
-        event_filter = myContract.events.<event_name>.create_filter(fromBlock="latest", argument_filters={'arg1':10})
+        event_filter = my_contract.events.<event_name>.create_filter(from_block="latest", argument_filters={'arg1':10})
         event_filter.get_new_entries()
 
 See :meth:`web3.contract.Contract.events.your_event_name.create_filter()` documentation for more information.

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -286,7 +286,7 @@ a contract, you can leverage web3.py filters.
    >>> new_filter = web3.eth.filter('latest')
 
    # Use case: filter for contract event "MyEvent"
-   >>> new_filter = deployed_contract.events.MyEvent.create_filter(fromBlock='latest')
+   >>> new_filter = deployed_contract.events.MyEvent.create_filter(from_block='latest')
 
    # retrieve filter results:
    >>> new_filter.get_all_entries()

--- a/docs/v7_migration.rst
+++ b/docs/v7_migration.rst
@@ -174,6 +174,21 @@ been functional since around October 2022. It was deprecated in ``v6`` and has b
 completely removed in ``v7``.
 
 
+Remaining cameCase -> snake_case Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following arguments have been renamed across the library from camelCase to
+snake_case in all methods where they are passed in as a kwarg.
+
+- ``fromBlock`` -> ``from_block``
+- ``toBlock`` -> ``to_block``
+- ``blockHash`` -> ``block_hash``
+
+Note that if a dictionary is used instead, say to a call such as `eth_getLogs`, the
+keys in the dictionary should be camelCase. This is because the dictionary is passed
+directly to the JSON-RPC request, where the keys are expected to be in camelCase.
+
+
 Miscellaneous Changes
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/web3.contract.rst
+++ b/docs/web3.contract.rst
@@ -264,12 +264,12 @@ Each Contract Factory exposes the following methods.
 
 .. _contract_create_filter:
 
-.. py:classmethod:: Contract.events.your_event_name.create_filter(fromBlock=None, toBlock="latest", argument_filters={}, topics=[])
+.. py:classmethod:: Contract.events.your_event_name.create_filter(from_block=None, to_block="latest", argument_filters={}, topics=[])
 
     Creates a new event filter, an instance of :py:class:`web3.utils.filters.LogFilter`.
 
-    - ``fromBlock`` is a mandatory field. Defines the starting block (exclusive) filter block range. It can be either the starting block number, or 'latest' for the last mined block, or 'pending' for unmined transactions. In the case of ``fromBlock``, 'latest' and 'pending' set the 'latest' or 'pending' block as a static value for the starting filter block.
-    - ``toBlock`` optional. Defaults to 'latest'. Defines the ending block (inclusive) in the filter block range.  Special values 'latest' and 'pending' set a dynamic range that always includes the 'latest' or 'pending' blocks for the filter's upper block range.
+    - ``from_block`` is a mandatory field. Defines the starting block (exclusive) filter block range. It can be either the starting block number, or 'latest' for the last mined block, or 'pending' for unmined transactions. In the case of ``from_block``, 'latest' and 'pending' set the 'latest' or 'pending' block as a static value for the starting filter block.
+    - ``to_block`` optional. Defaults to 'latest'. Defines the ending block (inclusive) in the filter block range.  Special values 'latest' and 'pending' set a dynamic range that always includes the 'latest' or 'pending' blocks for the filter's upper block range.
     - ``address`` optional. Defaults to the contract address. The filter matches the event logs emanating from ``address``.
     - ``argument_filters``, optional. Expects a dictionary of argument names and values. When provided event logs are filtered for the event argument values. Event arguments can be both indexed or unindexed. Indexed values will be translated to their corresponding topic arguments. Unindexed arguments will be filtered using a regular expression.
     - ``topics`` optional, accepts the standard JSON-RPC topics argument.  See the JSON-RPC documentation for `eth_newFilter <https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_newfilter>`_ more information on the ``topics`` parameters.
@@ -281,7 +281,7 @@ Each Contract Factory exposes the following methods.
     .. code-block:: python
 
         filter_builder = myContract.events.myEvent.build_filter()
-        filter_builder.fromBlock = "latest"
+        filter_builder.from_block = "latest"
         filter_builder.args.clientID.match_any(1, 2, 3, 4)
         filter_builder.args.region.match_single("UK")
         filter_instance = filter_builder.deploy()
@@ -297,9 +297,9 @@ Each Contract Factory exposes the following methods.
 
     .. code-block:: python
 
-        filter_builder = myContract.events.myEvent.build_filter()
-        filter_builder.fromBlock = "latest"
-        filter_builder.fromBlock = 0  # raises a ValueError
+        filter_builder = my_contract.events.myEvent.build_filter()
+        filter_builder.from_block = "latest"
+        filter_builder.from_block = 0  # raises a ValueError
 
 .. py:classmethod:: Contract.encode_abi(fn_name, args=None, kwargs=None, data=None)
 
@@ -939,7 +939,7 @@ For example:
 
 .. _contract_get_logs:
 
-.. py:method:: ContractEvents.myEvent(*args, **kwargs).get_logs(fromBlock=None, toBlock="latest", block_hash=None, argument_filters={})
+.. py:method:: ContractEvents.myEvent(*args, **kwargs).get_logs(from_block=None, to_block="latest", block_hash=None, argument_filters={})
    :noindex:
 
    Fetches all logs for a given event within the specified block range or block hash.
@@ -957,14 +957,14 @@ For example:
 
     .. code-block:: python
 
-        myContract = web3.eth.contract(address=contract_address, abi=contract_abi)
+        my_contract = web3.eth.contract(address=contract_address, abi=contract_abi)
 
         # get ``myEvent`` logs from block 1337 to block 2337 where the value for the
         # event argument "eventArg1" is either 1, 2, or 3
-        myContract.events.myEvent().get_logs(
+        my_contract.events.myEvent().get_logs(
             argument_filters={"eventArg1": [1, 2, 3]},
-            fromBlock=1337,
-            toBlock=2337,
+            from_block=1337,
+            to_block=2337,
         )
 
 .. _process_receipt:
@@ -1107,7 +1107,7 @@ Event Log Object
 
 .. doctest:: create_filter
 
-    >>> transfer_filter = my_token_contract.events.Transfer.create_filter(fromBlock="0x0", argument_filters={'from': '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf'})
+    >>> transfer_filter = my_token_contract.events.Transfer.create_filter(from_block="0x0", argument_filters={'from': '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf'})
     >>> transfer_filter.get_new_entries()
     [AttributeDict({'args': AttributeDict({'from': '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf',
      'to': '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf',

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -1136,7 +1136,8 @@ with the filtering API.
     callbacks which will be called with each result of the filter.
 
     When creating a new log filter, the ``filter_params`` should be a
-    dictionary with the following keys.
+    dictionary with the following keys. Note that the keys are camel-cased
+    strings, as is expected in a JSON-RPC request.
 
     * ``fromBlock``: ``integer/tag`` - (optional, default: "latest") Integer
       block number, or one of predefined block identifiers

--- a/newsfragments/3353.breaking.rst
+++ b/newsfragments/3353.breaking.rst
@@ -1,0 +1,1 @@
+Snake-case remaining arguments ``fromBlock``, ``toBlock``, and ``blockHash`` in contract and filter methods where they are passed in as kwargs.

--- a/tests/core/contracts/test_contract_events_build_filter.py
+++ b/tests/core/contracts/test_contract_events_build_filter.py
@@ -28,15 +28,15 @@ def test_build_filter_resetting_build_filter_properties(w3, math_contract_abi):
     filter_builder = contract.events.Increased.build_filter()
     # Address is setable from undeployed contract class
     filter_builder.address = b"\x10" * 40
-    filter_builder.fromBlock = 0
-    filter_builder.toBlock = "latest"
+    filter_builder.from_block = 0
+    filter_builder.to_block = "latest"
     # Test that all filter properties can only set values once
     with pytest.raises(Web3ValueError):
         filter_builder.address = b"\x00" * 40
     with pytest.raises(Web3ValueError):
-        filter_builder.fromBlock = 1
+        filter_builder.from_block = 1
     with pytest.raises(Web3ValueError):
-        filter_builder.toBlock = 50
+        filter_builder.to_block = 50
 
 
 def test_build_filter_argument_match_single_can_only_be_set_once(w3, math_contract_abi):
@@ -62,9 +62,9 @@ def test_deployed_build_filter_can_have_no_values_set(w3, math_contract_abi):
     with pytest.raises(Web3ValueError):
         filter_builder.address = b"\x00" * 40
     with pytest.raises(Web3ValueError):
-        filter_builder.fromBlock = 1
+        filter_builder.from_block = 1
     with pytest.raises(Web3ValueError):
-        filter_builder.toBlock = 50
+        filter_builder.to_block = 50
     with pytest.raises(Web3ValueError):
         filter_builder.args["value"].match_single(200)
     with pytest.raises(Web3ValueError):

--- a/tests/core/contracts/test_extracting_event_data.py
+++ b/tests/core/contracts/test_extracting_event_data.py
@@ -1188,7 +1188,7 @@ def test_single_log_processing_with_errors(indexed_event_contract, dup_txn_recei
 
 
 def test_get_all_entries_with_nested_tuple_event(w3, emitter):
-    struct_args_filter = emitter.events.LogStructArgs.create_filter(fromBlock=0)
+    struct_args_filter = emitter.events.LogStructArgs.create_filter(from_block=0)
 
     tx_hash = emitter.functions.logStruct(1, (2, 3, (4,))).transact()
     w3.eth.wait_for_transaction_receipt(tx_hash)
@@ -1213,7 +1213,7 @@ def test_get_all_entries_with_nested_tuple_event_non_strict(
     w3_non_strict_abi, non_strict_emitter
 ):
     struct_args_filter = non_strict_emitter.events.LogStructArgs.create_filter(
-        fromBlock=0
+        from_block=0
     )
 
     tx_hash = non_strict_emitter.functions.logStruct(1, (2, 3, (4,))).transact()

--- a/tests/core/filtering/conftest.py
+++ b/tests/core/filtering/conftest.py
@@ -51,8 +51,8 @@ def emitter(
 def return_filter(contract, args):
     event_name = args[0]
     kwargs = apply_key_map({"filter": "argument_filters"}, args[1])
-    if "fromBlock" not in kwargs:
-        kwargs["fromBlock"] = "latest"
+    if "from_block" not in kwargs:
+        kwargs["from_block"] = "latest"
     return contract.events[event_name].create_filter(**kwargs)
 
 
@@ -98,8 +98,8 @@ async def async_emitter(
 async def async_return_filter(contract, args):
     event_name = args[0]
     kwargs = apply_key_map({"filter": "argument_filters"}, args[1])
-    if "fromBlock" not in kwargs:
-        kwargs["fromBlock"] = "latest"
+    if "from_block" not in kwargs:
+        kwargs["from_block"] = "latest"
     return await contract.events[event_name].create_filter(**kwargs)
 
 

--- a/tests/core/filtering/test_basic_filter_tests.py
+++ b/tests/core/filtering/test_basic_filter_tests.py
@@ -5,7 +5,7 @@ def test_filtering_sequential_blocks_with_bounded_range(
     w3, emitter, wait_for_transaction
 ):
     builder = emitter.events.LogNoArguments.build_filter()
-    builder.fromBlock = "latest"
+    builder.from_block = "latest"
 
     initial_block_number = w3.eth.block_number
 
@@ -43,7 +43,7 @@ async def test_async_filtering_sequential_blocks_with_bounded_range(
     async_w3, async_emitter
 ):
     builder = async_emitter.events.LogNoArguments.build_filter()
-    builder.fromBlock = "latest"
+    builder.from_block = "latest"
     initial_block_number = await async_w3.eth.block_number
     builder.toBlock = initial_block_number + 100
     filter_ = await builder.deploy(async_w3)

--- a/tests/core/filtering/test_contract_create_filter_topic_merging.py
+++ b/tests/core/filtering/test_contract_create_filter_topic_merging.py
@@ -10,7 +10,7 @@ def test_merged_topic_list_event(emitter):
     ]
     with pytest.raises(TypeError):
         emitter.events.LogTripleWithIndex().create_filter(
-            fromBlock="latest",
+            from_block="latest",
             topics=manual_topics,
             argument_filters={"arg0": 2222, "arg1": 2222, "arg2": 2222},
         )

--- a/tests/core/filtering/test_contract_get_logs.py
+++ b/tests/core/filtering/test_contract_get_logs.py
@@ -52,10 +52,14 @@ def test_contract_get_logs_range(
     log_entries = list(contract.events.LogNoArguments.get_logs())
     assert len(log_entries) == 1
 
-    log_entries = list(contract.events.LogNoArguments.get_logs(fromBlock=2, toBlock=3))
+    log_entries = list(
+        contract.events.LogNoArguments.get_logs(from_block=2, to_block=3)
+    )
     assert len(log_entries) == 1
 
-    log_entries = list(contract.events.LogNoArguments.get_logs(fromBlock=1, toBlock=2))
+    log_entries = list(
+        contract.events.LogNoArguments.get_logs(from_block=1, to_block=2)
+    )
     assert len(log_entries) == 0
 
 
@@ -76,19 +80,19 @@ def test_contract_get_logs_argument_filter(
     for txn_hash in txn_hashes:
         wait_for_transaction(w3, txn_hash)
 
-    all_logs = contract.events.LogTripleWithIndex.get_logs(fromBlock=1)
+    all_logs = contract.events.LogTripleWithIndex.get_logs(from_block=1)
     assert len(all_logs) == 4
 
     # Filter all entries where arg1 in (1, 2)
     partial_logs = contract.events.LogTripleWithIndex.get_logs(
-        fromBlock=1,
+        from_block=1,
         argument_filters={"arg1": [1, 2]},
     )
     assert len(partial_logs) == 2
 
     # Filter all entries where arg0 == 1
     partial_logs = contract.events.LogTripleWithIndex.get_logs(
-        fromBlock=1,
+        from_block=1,
         argument_filters={"arg0": 1},
     )
     assert len(partial_logs) == 4
@@ -111,16 +115,16 @@ def test_get_logs_argument_filters_indexed_and_non_indexed_args(emitter):
     ).transact()
 
     # get all logs
-    logs_no_filter = emitter.events.LogIndexedAndNotIndexed.get_logs(fromBlock=1)
+    logs_no_filter = emitter.events.LogIndexedAndNotIndexed.get_logs(from_block=1)
     assert len(logs_no_filter) == 2
 
     # filter for the second log by each of the indexed args and compare
     logs_filter_indexed_address = emitter.events.LogIndexedAndNotIndexed.get_logs(
-        fromBlock=1,
+        from_block=1,
         argument_filters={"indexedAddress": f"0xdEaD{'00' * 17}02"},
     )
     logs_filter_indexed_uint256 = emitter.events.LogIndexedAndNotIndexed.get_logs(
-        fromBlock=1,
+        from_block=1,
         argument_filters={"indexedUint256": 102},
     )
     assert len(logs_filter_indexed_address) == len(logs_filter_indexed_uint256) == 1
@@ -132,7 +136,7 @@ def test_get_logs_argument_filters_indexed_and_non_indexed_args(emitter):
 
     # filter for the first log by non-indexed address
     logs_filter_non_indexed_address = emitter.events.LogIndexedAndNotIndexed.get_logs(
-        fromBlock=1,
+        from_block=1,
         argument_filters={"nonIndexedAddress": f"0xBEEf{'00' * 17}01"},
     )
     assert len(logs_filter_non_indexed_address) == 1
@@ -140,11 +144,11 @@ def test_get_logs_argument_filters_indexed_and_non_indexed_args(emitter):
 
     # filter for the second log by non-indexed uint256 and string separately
     logs_filter_non_indexed_uint256 = emitter.events.LogIndexedAndNotIndexed.get_logs(
-        fromBlock=1,
+        from_block=1,
         argument_filters={"nonIndexedUint256": 202},
     )
     logs_filter_non_indexed_string = emitter.events.LogIndexedAndNotIndexed.get_logs(
-        fromBlock=1,
+        from_block=1,
         argument_filters={"nonIndexedString": "SECOND"},
     )
     assert len(logs_filter_non_indexed_uint256) == 1
@@ -158,7 +162,7 @@ def test_get_logs_argument_filters_indexed_and_non_indexed_args(emitter):
     # filter by both string and uint256, non-indexed
     logs_filter_non_indexed_uint256_and_string = (
         emitter.events.LogIndexedAndNotIndexed.get_logs(
-            fromBlock=1,
+            from_block=1,
             argument_filters={
                 "nonIndexedUint256": 201,
                 "nonIndexedString": "FIRST",
@@ -235,13 +239,13 @@ async def test_async_contract_get_logs_range(
     assert len(log_entries) == 1
 
     contract_logs = await contract.events.LogNoArguments.get_logs(
-        fromBlock=2, toBlock=3
+        from_block=2, to_block=3
     )
     log_entries = list(contract_logs)
     assert len(log_entries) == 1
 
     contract_logs = await contract.events.LogNoArguments.get_logs(
-        fromBlock=1, toBlock=2
+        from_block=1, to_block=2
     )
     log_entries = list(contract_logs)
     assert len(log_entries) == 0
@@ -273,19 +277,19 @@ async def test_async_contract_get_logs_argument_filter(
     for txn_hash in txn_hashes:
         await async_wait_for_transaction(async_w3, txn_hash)
 
-    all_logs = await contract.events.LogTripleWithIndex.get_logs(fromBlock=1)
+    all_logs = await contract.events.LogTripleWithIndex.get_logs(from_block=1)
     assert len(all_logs) == 4
 
     # Filter all entries where arg1 in (1, 2)
     partial_logs = await contract.events.LogTripleWithIndex.get_logs(
-        fromBlock=1,
+        from_block=1,
         argument_filters={"arg1": [1, 2]},
     )
     assert len(partial_logs) == 2
 
     # Filter all entries where arg0 == 1
     partial_logs = await contract.events.LogTripleWithIndex.get_logs(
-        fromBlock=1,
+        from_block=1,
         argument_filters={"arg0": 1},
     )
     assert len(partial_logs) == 4
@@ -312,20 +316,20 @@ async def test_async_get_logs_argument_filters_indexed_and_non_indexed_args(
 
     # get all logs
     logs_no_filter = await async_emitter.events.LogIndexedAndNotIndexed.get_logs(
-        fromBlock=1
+        from_block=1
     )
     assert len(logs_no_filter) == 2
 
     # filter for the second log by each of the indexed args and compare
     logs_filter_indexed_address = (
         await async_emitter.events.LogIndexedAndNotIndexed.get_logs(
-            fromBlock=1,
+            from_block=1,
             argument_filters={"indexedAddress": f"0xdEaD{'00' * 17}02"},
         )
     )
     logs_filter_indexed_uint256 = (
         await async_emitter.events.LogIndexedAndNotIndexed.get_logs(
-            fromBlock=1,
+            from_block=1,
             argument_filters={"indexedUint256": 102},
         )
     )
@@ -339,7 +343,7 @@ async def test_async_get_logs_argument_filters_indexed_and_non_indexed_args(
     # filter for the first log by non-indexed address
     logs_filter_non_indexed_address = (
         await async_emitter.events.LogIndexedAndNotIndexed.get_logs(
-            fromBlock=1,
+            from_block=1,
             argument_filters={"nonIndexedAddress": f"0xBEEf{'00' * 17}01"},
         )
     )
@@ -349,13 +353,13 @@ async def test_async_get_logs_argument_filters_indexed_and_non_indexed_args(
     # filter for the second log by non-indexed uint256 and string separately
     logs_filter_non_indexed_uint256 = (
         await async_emitter.events.LogIndexedAndNotIndexed.get_logs(
-            fromBlock=1,
+            from_block=1,
             argument_filters={"nonIndexedUint256": 202},
         )
     )
     logs_filter_non_indexed_string = (
         await async_emitter.events.LogIndexedAndNotIndexed.get_logs(
-            fromBlock=1,
+            from_block=1,
             argument_filters={"nonIndexedString": "SECOND"},
         )
     )
@@ -370,7 +374,7 @@ async def test_async_get_logs_argument_filters_indexed_and_non_indexed_args(
     # filter by both string and uint256, non-indexed
     logs_filter_non_indexed_uint256_and_string = (
         await async_emitter.events.LogIndexedAndNotIndexed.get_logs(
-            fromBlock=1,
+            from_block=1,
             argument_filters={
                 "nonIndexedUint256": 201,
                 "nonIndexedString": "FIRST",

--- a/tests/core/filtering/test_contract_on_event_filtering.py
+++ b/tests/core/filtering/test_contract_on_event_filtering.py
@@ -11,10 +11,10 @@ def test_create_filter_address_parameter(
     emitter, emitter_contract_factory, call_deployed_contract
 ):
     if call_deployed_contract:
-        event_filter = emitter.events.LogNoArguments.create_filter(fromBlock="latest")
+        event_filter = emitter.events.LogNoArguments.create_filter(from_block="latest")
     else:
         event_filter = emitter_contract_factory.events.LogNoArguments.create_filter(
-            fromBlock="latest"
+            from_block="latest"
         )
 
     if call_deployed_contract:
@@ -158,7 +158,7 @@ def test_on_sync_filter_with_event_name_and_non_indexed_argument(
 
     post_event_filter = contract.events.LogTripleWithIndex.create_filter(
         argument_filters={"arg0": 1, "arg1": 2},
-        fromBlock=0,
+        from_block=0,
     )
 
     old_logs = post_event_filter.get_all_entries()
@@ -212,7 +212,7 @@ def test_on_sync_filter_with_topic_filter_options_on_old_apis(
 
     post_event_filter = contract.events.LogTripleWithIndex.create_filter(
         argument_filters={"arg1": [1, 2], "arg2": [1, 2]},
-        fromBlock=0,
+        from_block=0,
     )
 
     old_logs = post_event_filter.get_all_entries()
@@ -236,12 +236,12 @@ async def test_async_create_filter_address_parameter(
 ):
     if call_deployed_contract:
         event_filter = await async_emitter.events.LogNoArguments.create_filter(
-            fromBlock="latest"
+            from_block="latest"
         )
     else:
         event_filter = (
             await async_emitter_contract_factory.events.LogNoArguments.create_filter(
-                fromBlock="latest"
+                from_block="latest"
             )
         )
 
@@ -403,7 +403,7 @@ async def test_on_async_filter_with_event_name_and_non_indexed_argument(
 
     post_event_filter = await contract.events.LogTripleWithIndex.create_filter(
         argument_filters={"arg0": 1, "arg1": 2},
-        fromBlock=0,
+        from_block=0,
     )
 
     old_logs = await post_event_filter.get_all_entries()
@@ -469,7 +469,7 @@ async def test_on_async_filter_with_topic_filter_options_on_old_apis(
 
     post_event_filter = await contract.events.LogTripleWithIndex.create_filter(
         argument_filters={"arg1": [1, 2], "arg2": [1, 2]},
-        fromBlock=0,
+        from_block=0,
     )
 
     old_logs = await post_event_filter.get_all_entries()

--- a/tests/core/filtering/test_contract_past_event_filtering.py
+++ b/tests/core/filtering/test_contract_past_event_filtering.py
@@ -25,11 +25,11 @@ def test_on_filter_using_get_all_entries_interface(
 
     if api_style == "build_filter":
         builder = contract.events.LogNoArguments.build_filter()
-        builder.fromBlock = "latest"
+        builder.from_block = "latest"
         event_filter = builder.deploy(w3)
     else:
         event_filter = create_filter(
-            contract, ["LogNoArguments", {"fromBlock": "latest"}]
+            contract, ["LogNoArguments", {"from_block": "latest"}]
         )
 
     txn_hash = emitter.functions.logNoArgs(
@@ -73,11 +73,11 @@ def test_get_all_entries_returned_block_data(
 
     if api_style == "build_filter":
         builder = contract.events.LogNoArguments.build_filter()
-        builder.fromBlock = txn_receipt["blockNumber"]
+        builder.from_block = txn_receipt["blockNumber"]
         event_filter = builder.deploy(w3)
     else:
         event_filter = create_filter(
-            contract, ["LogNoArguments", {"fromBlock": txn_receipt["blockNumber"]}]
+            contract, ["LogNoArguments", {"from_block": txn_receipt["blockNumber"]}]
         )
 
     log_entries = event_filter.get_all_entries()
@@ -122,11 +122,11 @@ async def test_on_async_filter_using_get_all_entries_interface(
 
     if api_style == "build_filter":
         builder = contract.events.LogNoArguments.build_filter()
-        builder.fromBlock = "latest"
+        builder.from_block = "latest"
         event_filter = await builder.deploy(async_w3)
     else:
         event_filter = await async_create_filter(
-            contract, ["LogNoArguments", {"fromBlock": "latest"}]
+            contract, ["LogNoArguments", {"from_block": "latest"}]
         )
 
     txn_hash = await async_emitter.functions.logNoArgs(
@@ -171,11 +171,11 @@ async def test_async_get_all_entries_returned_block_data(
 
     if api_style == "build_filter":
         builder = contract.events.LogNoArguments.build_filter()
-        builder.fromBlock = txn_receipt["blockNumber"]
+        builder.from_block = txn_receipt["blockNumber"]
         event_filter = await builder.deploy(async_w3)
     else:
         event_filter = await async_create_filter(
-            contract, ["LogNoArguments", {"fromBlock": txn_receipt["blockNumber"]}]
+            contract, ["LogNoArguments", {"from_block": txn_receipt["blockNumber"]}]
         )
 
     log_entries = await event_filter.get_all_entries()

--- a/tests/core/filtering/test_filters_against_many_blocks.py
+++ b/tests/core/filtering/test_filters_against_many_blocks.py
@@ -47,10 +47,12 @@ def test_event_filter_new_events(
 
     if api_style == "build_filter":
         builder = emitter.events.LogNoArguments.build_filter()
-        builder.fromBlock = "latest"
+        builder.from_block = "latest"
         event_filter = builder.deploy(w3)
     else:
-        event_filter = emitter.events.LogNoArguments().create_filter(fromBlock="latest")
+        event_filter = emitter.events.LogNoArguments().create_filter(
+            from_block="latest"
+        )
 
     expected_match_counter = 0
 
@@ -126,10 +128,12 @@ def test_event_filter_new_events_many_deployed_contracts(
 
     if api_style == "build_filter":
         builder = emitter.events.LogNoArguments.build_filter()
-        builder.fromBlock = "latest"
+        builder.from_block = "latest"
         event_filter = builder.deploy(w3)
     else:
-        event_filter = emitter.events.LogNoArguments().create_filter(fromBlock="latest")
+        event_filter = emitter.events.LogNoArguments().create_filter(
+            from_block="latest"
+        )
 
     expected_match_counter = 0
 
@@ -194,11 +198,11 @@ async def test_async_event_filter_new_events(
 
     if api_style == "build_filter":
         builder = async_emitter.events.LogNoArguments.build_filter()
-        builder.fromBlock = "latest"
+        builder.from_block = "latest"
         event_filter = await builder.deploy(async_w3)
     else:
         event_filter = await async_emitter.events.LogNoArguments().create_filter(
-            fromBlock="latest"
+            from_block="latest"
         )
 
     expected_match_counter = 0
@@ -286,11 +290,11 @@ async def test_async_event_filter_new_events_many_deployed_contracts(
 
     if api_style == "build_filter":
         builder = async_emitter.events.LogNoArguments.build_filter()
-        builder.fromBlock = "latest"
+        builder.from_block = "latest"
         event_filter = await builder.deploy(async_w3)
     else:
         event_filter = await async_emitter.events.LogNoArguments().create_filter(
-            fromBlock="latest"
+            from_block="latest"
         )
 
     expected_match_counter = 0

--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -340,8 +340,8 @@ is_not_indexed = complement(is_indexed)
 
 class BaseEventFilterBuilder:
     formatter = None
-    _fromBlock = None
-    _toBlock = None
+    _from_block = None
+    _to_block = None
     _address = None
     _immutable = False
 
@@ -361,30 +361,30 @@ class BaseEventFilterBuilder:
         self._ordered_arg_names = tuple(arg["name"] for arg in event_abi["inputs"])
 
     @property
-    def fromBlock(self) -> BlockIdentifier:
-        return self._fromBlock
+    def from_block(self) -> BlockIdentifier:
+        return self._from_block
 
-    @fromBlock.setter
-    def fromBlock(self, value: BlockIdentifier) -> None:
-        if self._fromBlock is None and not self._immutable:
-            self._fromBlock = value
+    @from_block.setter
+    def from_block(self, value: BlockIdentifier) -> None:
+        if self._from_block is None and not self._immutable:
+            self._from_block = value
         else:
             raise Web3ValueError(
-                f"fromBlock is already set to {self._fromBlock!r}. "
+                f"from_block is already set to {self._from_block!r}. "
                 "Resetting filter parameters is not permitted"
             )
 
     @property
-    def toBlock(self) -> BlockIdentifier:
-        return self._toBlock
+    def to_block(self) -> BlockIdentifier:
+        return self._to_block
 
-    @toBlock.setter
-    def toBlock(self, value: BlockIdentifier) -> None:
-        if self._toBlock is None and not self._immutable:
-            self._toBlock = value
+    @to_block.setter
+    def to_block(self, value: BlockIdentifier) -> None:
+        if self._to_block is None and not self._immutable:
+            self._to_block = value
         else:
             raise Web3ValueError(
-                f"toBlock is already set to {self._toBlock!r}. "
+                f"toBlock is already set to {self._to_block!r}. "
                 "Resetting filter parameters is not permitted"
             )
 
@@ -432,8 +432,8 @@ class BaseEventFilterBuilder:
     def filter_params(self) -> FilterParams:
         params = {
             "topics": self.topics,
-            "fromBlock": self.fromBlock,
-            "toBlock": self.toBlock,
+            "fromBlock": self.from_block,
+            "toBlock": self.to_block,
             "address": self.address,
         }
         return valfilter(lambda x: x is not None, params)

--- a/web3/_utils/filters.py
+++ b/web3/_utils/filters.py
@@ -73,8 +73,8 @@ def construct_event_filter_params(
     contract_address: Optional[ChecksumAddress] = None,
     argument_filters: Optional[Dict[str, Any]] = None,
     topics: Optional[Sequence[HexStr]] = None,
-    fromBlock: Optional[BlockIdentifier] = None,
-    toBlock: Optional[BlockIdentifier] = None,
+    from_block: Optional[BlockIdentifier] = None,
+    to_block: Optional[BlockIdentifier] = None,
     address: Optional[ChecksumAddress] = None,
 ) -> Tuple[List[List[Optional[HexStr]]], FilterParams]:
     filter_params: FilterParams = {}
@@ -121,11 +121,11 @@ def construct_event_filter_params(
     else:
         validate_address(filter_params["address"])
 
-    if fromBlock is not None:
-        filter_params["fromBlock"] = fromBlock
+    if from_block is not None:
+        filter_params["fromBlock"] = from_block
 
-    if toBlock is not None:
-        filter_params["toBlock"] = toBlock
+    if to_block is not None:
+        filter_params["toBlock"] = to_block
 
     data_filters_set = construct_event_data_set(event_abi, abi_codec, argument_filters)
 

--- a/web3/contract/async_contract.py
+++ b/web3/contract/async_contract.py
@@ -111,8 +111,8 @@ class AsyncContractEvent(BaseContractEvent):
     async def get_logs(
         self,
         argument_filters: Optional[Dict[str, Any]] = None,
-        fromBlock: Optional[BlockIdentifier] = None,
-        toBlock: Optional[BlockIdentifier] = None,
+        from_block: Optional[BlockIdentifier] = None,
+        to_block: Optional[BlockIdentifier] = None,
         block_hash: Optional[HexBytes] = None,
     ) -> Awaitable[Iterable[EventData]]:
         """
@@ -135,7 +135,7 @@ class AsyncContractEvent(BaseContractEvent):
             from = max(mycontract.web3.eth.block_number - 10, 1)
             to = mycontract.web3.eth.block_number
 
-            events = mycontract.events.Transfer.getLogs(fromBlock=from, toBlock=to)
+            events = mycontract.events.Transfer.getLogs(from_block=from, to_block=to)
 
             for e in events:
                 print(e["args"]["from"],
@@ -165,10 +165,10 @@ class AsyncContractEvent(BaseContractEvent):
 
         :param argument_filters: Filter by argument values. Indexed arguments are
           filtered by the node while non-indexed arguments are filtered by the library.
-        :param fromBlock: block number or "latest", defaults to "latest"
-        :param toBlock: block number or "latest". Defaults to "latest"
+        :param from_block: block number or "latest", defaults to "latest"
+        :param to_block: block number or "latest". Defaults to "latest"
         :param block_hash: block hash. Cannot be set at the
-          same time as fromBlock or toBlock
+          same time as ``from_block`` or ``to_block``
         :yield: Tuple of :class:`AttributeDict` instances
         """
         event_abi = self._get_event_abi()
@@ -183,7 +183,7 @@ class AsyncContractEvent(BaseContractEvent):
                 )
 
         _filter_params = self._get_event_filter_params(
-            event_abi, argument_filters, fromBlock, toBlock, block_hash
+            event_abi, argument_filters, from_block, to_block, block_hash
         )
         # call JSON-RPC API
         logs = await self.w3.eth.get_logs(_filter_params)
@@ -204,8 +204,8 @@ class AsyncContractEvent(BaseContractEvent):
         self,
         *,  # PEP 3102
         argument_filters: Optional[Dict[str, Any]] = None,
-        fromBlock: Optional[BlockIdentifier] = None,
-        toBlock: BlockIdentifier = "latest",
+        from_block: Optional[BlockIdentifier] = None,
+        to_block: BlockIdentifier = "latest",
         address: Optional[ChecksumAddress] = None,
         topics: Optional[Sequence[Any]] = None,
     ) -> AsyncLogFilter:
@@ -215,8 +215,8 @@ class AsyncContractEvent(BaseContractEvent):
         filter_builder = AsyncEventFilterBuilder(self._get_event_abi(), self.w3.codec)
         self._set_up_filter_builder(
             argument_filters,
-            fromBlock,
-            toBlock,
+            from_block,
+            to_block,
             address,
             topics,
             filter_builder,

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -204,9 +204,9 @@ class BaseContractEvent:
         self,
         abi: ABIEvent,
         argument_filters: Optional[Dict[str, Any]] = None,
-        fromBlock: Optional[BlockIdentifier] = None,
-        toBlock: Optional[BlockIdentifier] = None,
-        blockHash: Optional[HexBytes] = None,
+        from_block: Optional[BlockIdentifier] = None,
+        to_block: Optional[BlockIdentifier] = None,
+        block_hash: Optional[HexBytes] = None,
     ) -> FilterParams:
         if not self.address:
             raise Web3TypeError(
@@ -219,11 +219,12 @@ class BaseContractEvent:
 
         _filters = dict(**argument_filters)
 
-        blkhash_set = blockHash is not None
-        blknum_set = fromBlock is not None or toBlock is not None
+        blkhash_set = block_hash is not None
+        blknum_set = from_block is not None or to_block is not None
         if blkhash_set and blknum_set:
             raise Web3ValidationError(
-                "blockHash cannot be set at the same time as fromBlock or toBlock"
+                "`block_hash` cannot be set at the same time as "
+                "`from_block` or `to_block`"
             )
 
         # Construct JSON-RPC raw filter presentation based on human readable
@@ -233,13 +234,13 @@ class BaseContractEvent:
             self.w3.codec,
             contract_address=self.address,
             argument_filters=_filters,
-            fromBlock=fromBlock,
-            toBlock=toBlock,
+            from_block=from_block,
+            to_block=to_block,
             address=self.address,
         )
 
-        if blockHash is not None:
-            event_filter_params["blockHash"] = blockHash
+        if block_hash is not None:
+            event_filter_params["blockHash"] = block_hash
 
         return event_filter_params
 
@@ -319,15 +320,15 @@ class BaseContractEvent:
     def _set_up_filter_builder(
         self,
         argument_filters: Optional[Dict[str, Any]] = None,
-        fromBlock: Optional[BlockIdentifier] = None,
-        toBlock: BlockIdentifier = "latest",
+        from_block: Optional[BlockIdentifier] = None,
+        to_block: BlockIdentifier = "latest",
         address: Optional[ChecksumAddress] = None,
         topics: Optional[Sequence[Any]] = None,
         filter_builder: Union[EventFilterBuilder, AsyncEventFilterBuilder] = None,
     ) -> None:
-        if fromBlock is None:
+        if from_block is None:
             raise Web3TypeError(
-                "Missing mandatory keyword argument to create_filter: fromBlock"
+                "Missing mandatory keyword argument to create_filter: `from_block`"
             )
 
         if argument_filters is None:
@@ -344,8 +345,8 @@ class BaseContractEvent:
             self.w3.codec,
             contract_address=self.address,
             argument_filters=_filters,
-            fromBlock=fromBlock,
-            toBlock=toBlock,
+            from_block=from_block,
+            to_block=to_block,
             address=address,
             topics=topics,
         )
@@ -353,8 +354,8 @@ class BaseContractEvent:
         filter_builder.address = cast(
             ChecksumAddress, event_filter_params.get("address")
         )
-        filter_builder.fromBlock = event_filter_params.get("fromBlock")
-        filter_builder.toBlock = event_filter_params.get("toBlock")
+        filter_builder.from_block = event_filter_params.get("fromBlock")
+        filter_builder.to_block = event_filter_params.get("toBlock")
         match_any_vals = {
             arg: value
             for arg, value in _filters.items()

--- a/web3/contract/contract.py
+++ b/web3/contract/contract.py
@@ -110,8 +110,8 @@ class ContractEvent(BaseContractEvent):
     def get_logs(
         self,
         argument_filters: Optional[Dict[str, Any]] = None,
-        fromBlock: Optional[BlockIdentifier] = None,
-        toBlock: Optional[BlockIdentifier] = None,
+        from_block: Optional[BlockIdentifier] = None,
+        to_block: Optional[BlockIdentifier] = None,
         block_hash: Optional[HexBytes] = None,
     ) -> Iterable[EventData]:
         """
@@ -131,10 +131,10 @@ class ContractEvent(BaseContractEvent):
 
         .. code-block:: python
 
-            from = max(mycontract.web3.eth.block_number - 10, 1)
-            to = mycontract.web3.eth.block_number
+            from = max(my_contract.web3.eth.block_number - 10, 1)
+            to = my_contract.web3.eth.block_number
 
-            events = mycontract.events.Transfer.get_logs(fromBlock=from, toBlock=to)
+            events = my_contract.events.Transfer.get_logs(from_block=from, to_block=to)
 
             for e in events:
                 print(e["args"]["from"],
@@ -164,10 +164,10 @@ class ContractEvent(BaseContractEvent):
 
         :param argument_filters: Filter by argument values. Indexed arguments are
           filtered by the node while non-indexed arguments are filtered by the library.
-        :param fromBlock: block number or "latest", defaults to "latest"
-        :param toBlock: block number or "latest". Defaults to "latest"
+        :param from_block: block number or "latest", defaults to "latest"
+        :param to_block: block number or "latest". Defaults to "latest"
         :param block_hash: block hash. block_hash cannot be set at the
-          same time as fromBlock or toBlock
+          same time as ``from_block`` or ``to_block``
         :yield: Tuple of :class:`AttributeDict` instances
         """
         event_abi = self._get_event_abi()
@@ -182,7 +182,7 @@ class ContractEvent(BaseContractEvent):
                 )
 
         _filter_params = self._get_event_filter_params(
-            event_abi, argument_filters, fromBlock, toBlock, block_hash
+            event_abi, argument_filters, from_block, to_block, block_hash
         )
         # call JSON-RPC API
         logs = self.w3.eth.get_logs(_filter_params)
@@ -205,8 +205,8 @@ class ContractEvent(BaseContractEvent):
         self,
         *,  # PEP 3102
         argument_filters: Optional[Dict[str, Any]] = None,
-        fromBlock: Optional[BlockIdentifier] = None,
-        toBlock: BlockIdentifier = "latest",
+        from_block: Optional[BlockIdentifier] = None,
+        to_block: BlockIdentifier = "latest",
         address: Optional[ChecksumAddress] = None,
         topics: Optional[Sequence[Any]] = None,
     ) -> LogFilter:
@@ -216,8 +216,8 @@ class ContractEvent(BaseContractEvent):
         filter_builder = EventFilterBuilder(self._get_event_abi(), self.w3.codec)
         self._set_up_filter_builder(
             argument_filters,
-            fromBlock,
-            toBlock,
+            from_block,
+            to_block,
             address,
             topics,
             filter_builder,

--- a/web3/providers/eth_tester/middleware.py
+++ b/web3/providers/eth_tester/middleware.py
@@ -110,14 +110,14 @@ filter_request_remapper = apply_key_map(FILTER_REQUEST_KEY_MAPPING)
 
 
 FILTER_REQUEST_FORMATTERS = {
-    "fromBlock": to_integer_if_hex,
-    "toBlock": to_integer_if_hex,
+    "from_block": to_integer_if_hex,
+    "to_block": to_integer_if_hex,
 }
 filter_request_formatter = apply_formatters_to_dict(FILTER_REQUEST_FORMATTERS)
 
 filter_request_transformer = compose(
-    filter_request_remapper,
     filter_request_formatter,
+    filter_request_remapper,
 )
 
 


### PR DESCRIPTION
### What was wrong?

Closes #3085

### How was it fixed?

- snake-case remaining camel-cased arguments: `fromBlock`, `toBlock`, and `blockHash`

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="724" alt="Screenshot 2024-04-17 at 17 02 17" src="https://github.com/ethereum/web3.py/assets/3532824/ee6e8304-2ee1-4127-9683-2d720fb207bd">
