### PR TITLE
Stricter validation for JSON-RPC responses

### DIFF
--- a/docs/v7_migration.rst
+++ b/docs/v7_migration.rst
@@ -189,6 +189,41 @@ keys in the dictionary should be camelCase. This is because the dictionary is pa
 directly to the JSON-RPC request, where the keys are expected to be in camelCase.
 
 
+Changes to Exception Handling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All Python standard library exceptions that were raised from within web3.py have
+been replaced with custom ``Web3Exception`` classes. This change allows for better
+control over exception handling, being able to distinguish between exceptions raised
+by web3.py and those raised from elsewhere in a codebase. The following exceptions
+have been replaced:
+
+- ``AssertionError`` -> ``Web3AssertionError``
+- ``ValueError`` -> ``Web3ValueError``
+- ``TypeError`` -> ``Web3TypeError``
+- ``AttributeError`` -> ``Web3AttributeError``
+
+A new ``MethodNotSupported`` exception is now raised when a method is not supported by
+web3.py. This allows a user to distinguish between when a method is not available on
+the current provider, ``MethodUnavailable``, and when a method is not supported by
+web3.py under certain conditions, ``MethodNotSupported``.
+
+
+JSON-RPC Error Handling
+```````````````````````
+
+Rather than a ``ValueError`` being replaced with a ``Web3ValueError`` when a JSON-RPC
+response comes back with an ``error`` object, a new ``Web3RPCError`` exception is
+now raised to provide more distinction for JSON-RPC error responses. Some previously
+existing exceptions now extend from this class since they too are related to JSON-RPC
+errors:
+
+- ``MethodUnavailable``
+- ``BlockNotFound``
+- ``TransactionNotFound``
+- ``TransactionIndexingInProgress``
+
+
 Miscellaneous Changes
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -207,3 +242,5 @@ Miscellaneous Changes
   without checking if the ``geth.ipc`` file exists.
 - ``Web3.is_address()`` returns ``True`` for non-checksummed addresses.
 - ``Contract.encodeABI()`` has been renamed to ``Contract.encode_abi()``.
+- JSON-RPC responses are now more strictly validated against the JSON-RPC 2.0
+  specification while providing more informative error messages for invalid responses.

--- a/newsfragments/3359.breaking.rst
+++ b/newsfragments/3359.breaking.rst
@@ -1,0 +1,1 @@
+Validate JSON-RPC responses more strictly against the JSON-RPC 2.0 specifications. ``BlockNumberOutofRange`` -> ``BlockNumberOutOfRange``.

--- a/newsfragments/3359.feature.rst
+++ b/newsfragments/3359.feature.rst
@@ -1,0 +1,1 @@
+Raise ``Web3RPCError`` on JSON-RPC errors rather than ``Web3ValueError``. Raise ``MethodNotSupported`` exception when a method is not supported within *web3.py*; keep ``MethodUnavailable`` for when a method is not available on the current provider (JSON-RPC error).

--- a/tests/core/caching-utils/test_request_caching.py
+++ b/tests/core/caching-utils/test_request_caching.py
@@ -13,7 +13,7 @@ from web3._utils.caching import (
     generate_cache_key,
 )
 from web3.exceptions import (
-    Web3ValueError,
+    Web3RPCError,
 )
 from web3.providers import (
     AsyncBaseProvider,
@@ -31,7 +31,7 @@ def simple_cache_return_value_a():
     _cache = SimpleCache()
     _cache.cache(
         generate_cache_key(f"{threading.get_ident()}:{('fake_endpoint', [1])}"),
-        {"result": "value-a"},
+        {"jsonrpc": "2.0", "id": 0, "result": "value-a"},
     )
     return _cache
 
@@ -92,9 +92,9 @@ def test_request_caching_does_not_cache_error_responses(request_mocker):
     with request_mocker(
         w3, mock_errors={"fake_endpoint": lambda *_: {"message": f"msg-{uuid.uuid4()}"}}
     ):
-        with pytest.raises(Web3ValueError) as err_a:
+        with pytest.raises(Web3RPCError) as err_a:
             w3.manager.request_blocking("fake_endpoint", [])
-        with pytest.raises(Web3ValueError) as err_b:
+        with pytest.raises(Web3RPCError) as err_b:
             w3.manager.request_blocking("fake_endpoint", [])
 
         assert str(err_a) != str(err_b)
@@ -197,9 +197,9 @@ async def test_async_request_caching_does_not_cache_error_responses(request_mock
         async_w3,
         mock_errors={"fake_endpoint": lambda *_: {"message": f"msg-{uuid.uuid4()}"}},
     ):
-        with pytest.raises(Web3ValueError) as err_a:
+        with pytest.raises(Web3RPCError) as err_a:
             await async_w3.manager.coro_request("fake_endpoint", [])
-        with pytest.raises(Web3ValueError) as err_b:
+        with pytest.raises(Web3RPCError) as err_b:
             await async_w3.manager.coro_request("fake_endpoint", [])
 
     assert str(err_a) != str(err_b)

--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -38,7 +38,7 @@ from web3.contract.contract import (
 )
 from web3.exceptions import (
     BadFunctionCallOutput,
-    BlockNumberOutofRange,
+    BlockNumberOutOfRange,
     FallbackNotFound,
     InvalidAddress,
     MismatchedABI,
@@ -538,7 +538,7 @@ def test_call_nonexistent_receive_function(fallback_function_contract):
 
 def test_throws_error_if_block_out_of_range(w3, math_contract):
     w3.provider.make_request(method="evm_mine", params=[20])
-    with pytest.raises(BlockNumberOutofRange):
+    with pytest.raises(BlockNumberOutOfRange):
         math_contract.functions.counter().call(block_identifier=-50)
 
 
@@ -1726,7 +1726,7 @@ async def test_async_call_nonexistent_receive_function(
 @pytest.mark.asyncio
 async def test_async_throws_error_if_block_out_of_range(async_w3, async_math_contract):
     await async_w3.provider.make_request(method="evm_mine", params=[20])
-    with pytest.raises(BlockNumberOutofRange):
+    with pytest.raises(BlockNumberOutOfRange):
         await async_math_contract.functions.counter().call(block_identifier=-50)
 
 

--- a/tests/core/contracts/test_contract_caller_interface.py
+++ b/tests/core/contracts/test_contract_caller_interface.py
@@ -1,7 +1,7 @@
 import pytest
 
 from web3.exceptions import (
-    BlockNumberOutofRange,
+    BlockNumberOutOfRange,
     MismatchedABI,
     NoABIFound,
     NoABIFunctionsFound,
@@ -139,12 +139,12 @@ def test_caller_with_invalid_block_identifier(w3, math_contract):
     # Invalid `block_identifier` should not raise when passed to `caller` directly.
     # The function call itself parses the value.
     caller = math_contract.caller(block_identifier="abc")
-    with pytest.raises(BlockNumberOutofRange):
+    with pytest.raises(BlockNumberOutOfRange):
         caller.counter()
 
     # Calling the function with an invalid `block_identifier` will raise.
     default_caller = math_contract.caller()
-    with pytest.raises(BlockNumberOutofRange):
+    with pytest.raises(BlockNumberOutOfRange):
         default_caller.counter(block_identifier="abc")
 
 
@@ -347,12 +347,12 @@ async def test_async_caller_with_invalid_block_identifier(
     # Invalid `block_identifier` should not raise when passed to `caller` directly.
     # The function call itself parses the value.
     caller = async_math_contract.caller(block_identifier="abc")
-    with pytest.raises(BlockNumberOutofRange):
+    with pytest.raises(BlockNumberOutOfRange):
         await caller.counter()
 
     # Calling the function with an invalid `block_identifier` will raise.
     default_caller = async_math_contract.caller()
-    with pytest.raises(BlockNumberOutofRange):
+    with pytest.raises(BlockNumberOutOfRange):
         await default_caller.counter(block_identifier="abc")
 
 

--- a/tests/core/contracts/test_contract_util_functions.py
+++ b/tests/core/contracts/test_contract_util_functions.py
@@ -8,7 +8,7 @@ from web3._utils.contracts import (
     validate_payable,
 )
 from web3.exceptions import (
-    BlockNumberOutofRange,
+    BlockNumberOutOfRange,
 )
 
 
@@ -50,7 +50,7 @@ def test_parse_block_identifier_bytes_and_hex(w3):
     ),
 )
 def test_parse_block_identifier_error(w3, block_identifier):
-    with pytest.raises(BlockNumberOutofRange):
+    with pytest.raises(BlockNumberOutOfRange):
         parse_block_identifier(w3, block_identifier)
 
 
@@ -117,7 +117,7 @@ async def test_async_parse_block_identifier_bytes_and_hex(async_w3):
     ),
 )
 async def test_async_parse_block_identifier_error(async_w3, block_identifier):
-    with pytest.raises(BlockNumberOutofRange):
+    with pytest.raises(BlockNumberOutOfRange):
         await async_parse_block_identifier(async_w3, block_identifier)
 
 

--- a/tests/core/manager/test_middleware_can_be_stateful.py
+++ b/tests/core/manager/test_middleware_can_be_stateful.py
@@ -15,7 +15,7 @@ class StatefulMiddleware(Web3Middleware):
     def wrap_make_request(self, make_request):
         def middleware(method, params):
             self.state.append((method, params))
-            return {"result": self.state}
+            return {"jsonrpc": "2.0", "id": 1, "result": self.state}
 
         return middleware
 

--- a/tests/core/manager/test_provider_request_wrapping.py
+++ b/tests/core/manager/test_provider_request_wrapping.py
@@ -9,6 +9,8 @@ from web3.providers import (
 class DummyProvider(BaseProvider):
     def make_request(self, method, params):
         return {
+            "jsonrpc": "2.0",
+            "id": 1,
             "result": {
                 "method": method,
                 "params": params,

--- a/tests/core/manager/test_response_formatters.py
+++ b/tests/core/manager/test_response_formatters.py
@@ -4,6 +4,9 @@ import re
 from eth_utils.toolz import (
     identity,
 )
+from toolz import (
+    merge,
+)
 
 from web3._utils.method_formatters import (
     raise_block_not_found,
@@ -16,328 +19,354 @@ from web3.exceptions import (
     ContractLogicError,
     MethodUnavailable,
     TransactionNotFound,
-    Web3ValueError,
+    Web3RPCError,
 )
 
-ERROR_RESPONSE = {
+DEFAULT_BAD_FORMAT_MSG = (
+    "The response was in an unexpected format and unable to be parsed."
+)
+INVALID_JSONRPC_MSG = 'The "jsonrpc" field must be present with a value of "2.0".'
+ERROR_OBJ_MSG = (
+    'response["error"] must be a valid object as defined by the JSON-RPC '
+    "2.0 specification."
+)
+INVALID_ERROR_CODE_MSG = 'error["code"] is required and must be an integer value.'
+INVALID_ERROR_MESSAGE_MSG = 'error["message"] is required and must be a string value.'
+METHOD_UNAVAILABLE_MSG = (
+    "the method eth_getTransactionByHash does not exist/is not available."
+)
+DEFAULT_USER_MSG = (
+    "An RPC error was returned by the node. Check the message provided in the error "
+    "and any available logs for more information."
+)
+
+
+VALID_RESULT_OBJ_RESPONSE = {"jsonrpc": "2.0", "id": 1, "result": {"foo": "bar"}}
+VALID_RESPONSE_EXTRA_FIELDS = merge(VALID_RESULT_OBJ_RESPONSE, {"unexpected": "field"})
+VALID_RESPONSE_STRING_ID = merge(VALID_RESULT_OBJ_RESPONSE, {"id": "1"})
+
+# response fields validation: id, jsonrpc, missing result / error
+INVALID_RESPONSE_INVALID_ID = merge(VALID_RESULT_OBJ_RESPONSE, {"id": None})
+INVALID_RESPONSE_MISSING_ID = {"jsonrpc": "2.0", "result": {"foo": "bar"}}
+
+INVALID_RESPONSE_INVALID_JSONRPC = merge(VALID_RESULT_OBJ_RESPONSE, {"jsonrpc": "1.0"})
+INVALID_RESPONSE_MISSING_JSONRPC = {"id": 1, "result": {"foo": "bar"}}
+
+INVALID_RESPONSE_MISSING_RESULT_OR_ERROR = {"jsonrpc": "2.0", "id": 1}
+
+
+# valid subscription response
+VALID_SUBSCRIPTION_RESPONSE = {
     "jsonrpc": "2.0",
-    "error": {
-        "code": -32000,
-        "message": "Requested block number is in a range that is not available yet, "
-        "because the ancient block sync is still in progress.",
+    "method": "eth_subscription",
+    "params": {
+        "subscription": "0xf13f7073ddef66a8c1b0c9c9f0e543c3",
+        "result": {"foo": "bar"},
     },
 }
-ERROR_RESPONSE_WITH_NONE_ID = {
-    "id": None,
+
+# error object validation
+VALID_ERROR_RESPONSE = {
     "jsonrpc": "2.0",
-    "error": {
-        "code": -32000,
-        "message": "Requested block number is in a range that is not available yet, "
-        "because the ancient block sync is still in progress.",
-    },
-}
-ERROR_RESPONSE_WITH_VALID_ID = {
     "id": 1,
-    "jsonrpc": "2.0",
     "error": {
         "code": -32000,
-        "message": "Requested block number is in a range that is not available yet, "
-        "because the ancient block sync is still in progress.",
+        "message": (
+            "Requested block number is in a range that is not available yet, because "
+            "the ancient block sync is still in progress."
+        ),
     },
 }
-NONE_RESPONSE = {"jsonrpc": "2.0", "id": 1, "result": None}
-ZERO_X_RESPONSE = {"jsonrpc": "2.0", "id": 1, "result": "0x"}
-INVALID_JSONRPC_RESP_FORMAT = {
-    "jsonrpc": "999",
-    "error": {
-        "code": -32000,
-        "message": "Requested block number is in a range that is not available yet, "
-        "because the ancient block sync is still in progress.",
-    },
-}
-UNEXPECTED_RESPONSE_FORMAT = {"jsonrpc": "2.0", "id": 1}
-UNEXPECTED_RESPONSE_FORMAT_NONE_ID = {"jsonrpc": "2.0", "id": None}
-ANOTHER_UNEXPECTED_RESP_FORMAT = {
-    "name": "LimitError",
-    "message": "You cannot query logs for more than 10000 blocks at once.",
-    "method": "eth_getLogs",
-}
-METHOD_NOT_FOUND_RESP_FORMAT = {
-    "jsonrpc": "2.0",
-    "error": {
-        "code": -32601,
-        "message": "the method eth_getTransactionByHash does not exist/is not "
-        "available",
-    },
-}
-INVALID_CODE_RESP_FORMAT = {
-    "jsonrpc": "2.0",
-    "error": {
-        "code": "-32601",
-        "message": "the method eth_getTransactionByHash does not exist/is not "
-        "available",
-    },
-}
-MISSING_CODE_RESP_FORMAT = {
-    "jsonrpc": "2.0",
-    "error": {
-        "message": "the method eth_getTransactionByHash does not exist/is not "
-        "available",
-    },
-}
-INVALID_MESSAGE_RESP_FORMAT = {
-    "jsonrpc": "2.0",
-    "error": {
-        "code": -32000,
-        "message": {},
-    },
-}
-ETH_TESTER_METHOD_NOT_FOUND_RESP_FORMAT = {
-    "error": "the method eth_getTransactionByHash does not exist/is not available",
-}
+ERROR_RESPONSE_VALID_ID_STRING = merge(VALID_ERROR_RESPONSE, {"id": "1"})
+ERROR_RESPONSE_VALID_ID_NONE = merge(VALID_ERROR_RESPONSE, {"id": None})
+ERROR_RESPONSE_VALID_METHOD_UNAVAILABLE = merge(
+    VALID_ERROR_RESPONSE,
+    {"error": {"code": -32601, "message": (METHOD_UNAVAILABLE_MSG)}},
+)
+ERROR_RESPONSE_INVALID_ID = merge(VALID_ERROR_RESPONSE, {"id": b"invalid"})
+ERROR_RESPONSE_INVALID_ERROR_OBJECT = merge(
+    VALID_ERROR_RESPONSE, {"error": METHOD_UNAVAILABLE_MSG}
+)
+ERROR_RESPONSE_INVALID_CODE = merge(VALID_ERROR_RESPONSE, {"error": {"code": "-32601"}})
+ERROR_RESPONSE_INVALID_MESSAGE = merge(
+    VALID_ERROR_RESPONSE, {"error": {"code": -32000, "message": {}}}
+)
+ERROR_RESPONSE_INVALID_MISSING_CODE = merge(
+    VALID_ERROR_RESPONSE, {"error": {"message": "msg"}}
+)
+ERROR_RESPONSE_INVALID_MISSING_MESSAGE = merge(
+    VALID_ERROR_RESPONSE, {"error": {"code": -32000}}
+)
+
+# result object validation
+VALID_RESPONSE_NULL_RESULT = merge(VALID_RESULT_OBJ_RESPONSE, {"result": None})
+VALID_RESPONSE_0x_RESULT = merge(VALID_RESULT_OBJ_RESPONSE, {"result": "0x"})
 
 
-def raise_contract_logic_error(response):
-    raise ContractLogicError
+def raise_contract_logic_error(_response):
+    raise ContractLogicError("Test contract logic error.")
 
 
 @pytest.mark.parametrize(
-    "response,params,error_formatters,null_result_formatters,error",
+    "response,expected",
+    (
+        (VALID_RESULT_OBJ_RESPONSE, VALID_RESULT_OBJ_RESPONSE["result"]),
+        (VALID_RESPONSE_STRING_ID, VALID_RESPONSE_STRING_ID["result"]),
+        # extra fields are ignored
+        (VALID_RESPONSE_EXTRA_FIELDS, VALID_RESPONSE_EXTRA_FIELDS["result"]),
+        # Response with null result doesn't raise w/o null result formatters
+        (VALID_RESPONSE_NULL_RESULT, VALID_RESPONSE_NULL_RESULT["result"]),
+        # Response with a result of '0x' doesn't raise w/o null result formatters
+        (VALID_RESPONSE_0x_RESULT, VALID_RESPONSE_0x_RESULT["result"]),
+        # Subscription response
+        (VALID_SUBSCRIPTION_RESPONSE, VALID_SUBSCRIPTION_RESPONSE["params"]),
+    ),
+)
+def test_formatted_response_valid_response_object(w3, response, expected):
+    formatted_resp = w3.manager.formatted_response(response, (), identity, identity)
+    assert formatted_resp == expected
+
+
+@pytest.mark.parametrize(
+    "response,error,error_message",
     [
         (
-            # Error response with no result formatters raises a ValueError
-            ERROR_RESPONSE,
-            (),
-            identity,
-            identity,
-            Web3ValueError,
+            INVALID_RESPONSE_INVALID_JSONRPC,
+            BadResponseFormat,
+            f"{DEFAULT_BAD_FORMAT_MSG} {INVALID_JSONRPC_MSG} "
+            f"The raw response is: {INVALID_RESPONSE_INVALID_JSONRPC}",
         ),
         (
-            # Error response with error formatters raises error in formatter
-            ERROR_RESPONSE,
-            (),
-            raise_contract_logic_error,
-            identity,
-            ContractLogicError,
+            INVALID_RESPONSE_MISSING_JSONRPC,
+            BadResponseFormat,
+            f"{DEFAULT_BAD_FORMAT_MSG} {INVALID_JSONRPC_MSG} "
+            f"The raw response is: {INVALID_RESPONSE_MISSING_JSONRPC}",
         ),
         (
-            # Error response with no error formatters raises ValueError
-            ERROR_RESPONSE,
-            (),
-            identity,
-            raise_block_not_found,
-            Web3ValueError,
+            INVALID_RESPONSE_INVALID_ID,
+            BadResponseFormat,
+            f'{DEFAULT_BAD_FORMAT_MSG} "id" must be an integer or a string '
+            "representation of an integer. The raw response is: "
+            f"{INVALID_RESPONSE_INVALID_ID}",
         ),
         (
-            # Error response with no result formatters raises a ValueError
-            ERROR_RESPONSE_WITH_NONE_ID,
-            (),
-            identity,
-            raise_block_not_found,
-            Web3ValueError,
+            INVALID_RESPONSE_MISSING_ID,
+            BadResponseFormat,
+            f'{DEFAULT_BAD_FORMAT_MSG} Response must include an "id" field or be '
+            "formatted as an `eth_subscription` response. The raw response is: "
+            f"{INVALID_RESPONSE_MISSING_ID}",
         ),
         (
-            # Error response with no result formatters raises a ValueError
-            ERROR_RESPONSE_WITH_VALID_ID,
-            (),
-            identity,
-            raise_block_not_found,
-            Web3ValueError,
-        ),
-        (
-            # None result raises error if there is a null_result_formatter
-            NONE_RESPONSE,
-            (),
-            identity,
-            raise_block_not_found,
-            BlockNotFound,
-        ),
-        (
-            # Params are handled with a None result
-            NONE_RESPONSE,
-            ("0x03",),
-            identity,
-            raise_block_not_found,
-            BlockNotFound,
-        ),
-        (
-            # Multiple params are handled with a None result
-            NONE_RESPONSE,
-            ("0x03", "0x01"),
-            identity,
-            raise_block_not_found_for_uncle_at_index,
-            BlockNotFound,
-        ),
-        (
-            # Raise function handles missing param
-            NONE_RESPONSE,
-            ("0x01",),
-            identity,
-            raise_block_not_found_for_uncle_at_index,
-            BlockNotFound,
-        ),
-        (
-            # 0x response gets handled the same as a None response
-            ZERO_X_RESPONSE,
-            ("0x03"),
-            identity,
-            raise_transaction_not_found,
-            TransactionNotFound,
-        ),
-        (
-            METHOD_NOT_FOUND_RESP_FORMAT,
-            (),
-            identity,
-            identity,
-            MethodUnavailable,
-        ),
-        (
-            ETH_TESTER_METHOD_NOT_FOUND_RESP_FORMAT,
-            (),
-            identity,
-            identity,
-            Web3ValueError,
+            INVALID_RESPONSE_MISSING_RESULT_OR_ERROR,
+            BadResponseFormat,
+            f'{DEFAULT_BAD_FORMAT_MSG} Response must include either "error" or '
+            '"result". The raw response is: '
+            f"{INVALID_RESPONSE_MISSING_RESULT_OR_ERROR}",
         ),
     ],
 )
-def test_formatted_response_raises_errors(
-    w3, response, params, error_formatters, null_result_formatters, error
+def test_formatted_response_invalid_response_object(w3, response, error, error_message):
+    with pytest.raises(error, match=re.escape(error_message)):
+        w3.manager.formatted_response(response, (), identity, identity)
+
+
+@pytest.mark.parametrize(
+    "response,error,error_message",
+    (
+        (
+            VALID_ERROR_RESPONSE,
+            Web3RPCError,
+            f'{VALID_ERROR_RESPONSE["error"]}\nUser message: {DEFAULT_USER_MSG}',
+        ),
+        (
+            ERROR_RESPONSE_VALID_ID_STRING,
+            Web3RPCError,
+            f'{ERROR_RESPONSE_VALID_ID_STRING["error"]}\n'
+            f"User message: {DEFAULT_USER_MSG}",
+        ),
+        (
+            ERROR_RESPONSE_VALID_ID_NONE,
+            Web3RPCError,
+            f'{ERROR_RESPONSE_VALID_ID_NONE["error"]}\n'
+            f"User message: {DEFAULT_USER_MSG}",
+        ),
+        (
+            ERROR_RESPONSE_VALID_METHOD_UNAVAILABLE,
+            MethodUnavailable,
+            METHOD_UNAVAILABLE_MSG,
+        ),
+    ),
+)
+def test_formatted_response_valid_error_object(response, w3, error, error_message):
+    with pytest.raises(error, match=re.escape(error_message)):
+        w3.manager.formatted_response(response, (), identity, identity)
+
+
+@pytest.mark.parametrize(
+    "response,null_result_formatters,error,error_message",
+    [
+        (
+            ERROR_RESPONSE_INVALID_CODE,
+            identity,
+            BadResponseFormat,
+            f"{DEFAULT_BAD_FORMAT_MSG} {INVALID_ERROR_CODE_MSG} "
+            f"The raw response is: {ERROR_RESPONSE_INVALID_CODE}",
+        ),
+        (
+            ERROR_RESPONSE_INVALID_MISSING_CODE,
+            identity,
+            BadResponseFormat,
+            f"{DEFAULT_BAD_FORMAT_MSG} {INVALID_ERROR_CODE_MSG} "
+            f"The raw response is: {ERROR_RESPONSE_INVALID_MISSING_CODE}",
+        ),
+        (
+            ERROR_RESPONSE_INVALID_MESSAGE,
+            identity,
+            BadResponseFormat,
+            f"{DEFAULT_BAD_FORMAT_MSG} {INVALID_ERROR_MESSAGE_MSG} "
+            f"The raw response is: {ERROR_RESPONSE_INVALID_MESSAGE}",
+        ),
+        (
+            ERROR_RESPONSE_INVALID_MISSING_MESSAGE,
+            identity,
+            BadResponseFormat,
+            f"{DEFAULT_BAD_FORMAT_MSG} {INVALID_ERROR_MESSAGE_MSG} "
+            f"The raw response is: {ERROR_RESPONSE_INVALID_MISSING_MESSAGE}",
+        ),
+        (
+            ERROR_RESPONSE_INVALID_ID,
+            identity,
+            BadResponseFormat,
+            f'{DEFAULT_BAD_FORMAT_MSG} "id" must be an integer or a string '
+            "representation of an integer. "
+            f"The raw response is: {ERROR_RESPONSE_INVALID_ID}",
+        ),
+        (
+            ERROR_RESPONSE_INVALID_ERROR_OBJECT,
+            identity,
+            BadResponseFormat,
+            f"{DEFAULT_BAD_FORMAT_MSG} {ERROR_OBJ_MSG} The raw response is: "
+            f"{ERROR_RESPONSE_INVALID_ERROR_OBJECT}",
+        ),
+        (
+            # Invalid error response w/ null result formatters raises on invalid format
+            ERROR_RESPONSE_INVALID_ERROR_OBJECT,  # raises on invalid error object
+            raise_block_not_found,  # does not raise `BlockNotFound`
+            BadResponseFormat,
+            f"{DEFAULT_BAD_FORMAT_MSG} {ERROR_OBJ_MSG} The raw response is: "
+            f"{ERROR_RESPONSE_INVALID_ERROR_OBJECT}",
+        ),
+    ],
+)
+def test_formatted_response_invalid_error_object(
+    response, w3, null_result_formatters, error, error_message
 ):
-    with pytest.raises(error):
+    with pytest.raises(error, match=re.escape(error_message)):
+        w3.manager.formatted_response(response, (), identity, null_result_formatters)
+
+
+@pytest.mark.parametrize(
+    "error_formatters,null_result_formatters,error,error_message",
+    (
+        (
+            # Valid error response with error formatters raises error in formatter
+            raise_contract_logic_error,
+            identity,
+            ContractLogicError,
+            "Test contract logic error.",
+        ),
+        (
+            # Non-null valid error response with no error formatters and null result
+            # formatters raises generic `Web3RPCError`, not `BlockNotFound`
+            identity,
+            raise_block_not_found,
+            Web3RPCError,
+            f'{VALID_ERROR_RESPONSE["error"]}\nUser message: {DEFAULT_USER_MSG}',
+        ),
+        (
+            # Valid error response with no null result formatters raises `Web3RPCError`
+            identity,
+            identity,
+            Web3RPCError,
+            f'{VALID_ERROR_RESPONSE["error"]}\nUser message: {DEFAULT_USER_MSG}',
+        ),
+    ),
+)
+def test_formatted_response_error_responses_with_formatters_raise_expected_exceptions(
+    w3, error_formatters, null_result_formatters, error, error_message
+):
+    with pytest.raises(error, match=re.escape(error_message)):
         w3.manager.formatted_response(
-            response, params, error_formatters, null_result_formatters
+            VALID_ERROR_RESPONSE, (), error_formatters, null_result_formatters
         )
 
 
 @pytest.mark.parametrize(
-    "response,params,error_formatters,null_result_formatters,error,error_message",
-    [
+    "params,null_result_formatters,error,error_message",
+    (
+        # raise via null_result_formatters
         (
-            NONE_RESPONSE,
-            ("0x01",),
-            identity,
+            (),
+            # test raise_block_not_found
+            raise_block_not_found,
+            BlockNotFound,
+            "Unknown block identifier",
+        ),
+        (
+            ("0x03",),  # test with param
+            # test raise_block_not_found
+            raise_block_not_found,
+            BlockNotFound,
+            "Block with id: '0x03' not found.",
+        ),
+        (
+            (),
+            # test raise_block_not_found_for_uncle_at_index
             raise_block_not_found_for_uncle_at_index,
             BlockNotFound,
             "Unknown block identifier or uncle index",
         ),
         (
-            NONE_RESPONSE,
-            ("0x01", "0x00"),
-            identity,
+            ("0x01",),  # test handles missing param
+            # test raise_block_not_found_for_uncle_at_index
+            raise_block_not_found_for_uncle_at_index,
+            BlockNotFound,
+            "Unknown block identifier or uncle index",
+        ),
+        (
+            ("0x01", "0x00"),  # both params
+            # test raise_block_not_found_for_uncle_at_index
             raise_block_not_found_for_uncle_at_index,
             BlockNotFound,
             "Uncle at index: 0 of block with id: '0x01' not found.",
         ),
         (
-            ZERO_X_RESPONSE,
+            (),
+            # test raise_transaction_not_found
+            raise_transaction_not_found,
+            TransactionNotFound,
+            "Unknown transaction hash",
+        ),
+        (
             ("0x01",),
-            identity,
+            # test raise_transaction_not_found
             raise_transaction_not_found,
             TransactionNotFound,
             "Transaction with hash: '0x01' not found.",
         ),
-        (
-            INVALID_JSONRPC_RESP_FORMAT,
-            (),
-            identity,
-            identity,
-            BadResponseFormat,
-            f"The response was in an unexpected format and unable to be parsed. "
-            f'The "jsonrpc" field must be present with a value of "2.0". '
-            f"The raw response is: {INVALID_JSONRPC_RESP_FORMAT}",
-        ),
-        (
-            UNEXPECTED_RESPONSE_FORMAT,
-            (),
-            identity,
-            identity,
-            BadResponseFormat,
-            f"The response was in an unexpected format and unable to be parsed. "
-            f"The raw response is: {UNEXPECTED_RESPONSE_FORMAT}",
-        ),
-        (
-            ANOTHER_UNEXPECTED_RESP_FORMAT,
-            (),
-            identity,
-            identity,
-            BadResponseFormat,
-            f"The response was in an unexpected format and unable to be parsed. "
-            f"The raw response is: {ANOTHER_UNEXPECTED_RESP_FORMAT}",
-        ),
-        (
-            INVALID_CODE_RESP_FORMAT,
-            (),
-            identity,
-            identity,
-            BadResponseFormat,
-            re.escape(
-                f"The response was in an unexpected format and unable to be parsed. "
-                f"error['code'] must be an integer. "
-                f"The raw response is: {INVALID_CODE_RESP_FORMAT}"
-            ),
-        ),
-        (
-            MISSING_CODE_RESP_FORMAT,
-            (),
-            identity,
-            identity,
-            BadResponseFormat,
-            re.escape(
-                f"The response was in an unexpected format and unable to be parsed. "
-                f"error['code'] must be an integer. "
-                f"The raw response is: {MISSING_CODE_RESP_FORMAT}"
-            ),
-        ),
-        (
-            INVALID_MESSAGE_RESP_FORMAT,
-            (),
-            identity,
-            identity,
-            BadResponseFormat,
-            re.escape(
-                f"The response was in an unexpected format and unable to be parsed. "
-                f"error['message'] must be a string. "
-                f"The raw response is: {INVALID_MESSAGE_RESP_FORMAT}"
-            ),
-        ),
-    ],
+    ),
 )
-def test_formatted_response_raises_correct_error_message(
-    response, w3, params, error_formatters, null_result_formatters, error, error_message
+def test_formatted_response_null_and_0x_results_with_formatters(
+    w3, params, null_result_formatters, error, error_message
 ):
-    with pytest.raises(error, match=error_message):
+    with pytest.raises(error, match=re.escape(error_message)):
+        # test null result response
         w3.manager.formatted_response(
-            response, params, error_formatters, null_result_formatters
+            VALID_RESPONSE_NULL_RESULT, params, identity, null_result_formatters
         )
 
-
-@pytest.mark.parametrize(
-    "response,params,error_formatters,null_result_formatters,expected",
-    [
-        (
-            # Response with a result of None doesn't raise
-            # if there is no null result formatter
-            NONE_RESPONSE,
-            ("0x03"),
-            identity,
-            identity,
-            NONE_RESPONSE["result"],
-        ),
-        (
-            # Response with a result of 0x doesn't raise
-            # if there is no null result formatter
-            ZERO_X_RESPONSE,
-            ("0x03"),
-            identity,
-            identity,
-            ZERO_X_RESPONSE["result"],
-        ),
-    ],
-)
-def test_formatted_response(
-    response, w3, params, error_formatters, null_result_formatters, expected
-):
-    formatted_resp = w3.manager.formatted_response(
-        response, params, error_formatters, null_result_formatters
-    )
-    assert formatted_resp == expected
+    with pytest.raises(error, match=re.escape(error_message)):
+        # test 0x result response
+        w3.manager.formatted_response(
+            VALID_RESPONSE_0x_RESULT, params, identity, null_result_formatters
+        )

--- a/tests/core/manager/test_response_formatters.py
+++ b/tests/core/manager/test_response_formatters.py
@@ -35,10 +35,6 @@ INVALID_ERROR_MESSAGE_MSG = 'error["message"] is required and must be a string v
 METHOD_UNAVAILABLE_MSG = (
     "the method eth_getTransactionByHash does not exist/is not available."
 )
-DEFAULT_USER_MSG = (
-    "An RPC error was returned by the node. Check the message provided in the error "
-    "and any available logs for more information."
-)
 
 
 VALID_RESULT_OBJ_RESPONSE = {"jsonrpc": "2.0", "id": 1, "result": {"foo": "bar"}}
@@ -179,19 +175,17 @@ def test_formatted_response_invalid_response_object(w3, response, error, error_m
         (
             VALID_ERROR_RESPONSE,
             Web3RPCError,
-            f'{VALID_ERROR_RESPONSE["error"]}\nUser message: {DEFAULT_USER_MSG}',
+            f'{VALID_ERROR_RESPONSE["error"]}',
         ),
         (
             ERROR_RESPONSE_VALID_ID_STRING,
             Web3RPCError,
-            f'{ERROR_RESPONSE_VALID_ID_STRING["error"]}\n'
-            f"User message: {DEFAULT_USER_MSG}",
+            f'{ERROR_RESPONSE_VALID_ID_STRING["error"]}',
         ),
         (
             ERROR_RESPONSE_VALID_ID_NONE,
             Web3RPCError,
-            f'{ERROR_RESPONSE_VALID_ID_NONE["error"]}\n'
-            f"User message: {DEFAULT_USER_MSG}",
+            f'{ERROR_RESPONSE_VALID_ID_NONE["error"]}',
         ),
         (
             ERROR_RESPONSE_VALID_METHOD_UNAVAILABLE,
@@ -284,7 +278,7 @@ def test_formatted_response_invalid_error_object(
             identity,
             raise_block_not_found,
             Web3RPCError,
-            f'{VALID_ERROR_RESPONSE["error"]}\nUser message: {DEFAULT_USER_MSG}',
+            f'{VALID_ERROR_RESPONSE["error"]}',
         ),
     ),
 )

--- a/tests/core/manager/test_response_formatters.py
+++ b/tests/core/manager/test_response_formatters.py
@@ -3,8 +3,6 @@ import re
 
 from eth_utils.toolz import (
     identity,
-)
-from toolz import (
     merge,
 )
 

--- a/tests/core/manager/test_response_formatters.py
+++ b/tests/core/manager/test_response_formatters.py
@@ -84,18 +84,21 @@ ERROR_RESPONSE_VALID_METHOD_UNAVAILABLE = merge(
     {"error": {"code": -32601, "message": (METHOD_UNAVAILABLE_MSG)}},
 )
 ERROR_RESPONSE_INVALID_ID = merge(VALID_ERROR_RESPONSE, {"id": b"invalid"})
-ERROR_RESPONSE_INVALID_ERROR_OBJECT = merge(
-    VALID_ERROR_RESPONSE, {"error": METHOD_UNAVAILABLE_MSG}
-)
+
 ERROR_RESPONSE_INVALID_CODE = merge(VALID_ERROR_RESPONSE, {"error": {"code": "-32601"}})
-ERROR_RESPONSE_INVALID_MESSAGE = merge(
-    VALID_ERROR_RESPONSE, {"error": {"code": -32000, "message": {}}}
-)
 ERROR_RESPONSE_INVALID_MISSING_CODE = merge(
     VALID_ERROR_RESPONSE, {"error": {"message": "msg"}}
 )
+
+ERROR_RESPONSE_INVALID_MESSAGE = merge(
+    VALID_ERROR_RESPONSE, {"error": {"code": -32000, "message": {}}}
+)
 ERROR_RESPONSE_INVALID_MISSING_MESSAGE = merge(
     VALID_ERROR_RESPONSE, {"error": {"code": -32000}}
+)
+
+ERROR_RESPONSE_INVALID_ERROR_OBJECT = merge(
+    VALID_ERROR_RESPONSE, {"error": METHOD_UNAVAILABLE_MSG}
 )
 
 # result object validation
@@ -280,13 +283,6 @@ def test_formatted_response_invalid_error_object(
             # formatters raises generic `Web3RPCError`, not `BlockNotFound`
             identity,
             raise_block_not_found,
-            Web3RPCError,
-            f'{VALID_ERROR_RESPONSE["error"]}\nUser message: {DEFAULT_USER_MSG}',
-        ),
-        (
-            # Valid error response with no null result formatters raises `Web3RPCError`
-            identity,
-            identity,
             Web3RPCError,
             f'{VALID_ERROR_RESPONSE["error"]}\nUser message: {DEFAULT_USER_MSG}',
         ),

--- a/tests/core/middleware/test_formatting_middleware.py
+++ b/tests/core/middleware/test_formatting_middleware.py
@@ -7,7 +7,7 @@ from web3 import (
     Web3,
 )
 from web3.exceptions import (
-    Web3ValueError,
+    Web3RPCError,
 )
 from web3.middleware import (
     FormattingMiddlewareBuilder,
@@ -98,6 +98,6 @@ def test_formatting_middleware_error_formatters(w3, request_mocker):
 
     expected = "error"
     with request_mocker(w3, mock_errors={"test_endpoint": {"message": "error"}}):
-        with pytest.raises(Web3ValueError) as err:
+        with pytest.raises(Web3RPCError) as err:
             w3.manager.request_blocking("test_endpoint", [])
             assert str(err.value) == expected

--- a/web3/_utils/contracts.py
+++ b/web3/_utils/contracts.py
@@ -75,7 +75,7 @@ from web3._utils.normalizers import (
     abi_string_to_text,
 )
 from web3.exceptions import (
-    BlockNumberOutofRange,
+    BlockNumberOutOfRange,
     Web3TypeError,
     Web3ValidationError,
     Web3ValueError,
@@ -424,7 +424,7 @@ def parse_block_identifier(
     ):
         return w3.eth.get_block(block_identifier)["number"]
     else:
-        raise BlockNumberOutofRange
+        raise BlockNumberOutOfRange
 
 
 def parse_block_identifier_int(w3: "Web3", block_identifier_int: int) -> BlockNumber:
@@ -434,7 +434,7 @@ def parse_block_identifier_int(w3: "Web3", block_identifier_int: int) -> BlockNu
         last_block = w3.eth.get_block("latest")["number"]
         block_num = last_block + block_identifier_int + 1
         if block_num < 0:
-            raise BlockNumberOutofRange
+            raise BlockNumberOutOfRange
     return BlockNumber(block_num)
 
 
@@ -453,7 +453,7 @@ async def async_parse_block_identifier(
         requested_block = await async_w3.eth.get_block(block_identifier)
         return requested_block["number"]
     else:
-        raise BlockNumberOutofRange
+        raise BlockNumberOutOfRange
 
 
 async def async_parse_block_identifier_int(
@@ -466,5 +466,5 @@ async def async_parse_block_identifier_int(
         last_block_num = last_block["number"]
         block_num = last_block_num + block_identifier_int + 1
         if block_num < 0:
-            raise BlockNumberOutofRange
+            raise BlockNumberOutOfRange
     return BlockNumber(block_num)

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -83,7 +83,9 @@ from web3.exceptions import (
     TooManyRequests,
     TransactionNotFound,
     TransactionTypeMismatch,
+    Web3RPCError,
     Web3ValidationError,
+    Web3ValueError,
 )
 from web3.middleware import (
     ExtraDataToPOAMiddleware,
@@ -399,7 +401,7 @@ class AsyncEthModuleTest:
             }
         """
         with pytest.raises(
-            ValueError,
+            Web3ValueError,
             match=r".*Expected 2 items for array type Person\[2\], got 1 items.*",
         ):
             await async_w3.eth.sign_typed_data(
@@ -1137,7 +1139,7 @@ class AsyncEthModuleTest:
     ) -> None:
         unknown_identifier = "unknown"
         with pytest.raises(
-            ValueError,
+            Web3ValueError,
             match=(
                 "Value did not match any of the recognized block identifiers: "
                 f"{unknown_identifier}"
@@ -1537,7 +1539,7 @@ class AsyncEthModuleTest:
         default_max_redirects = async_w3.provider.ccip_read_max_redirects
 
         async_w3.provider.ccip_read_max_redirects = max_redirects
-        with pytest.raises(ValueError, match="at least 4"):
+        with pytest.raises(Web3ValueError, match="at least 4"):
             await async_offchain_lookup_contract.caller().testOffchainLookup(
                 OFFCHAIN_LOOKUP_TEST_DATA
             )
@@ -1836,7 +1838,7 @@ class AsyncEthModuleTest:
             "fromBlock": async_block_with_txn_with_log["number"],
             "toBlock": BlockNumber(async_block_with_txn_with_log["number"] - 1),
         }
-        with pytest.raises(ValueError):
+        with pytest.raises(Web3RPCError):
             result = await async_w3.eth.get_logs(filter_params)
 
         # Test with `address`
@@ -2273,7 +2275,7 @@ class AsyncEthModuleTest:
         txn_params["maxFeePerGas"] = one_gwei_in_wei
         txn_params["maxPriorityFeePerGas"] = one_gwei_in_wei
 
-        with pytest.raises(ValueError, match="replacement transaction underpriced"):
+        with pytest.raises(Web3RPCError, match="replacement transaction underpriced"):
             await async_w3.eth.replace_transaction(txn_hash, txn_params)
 
     @flaky_geth_dev_mining
@@ -2319,7 +2321,7 @@ class AsyncEthModuleTest:
 
         txn_params["maxFeePerGas"] = async_w3.to_wei(3, "gwei")
         txn_params["maxPriorityFeePerGas"] = async_w3.to_wei(2, "gwei")
-        with pytest.raises(ValueError, match="Supplied transaction with hash"):
+        with pytest.raises(Web3ValueError, match="Supplied transaction with hash"):
             await async_w3.eth.replace_transaction(txn_hash, txn_params)
 
     @flaky_geth_dev_mining
@@ -2341,7 +2343,7 @@ class AsyncEthModuleTest:
         txn_params["maxFeePerGas"] = async_w3.to_wei(3, "gwei")
         txn_params["maxPriorityFeePerGas"] = async_w3.to_wei(2, "gwei")
         txn_params["nonce"] = Nonce(txn["nonce"] + 1)
-        with pytest.raises(ValueError):
+        with pytest.raises(Web3ValueError):
             await async_w3.eth.replace_transaction(txn_hash, txn_params)
 
     @flaky_geth_dev_mining
@@ -2361,7 +2363,7 @@ class AsyncEthModuleTest:
         txn_hash = await async_w3.eth.send_transaction(txn_params)
 
         txn_params["gasPrice"] = async_w3.to_wei(1, "gwei")
-        with pytest.raises(ValueError):
+        with pytest.raises(Web3ValueError):
             await async_w3.eth.replace_transaction(txn_hash, txn_params)
 
     @flaky_geth_dev_mining
@@ -2965,7 +2967,7 @@ class EthModuleTest:
             }
         """
         with pytest.raises(
-            ValueError,
+            Web3ValueError,
             match=r".*Expected 2 items for array type Person\[2\], got 1 items.*",
         ):
             w3.eth.sign_typed_data(
@@ -3481,7 +3483,7 @@ class EthModuleTest:
         txn_params["maxFeePerGas"] = one_gwei_in_wei
         txn_params["maxPriorityFeePerGas"] = one_gwei_in_wei
 
-        with pytest.raises(ValueError, match="replacement transaction underpriced"):
+        with pytest.raises(Web3RPCError, match="replacement transaction underpriced"):
             w3.eth.replace_transaction(txn_hash, txn_params)
 
     @flaky_geth_dev_mining
@@ -3521,7 +3523,7 @@ class EthModuleTest:
 
         txn_params["maxFeePerGas"] = w3.to_wei(3, "gwei")
         txn_params["maxPriorityFeePerGas"] = w3.to_wei(2, "gwei")
-        with pytest.raises(ValueError, match="Supplied transaction with hash"):
+        with pytest.raises(Web3ValueError, match="Supplied transaction with hash"):
             w3.eth.replace_transaction(txn_hash, txn_params)
 
     @flaky_geth_dev_mining
@@ -3542,7 +3544,7 @@ class EthModuleTest:
         txn_params["maxFeePerGas"] = w3.to_wei(3, "gwei")
         txn_params["maxPriorityFeePerGas"] = w3.to_wei(2, "gwei")
         txn_params["nonce"] = Nonce(txn["nonce"] + 1)
-        with pytest.raises(ValueError):
+        with pytest.raises(Web3ValueError):
             w3.eth.replace_transaction(txn_hash, txn_params)
 
     @flaky_geth_dev_mining
@@ -3559,7 +3561,7 @@ class EthModuleTest:
         txn_hash = w3.eth.send_transaction(txn_params)
 
         txn_params["gasPrice"] = w3.to_wei(1, "gwei")
-        with pytest.raises(ValueError):
+        with pytest.raises(Web3ValueError):
             w3.eth.replace_transaction(txn_hash, txn_params)
 
     @flaky_geth_dev_mining
@@ -4003,7 +4005,7 @@ class EthModuleTest:
         default_max_redirects = w3.provider.ccip_read_max_redirects
 
         w3.provider.ccip_read_max_redirects = max_redirects
-        with pytest.raises(ValueError, match="at least 4"):
+        with pytest.raises(Web3ValueError, match="at least 4"):
             offchain_lookup_contract.functions.testOffchainLookup(
                 OFFCHAIN_LOOKUP_TEST_DATA
             ).call()
@@ -4549,7 +4551,7 @@ class EthModuleTest:
             "fromBlock": block_with_txn_with_log["number"],
             "toBlock": BlockNumber(block_with_txn_with_log["number"] - 1),
         }
-        with pytest.raises(ValueError):
+        with pytest.raises(Web3RPCError):
             w3.eth.get_logs(filter_params)
 
         # Test with `address`
@@ -4768,7 +4770,7 @@ class EthModuleTest:
     ) -> None:
         unknown_identifier = "unknown"
         with pytest.raises(
-            ValueError,
+            Web3ValueError,
             match=(
                 "Value did not match any of the recognized block identifiers: "
                 f"{unknown_identifier}"

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -57,12 +57,13 @@ from web3.eth.base_eth import (
     BaseEth,
 )
 from web3.exceptions import (
-    MethodUnavailable,
+    MethodNotSupported,
     OffchainLookup,
     TimeExhausted,
     TooManyRequests,
     TransactionIndexingInProgress,
     TransactionNotFound,
+    Web3RPCError,
     Web3ValueError,
 )
 from web3.method import (
@@ -194,7 +195,7 @@ class AsyncEth(BaseEth):
         """
         try:
             return await self._max_priority_fee()
-        except (ValueError, MethodUnavailable):
+        except Web3RPCError:
             warnings.warn(
                 "There was an issue with the method eth_maxPriorityFeePerGas. "
                 "Calculating using eth_feeHistory.",
@@ -736,7 +737,7 @@ class AsyncEth(BaseEth):
         ] = None,
     ) -> HexStr:
         if not isinstance(self.w3.provider, PersistentConnectionProvider):
-            raise MethodUnavailable(
+            raise MethodNotSupported(
                 "eth_subscribe is only supported with providers that support "
                 "persistent connections."
             )
@@ -753,7 +754,7 @@ class AsyncEth(BaseEth):
 
     async def unsubscribe(self, subscription_id: HexStr) -> bool:
         if not isinstance(self.w3.provider, PersistentConnectionProvider):
-            raise MethodUnavailable(
+            raise MethodNotSupported(
                 "eth_unsubscribe is only supported with providers that support "
                 "persistent connections."
             )

--- a/web3/eth/eth.py
+++ b/web3/eth/eth.py
@@ -57,12 +57,12 @@ from web3.eth.base_eth import (
     BaseEth,
 )
 from web3.exceptions import (
-    MethodUnavailable,
     OffchainLookup,
     TimeExhausted,
     TooManyRequests,
     TransactionIndexingInProgress,
     TransactionNotFound,
+    Web3RPCError,
     Web3ValueError,
 )
 from web3.method import (
@@ -187,7 +187,7 @@ class Eth(BaseEth):
         """
         try:
             return self._max_priority_fee()
-        except (ValueError, MethodUnavailable):
+        except Web3RPCError:
             warnings.warn(
                 "There was an issue with the method eth_maxPriorityFeePerGas. "
                 "Calculating using eth_feeHistory.",

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -78,6 +78,12 @@ class Web3TypeError(Web3Exception, TypeError):
     """
 
 
+class MethodNotSupported(Web3Exception):
+    """
+    Raised when a method is not supported by the provider.
+    """
+
+
 class BadFunctionCallOutput(Web3Exception):
     """
     We failed to decode ABI output.
@@ -225,25 +231,6 @@ class TimeExhausted(Web3Exception):
     """
 
 
-class TransactionNotFound(Web3Exception):
-    """
-    Raised when a tx hash used to look up a tx in a jsonrpc call cannot be found.
-    """
-
-
-class TransactionIndexingInProgress(Web3Exception):
-    """
-    Raised when a transaction receipt is not yet available due to transaction indexing
-    still being in progress.
-    """
-
-
-class BlockNotFound(Web3Exception):
-    """
-    Raised when the block id used to lookup a block in a jsonrpc call cannot be found.
-    """
-
-
 class InfuraProjectIdNotFound(Web3Exception):
     """
     Raised when there is no Infura Project Id set.
@@ -356,14 +343,21 @@ class MethodUnavailable(Web3RPCError):
     Raised when the method is not available on the node
     """
 
-    def __init__(
-        self,
-        message: str,
-        rpc_response: Optional[RPCResponse] = None,
-        user_message: Optional[str] = "This method is not available.",
-    ) -> None:
-        super().__init__(
-            message,
-            rpc_response=rpc_response,
-            user_message=user_message,
-        )
+
+class TransactionNotFound(Web3RPCError):
+    """
+    Raised when a tx hash used to look up a tx in a jsonrpc call cannot be found.
+    """
+
+
+class TransactionIndexingInProgress(Web3RPCError):
+    """
+    Raised when a transaction receipt is not yet available due to transaction indexing
+    still being in progress.
+    """
+
+
+class BlockNotFound(Web3RPCError):
+    """
+    Raised when the block id used to look up a block in a jsonrpc call cannot be found.
+    """

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -43,12 +43,6 @@ class Web3Exception(Exception):
         # Assign properties of Web3Exception
         self.user_message = user_message
 
-    def __str__(self) -> str:
-        # append a clarifying user message if one is provided
-        return super().__str__() + (
-            f"\nUser message: {self.user_message}" if self.user_message else ""
-        )
-
 
 class Web3AssertionError(Web3Exception, AssertionError):
     """

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -193,6 +193,7 @@ def _validate_response(
         elif code == METHOD_NOT_FOUND:
             raise MethodUnavailable(
                 repr(error),
+                rpc_response=response,
                 user_message="Check your node provider or your client's API docs to "
                 "see what methods are supported and / or currently enabled.",
             )

--- a/web3/types.py
+++ b/web3/types.py
@@ -295,7 +295,7 @@ RPCId = Optional[Union[int, str]]
 
 
 class RPCResponse(TypedDict, total=False):
-    error: Union[RPCError, str]
+    error: RPCError
     id: RPCId
     jsonrpc: Literal["2.0"]
     result: Any


### PR DESCRIPTION
### What was wrong?

Closes #3095 by more tightly validating the JSON-RPC responses coming from providers (not just the `id` as the issue states) while providing good messaging on errors.

This PR also includes the following changes:

- Use `Web3RPCError` instead of a generic `Web3ValueError` for JSON-RPC errors returned by the provider.
- Error log the `user_message`, debug log the `response` for RPC errors for better clarity / debugging.
- In the spirit of wrapping up breaking changes for `v7` and snake-casing some final remnants of camelCase args, capitalize "Of": `BlockNumberOutofRange` -> `BlockNumberOutOfRange`
- Distinguish between `MethodUnavailable` (a JSON-RPC error from the node) and `MethodNotSupported` (*web3.py* does not support the method, internally, under some conditions).
- Re-organize the formatted_response tests to be more readable. Separate test cases into tests where they make sense together: test valid responses, test invalid fields, test valid error responses, test invalid error object, test error formatters and null formatters together.

### How was it fixed?

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes (including the `v7` migration guide)
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20240422_182152](https://github.com/ethereum/web3.py/assets/3532824/00d243fb-41c8-4367-8505-c8c87b5f8981)

