### PR TITLE
Bump pytest-asyncio

### DIFF
--- a/newsfragments/3368.internal.rst
+++ b/newsfragments/3368.internal.rst
@@ -1,0 +1,1 @@
+Increase pytest-asyncio dependency to be >=0.21.2,<0.23

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extras_require = {
         "importlib-metadata<5.0;python_version<'3.8'",
         "pre-commit>=2.21.0",
         "pytest>=7.0.0",
-        "pytest-asyncio>=0.18.1,<0.23",
+        "pytest-asyncio>=0.21.2,<0.23",
         "pytest-mock>=1.10",
         "pytest-watch>=4.2",
         "pytest-xdist>=1.29",


### PR DESCRIPTION
### What was wrong?
pytest/pytest-asyncio had a bug: https://github.com/pytest-dev/pytest/issues/12269. 

### How was it fixed?
pytest-asyncio has the fix released in 0.21.2.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)


#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://img.freepik.com/free-photo/full-shot-cute-dog-making-mess_23-2149636183.jpg)
