### PR TITLE
V7 support for request batching

### DIFF
--- a/newsfragments/3370.feature.rst
+++ b/newsfragments/3370.feature.rst
@@ -1,0 +1,1 @@
+Add support for request batching via ``w3.batch_requests()`` context manager (sync and async).

--- a/tests/integration/go_ethereum/common.py
+++ b/tests/integration/go_ethereum/common.py
@@ -17,6 +17,9 @@ from web3._utils.module_testing import (  # noqa: F401
     NetModuleTest,
     Web3ModuleTest,
 )
+from web3._utils.module_testing.web3_module import (
+    AsyncWeb3ModuleTest,
+)
 from web3.types import (
     BlockData,
 )
@@ -27,7 +30,7 @@ if TYPE_CHECKING:
     )
 
 
-class GoEthereumTest(Web3ModuleTest):
+class GoEthereumWeb3ModuleTest(Web3ModuleTest):
     def _check_web3_client_version(self, client_version):
         assert client_version.startswith("Geth/")
 
@@ -85,12 +88,16 @@ class GoEthereumNetModuleTest(NetModuleTest):
     pass
 
 
-class GoEthereumAsyncNetModuleTest(AsyncNetModuleTest):
-    pass
-
-
 class GoEthereumAdminModuleTest(GoEthereumAdminModuleTest):
     pass
+
+
+# --- async --- #
+
+
+class GoEthereumAsyncWeb3ModuleTest(AsyncWeb3ModuleTest):
+    def _check_web3_client_version(self, client_version):
+        assert client_version.startswith("Geth/")
 
 
 class GoEthereumAsyncEthModuleTest(AsyncEthModuleTest):
@@ -111,3 +118,7 @@ class GoEthereumAsyncEthModuleTest(AsyncEthModuleTest):
         await super().test_invalid_eth_sign_typed_data(
             async_w3, keyfile_account_address_dual_type, async_skip_if_testrpc
         )
+
+
+class GoEthereumAsyncNetModuleTest(AsyncNetModuleTest):
+    pass

--- a/tests/integration/go_ethereum/test_goethereum_http.py
+++ b/tests/integration/go_ethereum/test_goethereum_http.py
@@ -21,10 +21,11 @@ from .common import (
     GoEthereumAsyncEthModuleTest,
     GoEthereumAsyncNetModuleTest,
     GoEthereumAsyncTxPoolModuleTest,
+    GoEthereumAsyncWeb3ModuleTest,
     GoEthereumEthModuleTest,
     GoEthereumNetModuleTest,
-    GoEthereumTest,
     GoEthereumTxPoolModuleTest,
+    GoEthereumWeb3ModuleTest,
 )
 from .utils import (
     wait_for_aiohttp,
@@ -70,7 +71,7 @@ def w3(geth_process, endpoint_uri):
     return Web3(Web3.HTTPProvider(endpoint_uri))
 
 
-class TestGoEthereumTest(GoEthereumTest):
+class TestGoEthereumWeb3ModuleTest(GoEthereumWeb3ModuleTest):
     pass
 
 
@@ -114,6 +115,10 @@ async def async_w3(geth_process, endpoint_uri):
     await wait_for_aiohttp(endpoint_uri)
     _w3 = AsyncWeb3(AsyncHTTPProvider(endpoint_uri))
     return _w3
+
+
+class TestGoEthereumAsyncWeb3ModuleTest(GoEthereumAsyncWeb3ModuleTest):
+    pass
 
 
 class TestGoEthereumAsyncAdminModuleTest(GoEthereumAsyncAdminModuleTest):

--- a/tests/integration/go_ethereum/test_goethereum_ipc.py
+++ b/tests/integration/go_ethereum/test_goethereum_ipc.py
@@ -9,6 +9,9 @@ from web3 import (
     AsyncWeb3,
     Web3,
 )
+from web3._utils.module_testing.persistent_connection_provider import (
+    PersistentConnectionProviderTest,
+)
 
 from .common import (
     GoEthereumAdminModuleTest,
@@ -97,4 +100,8 @@ class TestGoEthereumNetModuleTest(GoEthereumNetModuleTest):
 
 
 class TestGoEthereumAsyncNetModuleTest(GoEthereumAsyncNetModuleTest):
+    pass
+
+
+class TestPersistentConnectionProviderTest(PersistentConnectionProviderTest):
     pass

--- a/tests/integration/go_ethereum/test_goethereum_ipc.py
+++ b/tests/integration/go_ethereum/test_goethereum_ipc.py
@@ -17,9 +17,10 @@ from .common import (
     GoEthereumAdminModuleTest,
     GoEthereumAsyncEthModuleTest,
     GoEthereumAsyncNetModuleTest,
+    GoEthereumAsyncWeb3ModuleTest,
     GoEthereumEthModuleTest,
     GoEthereumNetModuleTest,
-    GoEthereumTest,
+    GoEthereumWeb3ModuleTest,
 )
 from .utils import (
     wait_for_async_socket,
@@ -56,14 +57,15 @@ def w3(geth_process, geth_ipc_path):
     return Web3(Web3.IPCProvider(geth_ipc_path, timeout=30))
 
 
-@pytest_asyncio.fixture(scope="module")
-async def async_w3(geth_process, geth_ipc_path):
-    await wait_for_async_socket(geth_ipc_path)
-    async with AsyncWeb3(AsyncIPCProvider(geth_ipc_path)) as _aw3:
-        yield _aw3
+class TestGoEthereumWeb3ModuleTest(GoEthereumWeb3ModuleTest):
+    pass
 
 
-class TestGoEthereumTest(GoEthereumTest):
+class TestGoEthereumEthModuleTest(GoEthereumEthModuleTest):
+    pass
+
+
+class TestGoEthereumNetModuleTest(GoEthereumNetModuleTest):
     pass
 
 
@@ -87,15 +89,21 @@ class TestGoEthereumAdminModuleTest(GoEthereumAdminModuleTest):
         super().test_admin_start_stop_ws(w3)
 
 
-class TestGoEthereumEthModuleTest(GoEthereumEthModuleTest):
+# -- async -- #
+
+
+@pytest_asyncio.fixture(scope="module")
+async def async_w3(geth_process, geth_ipc_path):
+    await wait_for_async_socket(geth_ipc_path)
+    async with AsyncWeb3(AsyncIPCProvider(geth_ipc_path)) as _aw3:
+        yield _aw3
+
+
+class TestGoEthereumAsyncWeb3ModuleTest(GoEthereumAsyncWeb3ModuleTest):
     pass
 
 
 class TestGoEthereumAsyncEthModuleTest(GoEthereumAsyncEthModuleTest):
-    pass
-
-
-class TestGoEthereumNetModuleTest(GoEthereumNetModuleTest):
     pass
 
 

--- a/tests/integration/go_ethereum/test_goethereum_legacy_ws.py
+++ b/tests/integration/go_ethereum/test_goethereum_legacy_ws.py
@@ -17,7 +17,7 @@ from .common import (
     GoEthereumAdminModuleTest,
     GoEthereumEthModuleTest,
     GoEthereumNetModuleTest,
-    GoEthereumTest,
+    GoEthereumWeb3ModuleTest,
 )
 
 
@@ -70,7 +70,7 @@ def w3(geth_process, endpoint_uri):
     return _w3
 
 
-class TestGoEthereumTest(GoEthereumTest):
+class TestGoEthereumWeb3ModuleTest(GoEthereumWeb3ModuleTest):
     pass
 
 

--- a/tests/integration/go_ethereum/test_goethereum_ws/test_async_await_w3.py
+++ b/tests/integration/go_ethereum/test_goethereum_ws/test_async_await_w3.py
@@ -16,6 +16,7 @@ from web3._utils.module_testing.persistent_connection_provider import (
 from ..common import (
     GoEthereumAsyncEthModuleTest,
     GoEthereumAsyncNetModuleTest,
+    GoEthereumAsyncWeb3ModuleTest,
 )
 from ..utils import (
     wait_for_aiohttp,
@@ -28,6 +29,10 @@ async def async_w3(geth_process, endpoint_uri):
 
     # await the persistent connection itself
     return await AsyncWeb3(WebSocketProvider(endpoint_uri))
+
+
+class TestGoEthereumAsyncWeb3ModuleTest(GoEthereumAsyncWeb3ModuleTest):
+    pass
 
 
 class TestGoEthereumAsyncAdminModuleTest(GoEthereumAsyncAdminModuleTest):

--- a/tests/integration/go_ethereum/test_goethereum_ws/test_async_ctx_manager_w3.py
+++ b/tests/integration/go_ethereum/test_goethereum_ws/test_async_ctx_manager_w3.py
@@ -16,6 +16,7 @@ from web3._utils.module_testing.persistent_connection_provider import (
 from ..common import (
     GoEthereumAsyncEthModuleTest,
     GoEthereumAsyncNetModuleTest,
+    GoEthereumAsyncWeb3ModuleTest,
 )
 from ..utils import (
     wait_for_aiohttp,
@@ -29,6 +30,10 @@ async def async_w3(geth_process, endpoint_uri):
     # async context manager pattern
     async with AsyncWeb3(WebSocketProvider(endpoint_uri)) as w3:
         yield w3
+
+
+class TestGoEthereumAsyncWeb3ModuleTest(GoEthereumAsyncWeb3ModuleTest):
+    pass
 
 
 class TestGoEthereumAsyncAdminModuleTest(GoEthereumAsyncAdminModuleTest):

--- a/tests/integration/go_ethereum/test_goethereum_ws/test_async_iterator_w3.py
+++ b/tests/integration/go_ethereum/test_goethereum_ws/test_async_iterator_w3.py
@@ -16,6 +16,7 @@ from web3._utils.module_testing.persistent_connection_provider import (
 from ..common import (
     GoEthereumAsyncEthModuleTest,
     GoEthereumAsyncNetModuleTest,
+    GoEthereumAsyncWeb3ModuleTest,
 )
 from ..utils import (
     wait_for_aiohttp,
@@ -29,6 +30,10 @@ async def async_w3(geth_process, endpoint_uri):
     # async iterator pattern
     async for w3 in AsyncWeb3(WebSocketProvider(endpoint_uri)):
         return w3
+
+
+class TestGoEthereumAsyncWeb3ModuleTest(GoEthereumAsyncWeb3ModuleTest):
+    pass
 
 
 class TestGoEthereumAsyncAdminModuleTest(GoEthereumAsyncAdminModuleTest):

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -253,10 +253,12 @@ class TestEthereumTesterWeb3Module(Web3ModuleTest):
     test_batch_requests = not_implemented(
         Web3ModuleTest.test_batch_requests, Web3TypeError
     )
-
     test_batch_requests_raises_for_common_unsupported_methods = not_implemented(
         Web3ModuleTest.test_batch_requests_raises_for_common_unsupported_methods,
         Web3TypeError,
+    )
+    test_batch_requests_initialized_as_object = not_implemented(
+        Web3ModuleTest.test_batch_requests_initialized_as_object, Web3TypeError
     )
 
 

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -38,6 +38,7 @@ from web3._utils.module_testing.eth_module import (
 )
 from web3.exceptions import (
     MethodUnavailable,
+    Web3TypeError,
 )
 from web3.providers.eth_tester import (
     EthereumTesterProvider,
@@ -221,11 +222,6 @@ def keyfile_account_address_dual_type(keyfile_account_address, address_conversio
     yield keyfile_account_address
 
 
-class TestEthereumTesterWeb3Module(Web3ModuleTest):
-    def _check_web3_client_version(self, client_version):
-        assert client_version.startswith("EthereumTester/")
-
-
 def not_implemented(method, exc_type=NotImplementedError):
     @functools.wraps(method)
     def inner(*args, **kwargs):
@@ -248,6 +244,15 @@ def disable_auto_mine(func):
             eth_tester.revert_to_snapshot(snapshot)
 
     return func_wrapper
+
+
+class TestEthereumTesterWeb3Module(Web3ModuleTest):
+    def _check_web3_client_version(self, client_version):
+        assert client_version.startswith("EthereumTester/")
+
+    test_batch_request = not_implemented(
+        Web3ModuleTest.test_batch_request, Web3TypeError
+    )
 
 
 class TestEthereumTesterEthModule(EthModuleTest):

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -250,8 +250,13 @@ class TestEthereumTesterWeb3Module(Web3ModuleTest):
     def _check_web3_client_version(self, client_version):
         assert client_version.startswith("EthereumTester/")
 
-    test_batch_request = not_implemented(
-        Web3ModuleTest.test_batch_request, Web3TypeError
+    test_batch_requests = not_implemented(
+        Web3ModuleTest.test_batch_requests, Web3TypeError
+    )
+
+    test_batch_requests_raises_for_common_unsupported_methods = not_implemented(
+        Web3ModuleTest.test_batch_requests_raises_for_common_unsupported_methods,
+        Web3TypeError,
     )
 
 

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -260,6 +260,12 @@ class TestEthereumTesterWeb3Module(Web3ModuleTest):
     test_batch_requests_initialized_as_object = not_implemented(
         Web3ModuleTest.test_batch_requests_initialized_as_object, Web3TypeError
     )
+    test_batch_requests_cancel = not_implemented(
+        Web3ModuleTest.test_batch_requests_cancel, Web3TypeError
+    )
+    test_batch_requests_clear = not_implemented(
+        Web3ModuleTest.test_batch_requests_clear, Web3TypeError
+    )
 
 
 class TestEthereumTesterEthModule(EthModuleTest):

--- a/web3/_utils/batching.py
+++ b/web3/_utils/batching.py
@@ -1,0 +1,86 @@
+from types import (
+    TracebackType,
+)
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Generic,
+    List,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+
+from web3._utils.compat import (
+    Self,
+)
+from web3.method import (
+    Method,
+)
+from web3.types import (
+    TFunc,
+    TReturn,
+)
+
+if TYPE_CHECKING:
+    from web3 import (  # noqa: F401
+        AsyncWeb3,
+        Web3,
+    )
+    from web3.types import (  # noqa: F401
+        RPCEndpoint,
+        RPCResponse,
+    )
+
+BatchRequestInformation = Tuple[Tuple["RPCEndpoint", Any], Sequence[Any]]
+
+
+class BatchRequestContextManager(Generic[TFunc]):
+    def __init__(self, web3: Union["AsyncWeb3", "Web3"]) -> None:
+        self.web3 = web3
+        self._requests_info: List[BatchRequestInformation] = []
+
+    def add(self, batch_payload: Union[TReturn, Sequence[TReturn]]) -> None:
+        # When batching, we don't make a request. Instead, we will get the request
+        # information and store it in the _requests_info list.
+        if isinstance(batch_payload, Sequence):
+            for request_information in batch_payload:
+                self._requests_info.append(
+                    cast(BatchRequestInformation, request_information)
+                )
+        else:
+            self._requests_info.append(cast(BatchRequestInformation, batch_payload))
+
+    def __enter__(self) -> Self:
+        self.web3._is_batching = True
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Type[BaseException],
+        exc_val: BaseException,
+        exc_tb: TracebackType,
+    ) -> None:
+        self.web3._is_batching = False
+
+    def execute(self) -> List["RPCResponse"]:
+        return self.web3.manager.make_batch_request(self._requests_info)
+
+    # -- async -- #
+
+    async def __aenter__(self) -> Self:
+        self.web3._is_batching = True
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Type[BaseException],
+        exc_val: BaseException,
+        exc_tb: TracebackType,
+    ) -> None:
+        self.web3._is_batching = False
+
+    async def async_execute(self) -> List["RPCResponse"]:
+        return await self.web3.manager.async_make_batch_request(self._requests_info)

--- a/web3/_utils/batching.py
+++ b/web3/_utils/batching.py
@@ -19,6 +19,12 @@ from typing import (
 from web3._utils.compat import (
     Self,
 )
+from web3.contract.async_contract import (
+    AsyncContractFunction,
+)
+from web3.contract.contract import (
+    ContractFunction,
+)
 from web3.method import (
     Method,
 )
@@ -52,6 +58,9 @@ class BatchRequestContextManager(Generic[TFunc]):
         # When batching, we don't make a request. Instead, we will get the request
         # information and store it in the `_requests_info` list. So we have to cast the
         # apparent "request" into the BatchRequestInformation type.
+        if isinstance(batch_payload, (ContractFunction, AsyncContractFunction)):
+            batch_payload = batch_payload.call()  # type: ignore
+
         if self.web3.provider.is_async:
             self._async_requests_info.append(
                 cast(Coroutine[Any, Any, BatchRequestInformation], batch_payload)

--- a/web3/_utils/caching.py
+++ b/web3/_utils/caching.py
@@ -71,7 +71,9 @@ class RequestInformation:
         method: "RPCEndpoint",
         params: Any,
         response_formatters: Tuple[
-            Dict[str, Callable[..., Any]], Callable[..., Any], Callable[..., Any]
+            Union[Dict[str, Callable[..., Any]], Callable[..., Any]],
+            Callable[..., Any],
+            Callable[..., Any],
         ],
         subscription_id: str = None,
     ):

--- a/web3/_utils/caching.py
+++ b/web3/_utils/caching.py
@@ -6,6 +6,7 @@ from typing import (
     Any,
     Callable,
     Coroutine,
+    Dict,
     List,
     Tuple,
     TypeVar,
@@ -69,7 +70,9 @@ class RequestInformation:
         self,
         method: "RPCEndpoint",
         params: Any,
-        response_formatters: Tuple[Callable[..., Any], ...],
+        response_formatters: Tuple[
+            Dict[str, Callable[..., Any]], Callable[..., Any], Callable[..., Any]
+        ],
         subscription_id: str = None,
     ):
         self.method = method

--- a/web3/_utils/module_testing/persistent_connection_provider.py
+++ b/web3/_utils/module_testing/persistent_connection_provider.py
@@ -26,9 +26,6 @@ from web3.types import (
 )
 
 if TYPE_CHECKING:
-    from web3.contract import (
-        AsyncContract,
-    )
     from web3.main import (
         AsyncWeb3,
     )
@@ -397,41 +394,3 @@ class PersistentConnectionProviderTest:
         assert isinstance(chain_id, int)
         assert isinstance(chain_id2, int)
         assert isinstance(chain_id3, int)
-
-    @pytest.mark.asyncio
-    async def test_async_batch_request(
-        self, async_w3: "AsyncWeb3", async_math_contract: "AsyncContract"
-    ) -> None:
-        async with async_w3.manager.batch_requests() as batch:
-            batch.add(async_w3.eth.get_block(6))
-            batch.add(async_w3.eth.get_block(4))
-            batch.add(async_w3.eth.get_block(2))
-            batch.add(async_w3.eth.get_block(0))
-
-            batch.add(async_math_contract.functions.multiply7(0))
-
-            batch.add_mapping(
-                {
-                    async_math_contract.functions.multiply7: [1, 2, 3],
-                    async_w3.eth.get_block: [1, 3, 5],
-                }
-            )
-
-            responses = await batch.async_execute()
-
-        assert len(responses) == 11
-        assert all(isinstance(response, AttributeDict) for response in responses[:3])
-        assert responses[0]["number"] == 6
-        assert responses[1]["number"] == 4
-        assert responses[2]["number"] == 2
-        assert responses[3]["number"] == 0
-
-        assert responses[4] == 0
-        assert responses[5] == 7
-        assert responses[6] == 14
-        assert responses[7] == 21
-
-        assert all(isinstance(response, AttributeDict) for response in responses[8:])
-        assert responses[8]["number"] == 1
-        assert responses[9]["number"] == 3
-        assert responses[10]["number"] == 5

--- a/web3/_utils/module_testing/persistent_connection_provider.py
+++ b/web3/_utils/module_testing/persistent_connection_provider.py
@@ -4,7 +4,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
-    Sequence,
     Tuple,
     cast,
 )
@@ -23,11 +22,13 @@ from web3.middleware import (
     ExtraDataToPOAMiddleware,
 )
 from web3.types import (
-    BlockData,
     FormattedEthSubscriptionResponse,
 )
 
 if TYPE_CHECKING:
+    from web3.contract import (
+        AsyncContract,
+    )
     from web3.main import (
         AsyncWeb3,
     )
@@ -398,18 +399,39 @@ class PersistentConnectionProviderTest:
         assert isinstance(chain_id3, int)
 
     @pytest.mark.asyncio
-    async def test_async_batch_request(self, async_w3: "AsyncWeb3") -> None:
+    async def test_async_batch_request(
+        self, async_w3: "AsyncWeb3", async_math_contract: "AsyncContract"
+    ) -> None:
         async with async_w3.manager.batch_requests() as batch:
             batch.add(async_w3.eth.get_block(6))
             batch.add(async_w3.eth.get_block(4))
             batch.add(async_w3.eth.get_block(2))
             batch.add(async_w3.eth.get_block(0))
 
-            responses = cast(Sequence[BlockData], await batch.async_execute())
+            batch.add(async_math_contract.functions.multiply7(0))
 
-        assert len(responses) == 4
-        assert all(isinstance(response, AttributeDict) for response in responses)
+            batch.add_mapping(
+                {
+                    async_math_contract.functions.multiply7: [1, 2, 3],
+                    async_w3.eth.get_block: [1, 3, 5],
+                }
+            )
+
+            responses = await batch.async_execute()
+
+        assert len(responses) == 11
+        assert all(isinstance(response, AttributeDict) for response in responses[:3])
         assert responses[0]["number"] == 6
         assert responses[1]["number"] == 4
         assert responses[2]["number"] == 2
         assert responses[3]["number"] == 0
+
+        assert responses[4] == 0
+        assert responses[5] == 7
+        assert responses[6] == 14
+        assert responses[7] == 21
+
+        assert all(isinstance(response, AttributeDict) for response in responses[8:])
+        assert responses[8]["number"] == 1
+        assert responses[9]["number"] == 3
+        assert responses[10]["number"] == 5

--- a/web3/_utils/module_testing/web3_module.py
+++ b/web3/_utils/module_testing/web3_module.py
@@ -336,7 +336,7 @@ class Web3ModuleTest:
 
             # assert proper batch cleanup after execution
             assert batch._requests_info == []
-            assert not batch.web3.provider._is_batching
+            assert not batch._provider._is_batching
 
             # assert batch cannot be added to after execution
             with pytest.raises(
@@ -395,7 +395,7 @@ class Web3ModuleTest:
 
         # assert proper batch cleanup after execution
         assert batch._requests_info == []
-        assert not batch.web3.provider._is_batching
+        assert not batch._provider._is_batching
 
         # assert batch cannot be added to after execution
         with pytest.raises(
@@ -551,7 +551,7 @@ class AsyncWeb3ModuleTest(Web3ModuleTest):
 
             # assert proper batch cleanup after execution
             assert batch._async_requests_info == []
-            assert not batch.web3.provider._is_batching
+            assert not batch._provider._is_batching
 
             # assert batch cannot be added to after execution
             with pytest.raises(
@@ -614,7 +614,7 @@ class AsyncWeb3ModuleTest(Web3ModuleTest):
 
         # assert proper batch cleanup after execution
         assert batch._async_requests_info == []
-        assert not batch.web3.provider._is_batching
+        assert not batch._provider._is_batching
 
         # assert batch cannot be added to after execution
         with pytest.raises(

--- a/web3/_utils/module_testing/web3_module.py
+++ b/web3/_utils/module_testing/web3_module.py
@@ -356,6 +356,27 @@ class Web3ModuleTest:
         assert last_three_responses[1]["number"] == 3
         assert last_three_responses[2]["number"] == 5
 
+    def test_batch_requests_initialized_as_object(
+        self, w3: "Web3", math_contract: Contract
+    ) -> None:
+        batch = w3.batch_requests()
+        batch.add(w3.eth.get_block(1))
+        batch.add(w3.eth.get_block(2))
+        batch.add(math_contract.functions.multiply7(0))
+        batch.add_mapping(
+            {math_contract.functions.multiply7: [1, 2], w3.eth.get_block: [3, 4]}
+        )
+
+        b1, b2, m0, m1, m2, b3, b4 = batch.execute()
+
+        assert cast(BlockData, b1)["number"] == 1
+        assert cast(BlockData, b2)["number"] == 2
+        assert cast(int, m0) == 0
+        assert cast(int, m1) == 7
+        assert cast(int, m2) == 14
+        assert cast(BlockData, b3)["number"] == 3
+        assert cast(BlockData, b4)["number"] == 4
+
     def test_batch_requests_raises_for_common_unsupported_methods(
         self, w3: "Web3", math_contract: Contract
     ) -> None:
@@ -437,6 +458,31 @@ class AsyncWeb3ModuleTest(Web3ModuleTest):
         assert last_three_responses[0]["number"] == 1
         assert last_three_responses[1]["number"] == 3
         assert last_three_responses[2]["number"] == 5
+
+    @pytest.mark.asyncio
+    async def test_batch_requests_initialized_as_object(
+        self, async_w3: AsyncWeb3, async_math_contract: "AsyncContract"
+    ) -> None:
+        batch = async_w3.batch_requests()
+        batch.add(async_w3.eth.get_block(1))
+        batch.add(async_w3.eth.get_block(2))
+        batch.add(async_math_contract.functions.multiply7(0))
+        batch.add_mapping(
+            {
+                async_math_contract.functions.multiply7: [1, 2],
+                async_w3.eth.get_block: [3, 4],
+            }
+        )
+
+        b1, b2, m0, m1, m2, b3, b4 = await batch.async_execute()
+
+        assert cast(BlockData, b1)["number"] == 1
+        assert cast(BlockData, b2)["number"] == 2
+        assert cast(int, m0) == 0
+        assert cast(int, m1) == 7
+        assert cast(int, m2) == 14
+        assert cast(BlockData, b3)["number"] == 3
+        assert cast(BlockData, b4)["number"] == 4
 
     @pytest.mark.asyncio
     async def test_batch_requests_raises_for_common_unsupported_methods(

--- a/web3/_utils/module_testing/web3_module.py
+++ b/web3/_utils/module_testing/web3_module.py
@@ -1,9 +1,11 @@
 import pytest
 from typing import (
     Any,
+    List,
     NoReturn,
     Sequence,
     Union,
+    cast,
 )
 
 from eth_typing import (
@@ -25,6 +27,9 @@ from web3._utils.ens import (
 )
 from web3.exceptions import (
     InvalidAddress,
+)
+from web3.types import (
+    BlockData,
 )
 
 
@@ -313,3 +318,18 @@ class Web3ModuleTest:
 
     def test_is_connected(self, w3: "Web3") -> None:
         assert w3.is_connected()
+
+    def test_batch_request(self, w3: "Web3") -> None:
+        with w3.manager.batch_requests() as batch:
+            batch.add(w3.eth.get_block(6))
+            batch.add(w3.eth.get_block(4))
+            batch.add(w3.eth.get_block(2))
+            batch.add(w3.eth.get_block(0))
+
+            responses = cast(List[BlockData], batch.execute())
+
+        assert len(responses) == 4
+        assert responses[0]["number"] == 6
+        assert responses[1]["number"] == 4
+        assert responses[2]["number"] == 2
+        assert responses[3]["number"] == 0

--- a/web3/contract/utils.py
+++ b/web3/contract/utils.py
@@ -154,7 +154,8 @@ def call_contract_function(
 
     output_types = get_abi_output_types(fn_abi)
 
-    if w3.provider._is_batching:
+    provider = w3.provider
+    if hasattr(provider, "_is_batching") and provider._is_batching:
         # request_information == ((method, params), response_formatters)
         request_information = tuple(return_data)
         method_and_params = request_information[0]

--- a/web3/main.py
+++ b/web3/main.py
@@ -147,7 +147,7 @@ from web3.types import (
 )
 
 if TYPE_CHECKING:
-    from web3._utils.batching import BatchRequestContextManager  # noqa: F401
+    from web3._utils.batching import RequestBatcher  # noqa: F401
     from web3._utils.empty import Empty  # noqa: F401
     from web3.providers.persistent import PersistentConnectionProvider  # noqa: F401
 
@@ -346,7 +346,7 @@ class BaseWeb3:
 
     def batch_requests(
         self,
-    ) -> "BatchRequestContextManager[Method[Callable[..., Any]]]":
+    ) -> "RequestBatcher[Method[Callable[..., Any]]]":
         return self.manager._batch_requests()
 
 

--- a/web3/main.py
+++ b/web3/main.py
@@ -34,6 +34,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncIterator,
+    Callable,
     Dict,
     Generator,
     List,
@@ -100,6 +101,9 @@ from web3.manager import (
     RequestManager as DefaultRequestManager,
 )
 from web3.middleware.base import MiddlewareOnion
+from web3.method import (
+    Method,
+)
 from web3.module import (
     Module,
 )
@@ -143,6 +147,7 @@ from web3.types import (
 )
 
 if TYPE_CHECKING:
+    from web3._utils.batching import BatchRequestContextManager  # noqa: F401
     from web3._utils.empty import Empty  # noqa: F401
     from web3.providers.persistent import PersistentConnectionProvider  # noqa: F401
 
@@ -337,6 +342,13 @@ class BaseWeb3:
     def is_encodable(self, _type: TypeStr, value: Any) -> bool:
         return self.codec.is_encodable(_type, value)
 
+    # -- APIs for high-level requests -- #
+
+    def batch_requests(
+        self,
+    ) -> "BatchRequestContextManager[Method[Callable[..., Any]]]":
+        return self.manager._batch_requests()
+
 
 class Web3(BaseWeb3):
     # mypy types
@@ -469,7 +481,7 @@ class AsyncWeb3(BaseWeb3):
             new_ens.w3 = self  # set self object reference for ``AsyncENS.w3``
         self._ens = new_ens
 
-        # -- persistent connection methods -- #
+    # -- persistent connection methods -- #
 
     @property
     @persistent_connection_provider_method()

--- a/web3/main.py
+++ b/web3/main.py
@@ -179,6 +179,7 @@ def get_default_modules() -> Dict[str, Union[Type[Module], Sequence[Any]]]:
 
 class BaseWeb3:
     _strict_bytes_type_checking = True
+    _is_batching: bool = False
 
     # Managers
     RequestManager = DefaultRequestManager

--- a/web3/main.py
+++ b/web3/main.py
@@ -179,7 +179,6 @@ def get_default_modules() -> Dict[str, Union[Type[Module], Sequence[Any]]]:
 
 class BaseWeb3:
     _strict_bytes_type_checking = True
-    _is_batching: bool = False
 
     # Managers
     RequestManager = DefaultRequestManager

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -394,6 +394,8 @@ class RequestManager:
         """
         Context manager for making batch requests
         """
+        if not isinstance(self.provider, (AsyncJSONBaseProvider, JSONBaseProvider)):
+            raise Web3TypeError("Batch requests are not supported by this provider.")
         return BatchRequestContextManager(self.w3)
 
     def _make_batch_request(
@@ -402,12 +404,8 @@ class RequestManager:
         """
         Make a batch request using the provider
         """
-        if not isinstance(self.provider, JSONBaseProvider):
-            raise Web3TypeError(
-                "Only JSONBaseProvider classes support batched requests."
-            )
-
-        request_func = self.provider.batch_request_func(
+        provider = cast(JSONBaseProvider, self.provider)
+        request_func = provider.batch_request_func(
             cast("Web3", self.w3), cast("MiddlewareOnion", self.middleware_onion)
         )
         responses = request_func(
@@ -431,12 +429,8 @@ class RequestManager:
         """
         Make an asynchronous batch request using the provider
         """
-        if not isinstance(self.provider, AsyncJSONBaseProvider):
-            raise Web3TypeError(
-                "Only AsyncJSONBaseProvider classes support batched requests."
-            )
-
-        request_func = await self.provider.batch_request_func(
+        provider = cast(AsyncJSONBaseProvider, self.provider)
+        request_func = await provider.batch_request_func(
             cast("AsyncWeb3", self.w3),
             cast("MiddlewareOnion", self.middleware_onion),
         )

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -388,15 +388,15 @@ class RequestManager:
             response, params, error_formatters, null_result_formatters
         )
 
-    # -- batch requests -- #
+    # -- batch requests management -- #
 
-    def batch_requests(self) -> BatchRequestContextManager[Method[Callable[..., Any]]]:
+    def _batch_requests(self) -> BatchRequestContextManager[Method[Callable[..., Any]]]:
         """
         Context manager for making batch requests
         """
         return BatchRequestContextManager(self.w3)
 
-    def make_batch_request(
+    def _make_batch_request(
         self, requests_info: List[Tuple[Tuple["RPCEndpoint", Any], Sequence[Any]]]
     ) -> List[RPCResponse]:
         """
@@ -422,7 +422,7 @@ class RequestManager:
         ]
         return list(formatted_responses)
 
-    async def async_make_batch_request(
+    async def _async_make_batch_request(
         self,
         requests_info: List[
             Coroutine[Any, Any, Tuple[Tuple["RPCEndpoint", Any], Sequence[Any]]]

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -25,7 +25,7 @@ from websockets.exceptions import (
 )
 
 from web3._utils.batching import (
-    BatchRequestContextManager,
+    RequestBatcher,
 )
 from web3._utils.caching import (
     generate_cache_key,
@@ -390,13 +390,13 @@ class RequestManager:
 
     # -- batch requests management -- #
 
-    def _batch_requests(self) -> BatchRequestContextManager[Method[Callable[..., Any]]]:
+    def _batch_requests(self) -> RequestBatcher[Method[Callable[..., Any]]]:
         """
         Context manager for making batch requests
         """
         if not isinstance(self.provider, (AsyncJSONBaseProvider, JSONBaseProvider)):
             raise Web3TypeError("Batch requests are not supported by this provider.")
-        return BatchRequestContextManager(self.w3)
+        return RequestBatcher(self.w3)
 
     def _make_batch_request(
         self, requests_info: List[Tuple[Tuple["RPCEndpoint", Any], Sequence[Any]]]

--- a/web3/method.py
+++ b/web3/method.py
@@ -21,6 +21,9 @@ from eth_utils.toolz import (
     pipe,
 )
 
+from web3._utils.batching import (
+    RPC_METHODS_UNSUPPORTED_DURING_BATCH,
+)
 from web3._utils.method_formatters import (
     get_error_formatters,
     get_null_result_formatters,
@@ -31,6 +34,7 @@ from web3._utils.rpc_abi import (
     RPC,
 )
 from web3.exceptions import (
+    MethodNotSupported,
     Web3TypeError,
     Web3ValidationError,
     Web3ValueError,
@@ -161,6 +165,11 @@ class Method(Generic[TFunc]):
                 "usually attached to a web3 instance."
             )
         if module.w3.provider._is_batching:
+            if self.json_rpc_method in RPC_METHODS_UNSUPPORTED_DURING_BATCH:
+                raise MethodNotSupported(
+                    f"Method `{self.json_rpc_method}` is not supported within a batch "
+                    "request."
+                )
             return module.retrieve_request_information(self)
         else:
             return module.retrieve_caller_fn(self)

--- a/web3/method.py
+++ b/web3/method.py
@@ -160,7 +160,7 @@ class Method(Generic[TFunc]):
                 "Methods must be called from a module instance, "
                 "usually attached to a web3 instance."
             )
-        if module.w3._is_batching:
+        if module.w3.provider._is_batching:
             return module.retrieve_request_information(self)
         else:
             return module.retrieve_caller_fn(self)

--- a/web3/method.py
+++ b/web3/method.py
@@ -164,7 +164,9 @@ class Method(Generic[TFunc]):
                 "Methods must be called from a module instance, "
                 "usually attached to a web3 instance."
             )
-        if module.w3.provider._is_batching:
+
+        provider = module.w3.provider
+        if hasattr(provider, "_is_batching") and provider._is_batching:
             if self.json_rpc_method in RPC_METHODS_UNSUPPORTED_DURING_BATCH:
                 raise MethodNotSupported(
                     f"Method `{self.json_rpc_method}` is not supported within a batch "

--- a/web3/method.py
+++ b/web3/method.py
@@ -42,7 +42,10 @@ from web3.types import (
 )
 
 if TYPE_CHECKING:
-    from web3 import Web3  # noqa: F401
+    from web3 import (  # noqa: F401
+        PersistentConnectionProvider,
+        Web3,
+    )
     from web3.module import Module  # noqa: F401
 
 

--- a/web3/providers/async_base.py
+++ b/web3/providers/async_base.py
@@ -7,6 +7,7 @@ from typing import (
     Callable,
     Coroutine,
     Iterable,
+    List,
     Optional,
     Set,
     Tuple,
@@ -116,8 +117,8 @@ class AsyncBaseProvider:
         raise NotImplementedError("Providers must implement this method")
 
     async def make_batch_request(
-        self, requests: Iterable[tuple[RPCEndpoint, Any]]
-    ) -> list[RPCResponse]:
+        self, requests: Iterable[Tuple[RPCEndpoint, Any]]
+    ) -> List[RPCResponse]:
         raise NotImplementedError("Only AsyncHTTPProvider supports this method")
 
     async def is_connected(self, show_traceback: bool = False) -> bool:
@@ -164,7 +165,7 @@ class AsyncJSONBaseProvider(AsyncBaseProvider):
         return to_bytes(text=encoded)
 
     def encode_batch_rpc_request(
-        self, requests: Iterable[tuple[RPCEndpoint, Any]]
+        self, requests: Iterable[Tuple[RPCEndpoint, Any]]
     ) -> bytes:
         return (
             b"["
@@ -180,7 +181,7 @@ class AsyncJSONBaseProvider(AsyncBaseProvider):
         )
         return cast(RPCResponse, FriendlyJsonSerde().json_decode(text_response))
 
-    def decode_batch_rpc_response(self, raw_response: bytes) -> list[RPCResponse]:
+    def decode_batch_rpc_response(self, raw_response: bytes) -> List[RPCResponse]:
         text_response = str(
             to_text(raw_response) if not is_text(raw_response) else raw_response
         )

--- a/web3/providers/async_base.py
+++ b/web3/providers/async_base.py
@@ -78,6 +78,8 @@ class AsyncBaseProvider:
     _request_func_cache: Tuple[
         Tuple[Middleware, ...], Callable[..., Coroutine[Any, Any, RPCResponse]]
     ] = (None, None)
+
+    _is_batching: bool = False
     _batch_request_func_cache: Tuple[
         Tuple[Middleware, ...], Callable[..., Coroutine[Any, Any, List[RPCResponse]]]
     ] = (None, None)

--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -67,6 +67,8 @@ class BaseProvider:
         None,
         None,
     )
+
+    _is_batching: bool = False
     _batch_request_func_cache: Tuple[
         Tuple[Middleware, ...], Callable[..., List[RPCResponse]]
     ] = (None, None)

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -218,12 +218,17 @@ class IPCProvider(JSONBaseProvider):
                         timeout.sleep(0)
                     elif has_valid_json_rpc_ending(raw_response):
                         try:
-                            response = self.decode_rpc_response(raw_response)
+                            response = cast(
+                                List[RPCResponse],
+                                self.decode_rpc_response(raw_response),
+                            )
                         except JSONDecodeError:
                             timeout.sleep(0)
                             continue
                         else:
-                            return cast(List[RPCResponse], response)
+                            # sort by response `id` since the JSON-RPC 2.0 spec doesn't
+                            # guarantee order
+                            return sorted(response, key=lambda resp: int(resp["id"]))
                     else:
                         timeout.sleep(0)
                         continue

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -29,6 +29,9 @@ from web3.types import (
     RPCResponse,
 )
 
+from .._utils.batching import (
+    sort_batch_response_by_response_ids,
+)
 from ..exceptions import (
     Web3TypeError,
     Web3ValueError,
@@ -200,7 +203,7 @@ class IPCProvider(JSONBaseProvider):
         self.logger.debug(f"Making batch request IPC. Path: {self.ipc_path}")
         request_data = self.encode_batch_rpc_request(requests)
         response = cast(List[RPCResponse], self._make_request(request_data))
-        return sorted(response, key=lambda resp: resp["id"])
+        return sort_batch_response_by_response_ids(response)
 
 
 # A valid JSON RPC response can only end in } or ] http://www.jsonrpc.org/specification

--- a/web3/providers/legacy_websocket.py
+++ b/web3/providers/legacy_websocket.py
@@ -148,4 +148,6 @@ class LegacyWebSocketProvider(JSONBaseProvider):
         future = asyncio.run_coroutine_threadsafe(
             self.coro_make_request(request_data), LegacyWebSocketProvider._loop
         )
-        return cast(List[RPCResponse], future.result())
+        response = cast(List[RPCResponse], future.result())
+        # sort by response `id` since the JSON-RPC 2.0 spec doesn't guarantee order
+        return sorted(response, key=lambda resp: int(resp["id"]))

--- a/web3/providers/legacy_websocket.py
+++ b/web3/providers/legacy_websocket.py
@@ -10,9 +10,12 @@ from types import (
 )
 from typing import (
     Any,
+    List,
     Optional,
+    Tuple,
     Type,
     Union,
+    cast,
 )
 
 from eth_typing import (
@@ -133,3 +136,16 @@ class LegacyWebSocketProvider(JSONBaseProvider):
             self.coro_make_request(request_data), LegacyWebSocketProvider._loop
         )
         return future.result()
+
+    def make_batch_request(
+        self, requests: List[Tuple[RPCEndpoint, Any]]
+    ) -> List[RPCResponse]:
+        self.logger.debug(
+            f"Making batch request WebSocket. URI: {self.endpoint_uri}, "
+            f"Methods: {requests}"
+        )
+        request_data = self.encode_batch_rpc_request(requests)
+        future = asyncio.run_coroutine_threadsafe(
+            self.coro_make_request(request_data), LegacyWebSocketProvider._loop
+        )
+        return cast(List[RPCResponse], future.result())

--- a/web3/providers/legacy_websocket.py
+++ b/web3/providers/legacy_websocket.py
@@ -28,6 +28,9 @@ from websockets.legacy.client import (
     WebSocketClientProtocol,
 )
 
+from web3._utils.batching import (
+    sort_batch_response_by_response_ids,
+)
 from web3.exceptions import (
     Web3ValidationError,
 )
@@ -149,5 +152,4 @@ class LegacyWebSocketProvider(JSONBaseProvider):
             self.coro_make_request(request_data), LegacyWebSocketProvider._loop
         )
         response = cast(List[RPCResponse], future.result())
-        # sort by response `id` since the JSON-RPC 2.0 spec doesn't guarantee order
-        return sorted(response, key=lambda resp: int(resp["id"]))
+        return sort_batch_response_by_response_ids(response)

--- a/web3/providers/persistent/async_ipc.py
+++ b/web3/providers/persistent/async_ipc.py
@@ -163,8 +163,11 @@ class AsyncIPCProvider(PersistentConnectionProvider):
 
         # generate a cache key with all the request ids hashed
         request_ids = [rpc_request["id"] for rpc_request in json.loads(request_data)]
-        response = await self._get_response_for_request_id(request_ids)
-        return cast(List[RPCResponse], response)
+        response = cast(
+            List[RPCResponse], await self._get_response_for_request_id(request_ids)
+        )
+        # sort by response `id` since the JSON-RPC 2.0 spec doesn't guarantee order
+        return sorted(response, key=lambda resp: int(resp["id"]))
 
     async def _provider_specific_message_listener(self) -> None:
         self._raw_message += to_text(await self._reader.read(4096)).lstrip()

--- a/web3/providers/persistent/persistent.py
+++ b/web3/providers/persistent/persistent.py
@@ -44,6 +44,8 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
     _message_listener_task: Optional["asyncio.Task[None]"] = None
     _listen_event: asyncio.Event = asyncio.Event()
 
+    _batch_request_counter: Optional[int] = None
+
     def __init__(
         self,
         request_timeout: float = DEFAULT_PERSISTENT_CONNECTION_TIMEOUT,

--- a/web3/providers/persistent/persistent.py
+++ b/web3/providers/persistent/persistent.py
@@ -4,7 +4,9 @@ from abc import (
 import asyncio
 import logging
 from typing import (
+    List,
     Optional,
+    Union,
 )
 
 from websockets import (
@@ -187,7 +189,7 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
             raise msg_listener_task.exception()
 
     async def _get_response_for_request_id(
-        self, request_id: RPCId, timeout: Optional[float] = None
+        self, request_id: Union[RPCId, List[RPCId]], timeout: Optional[float] = None
     ) -> RPCResponse:
         if timeout is None:
             timeout = self.request_timeout

--- a/web3/providers/persistent/request_processor.py
+++ b/web3/providers/persistent/request_processor.py
@@ -19,6 +19,9 @@ from eth_utils.toolz import (
     compose,
 )
 
+from web3._utils.batching import (
+    BATCH_REQUEST_ID,
+)
 from web3._utils.caching import (
     RequestInformation,
     generate_cache_key,
@@ -297,9 +300,9 @@ class RequestProcessor:
             )
             await self._subscription_response_queue.put(raw_response)
         elif isinstance(raw_response, list):
-            # hash all response ids in the list and cache the list with this hash
-            response_ids = [response.get("id") for response in raw_response]
-            cache_key = generate_cache_key(response_ids)
+            # Since only one batch should be in the cache at all times, we use a
+            # constant cache key for the batch response.
+            cache_key = generate_cache_key(BATCH_REQUEST_ID)
             self._provider.logger.debug(
                 f"Caching batch response:\n    cache_key={cache_key},\n"
                 f"    response={raw_response}"

--- a/web3/providers/persistent/request_processor.py
+++ b/web3/providers/persistent/request_processor.py
@@ -95,7 +95,11 @@ class RequestProcessor:
         self,
         method: RPCEndpoint,
         params: Any,
-        response_formatters: Tuple[Callable[..., Any], ...],
+        response_formatters: Tuple[
+            Dict[str, Callable[..., Any]],
+            Callable[..., Any],
+            Callable[..., Any],
+        ],
     ) -> Optional[str]:
         cached_requests_key = generate_cache_key((method, params))
         if cached_requests_key in self._provider._request_cache._data:

--- a/web3/providers/persistent/request_processor.py
+++ b/web3/providers/persistent/request_processor.py
@@ -240,13 +240,18 @@ class RequestProcessor:
             self._request_information_cache.get_cache_entry(cache_key)
         )
         if cached_request_info_for_id is not None:
+            (
+                current_result_formatters,
+                error_formatters,
+                null_result_formatters,
+            ) = cached_request_info_for_id.response_formatters
             cached_request_info_for_id.response_formatters = (
                 compose(
                     result_formatter,
-                    cached_request_info_for_id.response_formatters[0],
+                    current_result_formatters,
                 ),
-                cached_request_info_for_id.response_formatters[1],
-                cached_request_info_for_id.response_formatters[2],
+                error_formatters,
+                null_result_formatters,
             )
         else:
             self._provider.logger.debug(

--- a/web3/providers/persistent/request_processor.py
+++ b/web3/providers/persistent/request_processor.py
@@ -190,9 +190,8 @@ class RequestProcessor:
                 # i.e. subscription request information remains in the cache
                 self._request_information_cache.get_cache_entry(cache_key)
             )
-
         else:
-            # retrieve the request info from the cache using the request id
+            # retrieve the request info from the cache using the response id
             cache_key = generate_cache_key(response["id"])
             if response in self._provider._request_cache._data.values():
                 request_info = (
@@ -266,6 +265,15 @@ class RequestProcessor:
                 f"Caching subscription response:\n    response={raw_response}"
             )
             await self._subscription_response_queue.put(raw_response)
+        elif isinstance(raw_response, list):
+            # hash all response ids in the list and cache the list with this hash
+            response_ids = [response.get("id") for response in raw_response]
+            cache_key = generate_cache_key(response_ids)
+            self._provider.logger.debug(
+                f"Caching batch response:\n    cache_key={cache_key},\n"
+                f"    response={raw_response}"
+            )
+            self._request_response_cache.cache(cache_key, raw_response)
         else:
             response_id = raw_response.get("id")
             cache_key = generate_cache_key(response_id)

--- a/web3/providers/persistent/websocket.py
+++ b/web3/providers/persistent/websocket.py
@@ -160,8 +160,11 @@ class WebSocketProvider(PersistentConnectionProvider):
 
         # generate a cache key with all the request ids hashed
         request_ids = [rpc_request["id"] for rpc_request in json.loads(request_data)]
-        response = await self._get_response_for_request_id(request_ids)
-        return cast(List[RPCResponse], response)
+        response = cast(
+            List[RPCResponse], await self._get_response_for_request_id(request_ids)
+        )
+        # sort by response `id` since the JSON-RPC 2.0 spec doesn't guarantee order
+        return sorted(response, key=lambda resp: int(resp["id"]))
 
     async def _provider_specific_message_listener(self) -> None:
         async for raw_message in self._ws:

--- a/web3/providers/rpc/async_rpc.py
+++ b/web3/providers/rpc/async_rpc.py
@@ -39,6 +39,9 @@ from web3.types import (
     RPCResponse,
 )
 
+from ..._utils.batching import (
+    sort_batch_response_by_response_ids,
+)
 from ..._utils.caching import (
     async_handle_request_caching,
 )
@@ -160,5 +163,4 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
         )
         self.logger.debug("Received batch response HTTP.")
         responses_list = cast(List[RPCResponse], self.decode_rpc_response(raw_response))
-        # sort by response `id` since the JSON-RPC 2.0 spec doesn't guarantee order
-        return sorted(responses_list, key=lambda resp: int(resp["id"]))
+        return sort_batch_response_by_response_ids(responses_list)

--- a/web3/providers/rpc/async_rpc.py
+++ b/web3/providers/rpc/async_rpc.py
@@ -4,6 +4,7 @@ from typing import (
     Any,
     Dict,
     Iterable,
+    List,
     Optional,
     Tuple,
     Union,
@@ -149,13 +150,13 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
         return response
 
     async def make_batch_request(
-        self, requests: Iterable[tuple[RPCEndpoint, Any]]
-    ) -> list[RPCResponse]:
+        self, requests: Iterable[Tuple[RPCEndpoint, Any]]
+    ) -> List[RPCResponse]:
         self.logger.debug(f"Making batch request HTTP. URI: {self.endpoint_uri}")
         request_data: bytes = self.encode_batch_rpc_request(requests)
         raw_response: bytes = await async_make_post_request(
             self.endpoint_uri, request_data, **self.get_request_kwargs()
         )
-        response = self.decode_batch_rpc_response(raw_response)
+        response: List[RPCResponse] = self.decode_batch_rpc_response(raw_response)
         self.logger.debug(f"Getting batch response HTTP. URI: {self.endpoint_uri}")
         return response

--- a/web3/providers/rpc/async_rpc.py
+++ b/web3/providers/rpc/async_rpc.py
@@ -147,3 +147,15 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
             f"Method: {method}, Response: {response}"
         )
         return response
+
+    async def make_batch_request(
+        self, requests: Iterable[tuple[RPCEndpoint, Any]]
+    ) -> list[RPCResponse]:
+        self.logger.debug(f"Making batch request HTTP. URI: {self.endpoint_uri}")
+        request_data: bytes = self.encode_batch_rpc_request(requests)
+        raw_response: bytes = await async_make_post_request(
+            self.endpoint_uri, request_data, **self.get_request_kwargs()
+        )
+        response = self.decode_batch_rpc_response(raw_response)
+        self.logger.debug(f"Getting batch response HTTP. URI: {self.endpoint_uri}")
+        return response

--- a/web3/providers/rpc/rpc.py
+++ b/web3/providers/rpc/rpc.py
@@ -5,9 +5,11 @@ from typing import (
     Any,
     Dict,
     Iterable,
+    List,
     Optional,
     Tuple,
     Union,
+    cast,
 )
 
 from eth_typing import (
@@ -155,3 +157,16 @@ class HTTPProvider(JSONBaseProvider):
             f"Method: {method}, Response: {response}"
         )
         return response
+
+    def make_batch_request(
+        self, batch_requests: List[Tuple[RPCEndpoint, Any]]
+    ) -> List[RPCResponse]:
+        self.logger.debug(f"Making batch request HTTP, uri: `{self.endpoint_uri}`")
+        request_data = self.encode_batch_rpc_request(batch_requests)
+        raw_response = make_post_request(
+            self.endpoint_uri, request_data, **self.get_request_kwargs()
+        )
+        self.logger.debug("Received batch response HTTP.")
+        responses_list = cast(List[RPCResponse], self.decode_rpc_response(raw_response))
+        # sort by response `id` since the JSON-RPC 2.0 spec doesn't guarantee order
+        return sorted(responses_list, key=lambda resp: int(resp["id"]))

--- a/web3/providers/rpc/rpc.py
+++ b/web3/providers/rpc/rpc.py
@@ -37,6 +37,9 @@ from web3.types import (
     RPCResponse,
 )
 
+from ..._utils.batching import (
+    sort_batch_response_by_response_ids,
+)
 from ..._utils.caching import (
     handle_request_caching,
 )
@@ -168,5 +171,4 @@ class HTTPProvider(JSONBaseProvider):
         )
         self.logger.debug("Received batch response HTTP.")
         responses_list = cast(List[RPCResponse], self.decode_rpc_response(raw_response))
-        # sort by response `id` since the JSON-RPC 2.0 spec doesn't guarantee order
-        return sorted(responses_list, key=lambda resp: int(resp["id"]))
+        return sort_batch_response_by_response_ids(responses_list)

--- a/web3/types.py
+++ b/web3/types.py
@@ -9,6 +9,7 @@ from typing import (
     NewType,
     Optional,
     Sequence,
+    Tuple,
     Type,
     TypedDict,
     TypeVar,
@@ -43,8 +44,9 @@ if TYPE_CHECKING:
     )
 
 
-TReturn = TypeVar("TReturn")
+TFunc = TypeVar("TFunc", bound=Callable[..., Any])
 TParams = TypeVar("TParams")
+TReturn = TypeVar("TReturn")
 TValue = TypeVar("TValue")
 
 BlockParams = Literal["latest", "earliest", "pending", "safe", "finalized"]
@@ -318,7 +320,11 @@ class CreateAccessListResponse(TypedDict):
 
 
 MakeRequestFn = Callable[[RPCEndpoint, Any], RPCResponse]
+MakeBatchRequestFn = Callable[[List[Tuple[RPCEndpoint, Any]]], List[RPCResponse]]
 AsyncMakeRequestFn = Callable[[RPCEndpoint, Any], Coroutine[Any, Any, RPCResponse]]
+AsyncMakeBatchRequestFn = Callable[
+    [List[Tuple[RPCEndpoint, Any]]], Coroutine[Any, Any, List[RPCResponse]]
+]
 
 
 class FormattersDict(TypedDict, total=False):


### PR DESCRIPTION
### What was wrong?

Closes #832

### How was it fixed?

Add batch request support to the `RequestManager` via a context manager. Expose this as a high-level API on the `Web3` / `AsyncWeb3` class itself (`w3.batch_requests()`).

### Todo:

- [x] Handle / skip `EthereumTesterProvider` test case
- [x] Handle IPC & WS provider batch request cases
- [x] Handle persistent connection provider cases
- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)
- [ ] Add or update documentation related to these changes -- separate PR ?

#### Cute Animal Picture

<img width="723" alt="Screenshot 2024-04-30 at 15 38 09" src="https://github.com/ethereum/web3.py/assets/3532824/f0833b5a-c3d7-4b7f-a742-ce3951d6fe2b">