### PR TITLE
feat: Exponential backoff factor for HTTP request retries

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -146,8 +146,10 @@ Retry Requests for HTTP Providers
 
 ``HTTPProvider`` and ``AsyncHTTPProvider`` instances retry certain requests by default
 on exceptions. This can be configured via configuration options on the provider
-instance. Below is an example showing the default options for the retry configuration
-and how to override them.
+instance. The retry mechanism employs an exponential backoff strategy, starting from
+the initial value determined by the ``backoff_factor``, and doubling the delay with
+each attempt, up to the ``retries`` value. Below is an example showing the default
+options for the retry configuration and how to override them.
 
 .. code-block:: python
 
@@ -165,8 +167,8 @@ and how to override them.
             # number of retries to attempt
             retries=5,
 
-            # how long to wait between retries
-            backoff_factor=0.5,
+            # initial delay multiplier, doubles with each retry attempt
+            backoff_factor=0.125,
 
             # an in-house default list of retryable methods
             method_allowlist=REQUEST_RETRY_ALLOWLIST,

--- a/newsfragments/3358.breaking.rst
+++ b/newsfragments/3358.breaking.rst
@@ -1,0 +1,1 @@
+Employ an exponential backoff strategy using the ``backoff_factor`` in ``ExceptionRetryConfiguration`` for ``HTTPProvider`` and ``AsyncHTTPProvider``. Reduce the default initial delay to ``0.125`` seconds.

--- a/web3/providers/rpc/async_rpc.py
+++ b/web3/providers/rpc/async_rpc.py
@@ -123,7 +123,7 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
                 except tuple(self.exception_retry_configuration.errors):
                     if i < self.exception_retry_configuration.retries - 1:
                         await asyncio.sleep(
-                            self.exception_retry_configuration.backoff_factor
+                            self.exception_retry_configuration.backoff_factor * 2**i
                         )
                         continue
                     else:

--- a/web3/providers/rpc/rpc.py
+++ b/web3/providers/rpc/rpc.py
@@ -130,7 +130,9 @@ class HTTPProvider(JSONBaseProvider):
                     )
                 except tuple(self.exception_retry_configuration.errors) as e:
                     if i < self.exception_retry_configuration.retries - 1:
-                        time.sleep(self.exception_retry_configuration.backoff_factor)
+                        time.sleep(
+                            self.exception_retry_configuration.backoff_factor * 2**i
+                        )
                         continue
                     else:
                         raise e

--- a/web3/providers/rpc/utils.py
+++ b/web3/providers/rpc/utils.py
@@ -84,7 +84,7 @@ class ExceptionRetryConfiguration(BaseModel):
         self,
         errors: Sequence[Type[BaseException]] = None,
         retries: int = 5,
-        backoff_factor: float = 0.5,
+        backoff_factor: float = 0.125,
         method_allowlist: Sequence[str] = None,
     ):
         super().__init__(


### PR DESCRIPTION
### What was wrong?

Related to Issue https://github.com/ethereum/web3.py/issues/3210

### How was it fixed?
Make the backoff_factor for the ExceptionRetryConfiguration class work as an actual exponential "backoff factor" And Update the doc.

Reuse `backoff_factor` as the initial back off time

Introduce a new field `exponential_factor` 
### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="723" alt="Screenshot 2024-04-24 at 10 40 03" src="https://github.com/ethereum/web3.py/assets/3532824/d0cd8381-fae5-4ecf-bd45-fd26b6451eda">
