### PR TITLE
`eth-utils` for ABI methods

### DIFF
--- a/docs/web3.contract.rst
+++ b/docs/web3.contract.rst
@@ -634,7 +634,7 @@ Taking the following contract code as an example:
     >>> arrays_contract.functions.setBytes2Value([b'b']).transact()
     Traceback (most recent call last):
        ...
-    web3.exceptions.Web3ValidationError:
+    web3.exceptions.Web3TypeError:
     Could not identify the intended function with name
     >>> # check value is still b'aa'
     >>> arrays_contract.functions.getBytes2Value().call()
@@ -659,7 +659,7 @@ Taking the following contract code as an example:
     >>> arrays_contract.functions.setBytes2Value([b'a']).transact()
     Traceback (most recent call last):
        ...
-    web3.exceptions.Web3ValidationError:
+    web3.exceptions.Web3TypeError:
     Could not identify the intended function with name
 
 .. _contract-functions:

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -399,11 +399,8 @@ To sign a transaction locally that will invoke a smart contract:
 
     >>> from web3 import Web3, EthereumTesterProvider
     >>> w3 = Web3(EthereumTesterProvider())
-
     >>> unicorns = w3.eth.contract(address="0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359", abi=EIP20_ABI)
-
     >>> nonce = w3.eth.get_transaction_count('0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E')  # doctest: +SKIP
-
     # Build a transaction that invokes this contract's function, called transfer
     >>> unicorn_txn = unicorns.functions.transfer(
     ...     '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359',
@@ -415,7 +412,6 @@ To sign a transaction locally that will invoke a smart contract:
     ...     'maxPriorityFeePerGas': w3.to_wei('1', 'gwei'),
     ...     'nonce': nonce,
     ... })
-
     >>> unicorn_txn
     {'value': 0,
      'chainId': 1,
@@ -425,7 +421,6 @@ To sign a transaction locally that will invoke a smart contract:
      'nonce': 0,
      'to': '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359',
      'data': '0xa9059cbb000000000000000000000000fb6916095ca1df60bb79ce92ce3ea74c37c5d3590000000000000000000000000000000000000000000000000000000000000001'}
-
     >>> private_key = b"\xb2\\}\xb3\x1f\xee\xd9\x12''\xbf\t9\xdcv\x9a\x96VK-\xe4\xc4rm\x03[6\xec\xf1\xe5\xb3d"
     >>> signed_txn = w3.eth.account.sign_transaction(unicorn_txn, private_key=private_key)
     >>> signed_txn.hash
@@ -438,9 +433,7 @@ To sign a transaction locally that will invoke a smart contract:
     48417310681110102814014302147799665717176259465062324746227758019974374282313
     >>> signed_txn.v
     1
-
     >>> w3.eth.send_raw_transaction(signed_txn.raw_transaction)  # doctest: +SKIP
-
     # When you run send_raw_transaction, you get the same result as the hash of the transaction:
     >>> w3.to_hex(w3.keccak(signed_txn.raw_transaction))
     '0x748db062639a45e519dba934fce09c367c92043867409160c9989673439dc817'

--- a/docs/web3.main.rst
+++ b/docs/web3.main.rst
@@ -333,22 +333,14 @@ Check Encodability
     .. doctest::
 
         >>> from web3.auto.gethdev import w3
-
         >>> w3.is_encodable('bytes2', b'12')
         True
-
-        >>>  # not of exact size bytes2
-        >>> w3.is_encodable('bytes2', b'1')
+        >>> w3.is_encodable('bytes2', b'1')  # not of exact size bytes2
         False
-
-        >>> w3.strict_bytes_type_checking = False
-
-        >>> # zero-padded, so encoded to: b'1\x00'
+        >>> w3.strict_bytes_type_checking = False  # zero-padded, so encoded to: b'1\x00'
         >>> w3.is_encodable('bytes2', b'1')
         True
-
-        >>> # re-enable it
-        >>> w3.strict_bytes_type_checking = True
+        >>> w3.strict_bytes_type_checking = True  # re-enable it
         >>> w3.is_encodable('bytes2', b'1')
         False
 

--- a/docs/web3.utils.rst
+++ b/docs/web3.utils.rst
@@ -8,14 +8,13 @@ The ``utils`` module houses public utility functions and classes.
 ABI
 ---
 
-.. py:method:: utils.get_abi_input_names(abi)
+ABI utilities re-exported as ``web3.utils.abi`` from
+`eth-utils <https://github.com/ethereum/eth-utils>`_.
 
-    Return the ``input`` names for an ABI function or event.
-
-
-.. py:method:: utils.get_abi_output_names(abi)
-
-    Return the ``output`` names an ABI function or event.
+.. automodule:: web3.utils.abi
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Address
 -------

--- a/docs/web3.utils.rst
+++ b/docs/web3.utils.rst
@@ -8,8 +8,12 @@ The ``utils`` module houses public utility functions and classes.
 ABI
 ---
 
-ABI utilities re-exported as ``web3.utils.abi`` from
-`eth-utils <https://github.com/ethereum/eth-utils>`_.
+``web3.utils.abi``
+
+Application Binary Interface (ABI) methods to encode/decode contract transactions.
+
+It is generally recommended to use the `web3.eth.contract` module. These methods are
+useful when a contract's ABI is known and a Web3 instance is not needed.
 
 .. automodule:: web3.utils.abi
    :members:

--- a/ens/base_ens.py
+++ b/ens/base_ens.py
@@ -17,11 +17,11 @@ from hexbytes import (
 
 from .utils import (
     address_to_reverse_domain,
-    get_abi_output_types,
     is_valid_name,
     label_to_hash,
     normalize_name,
     raw_name_to_hash,
+    get_abi_output_types,
 )
 
 if TYPE_CHECKING:
@@ -108,7 +108,14 @@ class BaseENS:
             if fn_name == "addr"
             else extended_resolver.get_function_by_name(fn_name)
         )
-        output_types = get_abi_output_types(func.abi)
+        try:
+            output_types = get_abi_output_types(func.abi)
+        except ValueError:
+            # constructor, fallback and receive functions do not have outputs
+            # proceed with decoding data without outputs
+            output_types = []
+            pass
+
         decoded = self.w3.codec.decode(output_types, contract_call_result)
 
         # if decoding a single value, return that value - else, return the tuple

--- a/ens/utils.py
+++ b/ens/utils.py
@@ -29,7 +29,7 @@ from eth_utils import (
     to_normalized_address,
 )
 from eth_utils.abi import (
-    collapse_if_tuple,
+    get_normalized_abi_arg_type,
 )
 from hexbytes import (
     HexBytes,
@@ -57,6 +57,9 @@ default = object()
 
 
 if TYPE_CHECKING:
+    from eth_typing import (  # noqa: F401
+        ABIFunction,
+    )
     from web3 import (  # noqa: F401
         AsyncWeb3,
         Web3 as _Web3,
@@ -67,9 +70,6 @@ if TYPE_CHECKING:
     from web3.providers import (  # noqa: F401
         AsyncBaseProvider,
         BaseProvider,
-    )
-    from web3.types import (  # noqa: F401
-        ABIFunction,
     )
 
 
@@ -298,7 +298,7 @@ def get_abi_output_types(abi: "ABIFunction") -> List[str]:
     return (
         []
         if abi["type"] == "fallback"
-        else [collapse_if_tuple(cast(Dict[str, Any], arg)) for arg in abi["outputs"]]
+        else [get_normalized_abi_arg_type(arg) for arg in abi["outputs"]]
     )
 
 

--- a/ens/utils.py
+++ b/ens/utils.py
@@ -6,7 +6,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Collection,
-    Dict,
     List,
     Optional,
     Sequence,
@@ -60,6 +59,7 @@ if TYPE_CHECKING:
     from eth_typing import (  # noqa: F401
         ABIFunction,
     )
+
     from web3 import (  # noqa: F401
         AsyncWeb3,
         Web3 as _Web3,

--- a/ens/utils.py
+++ b/ens/utils.py
@@ -26,9 +26,7 @@ from eth_utils import (
     remove_0x_prefix,
     to_bytes,
     to_normalized_address,
-)
-from eth_utils.abi import (
-    get_normalized_abi_arg_type,
+    get_abi_output_types as abi_output_types,
 )
 from hexbytes import (
     HexBytes,
@@ -293,13 +291,9 @@ def is_valid_ens_name(ens_name: str) -> bool:
     return True
 
 
-# borrowed from similar method at `web3._utils.abi` due to circular dependency
+# Wrap `get_abi_output_types` to prevent direct imports causing circular dependencies
 def get_abi_output_types(abi: "ABIFunction") -> List[str]:
-    return (
-        []
-        if abi["type"] == "fallback"
-        else [get_normalized_abi_arg_type(arg) for arg in abi["outputs"]]
-    )
+    return abi_output_types(abi)
 
 
 # -- async -- #

--- a/newsfragments/3036.feature.rst
+++ b/newsfragments/3036.feature.rst
@@ -1,0 +1,1 @@
+Upgrade to `eth-utils` @ 4.2.2 with public ABI utilities.

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "eth-account>=0.12.2",
         "eth-hash[pycryptodome]>=0.5.1",
         "eth-typing>=4.0.0",
-        "eth-utils>=4.0.0",
+        "eth-utils @ git+https://github.com/reedsa/eth-utils@abi-element-utils",
         "hexbytes>=1.2.0",
         "pydantic>=2.4.0",
         "pywin32>=223;platform_system=='Windows'",

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "eth-abi>=5.0.1",
         "eth-account>=0.12.2",
         "eth-hash[pycryptodome]>=0.5.1",
-        "eth-typing>=4.0.0",
+        "eth-typing @ pip install git+https://github.com/reedsa/eth-utils@abi-deprecate-types",
         "eth-utils @ git+https://github.com/reedsa/eth-utils@abi-element-utils",
         "hexbytes>=1.2.0",
         "pydantic>=2.4.0",

--- a/tests/core/contracts/test_contract_method_to_argument_matching.py
+++ b/tests/core/contracts/test_contract_method_to_argument_matching.py
@@ -1,7 +1,7 @@
 import json
 import pytest
 
-from web3._utils.abi import (
+from web3.utils.abi import (
     get_abi_input_types,
 )
 from web3._utils.function_identifiers import (

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -158,12 +158,19 @@ def filter_by_argument_count(
 def filter_by_argument_name(
     argument_names: Collection[str], contract_abi: ABI
 ) -> List[Union[ABIFunction, ABIEvent]]:
-    return [
-        abi
-        for abi in contract_abi
-        if set(argument_names).intersection(get_abi_input_names(abi))
-        == set(argument_names)
-    ]
+    abis_with_matching_args = ()
+    for abi_element in contract_abi:
+        try:
+            abi_arg_names = get_abi_input_names(abi_element)
+
+            if set(argument_names).intersection(abi_arg_names) == set(abi_arg_names):
+                abis_with_matching_args.push(abi_element)
+        except ValueError:
+            # fallback or receive functions do not have arguments
+            # proceed to next ABIElement
+            continue
+
+    return abis_with_matching_args
 
 
 # type ignored because subclassing encoding.AddressEncoder which has type Any

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -92,7 +92,7 @@ from web3.exceptions import (
 from web3.types import (
     TReturn,
 )
-from web3.utils import (  # public utils module
+from web3.utils import (
     get_abi_input_names,
 )
 
@@ -115,20 +115,6 @@ def filter_by_name(name: str, contract_abi: ABI) -> List[Union[ABIFunction, ABIE
             and abi["name"] == name
         )
     ]
-
-
-def get_abi_input_types(abi: ABIFunction) -> List[str]:
-    if "inputs" not in abi and (abi["type"] == "fallback" or abi["type"] == "receive"):
-        return []
-    else:
-        return [get_normalized_abi_arg_type(arg) for arg in abi["inputs"]]
-
-
-def get_abi_output_types(abi: ABIFunction) -> List[str]:
-    if abi["type"] == "fallback":
-        return []
-    else:
-        return [get_normalized_abi_arg_type(arg) for arg in abi["outputs"]]
 
 
 def get_receive_func_abi(contract_abi: ABI) -> ABIFunction:

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -47,6 +47,11 @@ from eth_abi.registry import (
     registry as default_registry,
 )
 from eth_typing import (
+    ABI,
+    ABIEvent,
+    ABIEventParam,
+    ABIFunction,
+    ABIFunctionParam,
     HexStr,
     TypeStr,
 )
@@ -60,7 +65,7 @@ from eth_utils import (
     to_tuple,
 )
 from eth_utils.abi import (
-    collapse_if_tuple,
+    get_normalized_abi_arg_type,
 )
 from eth_utils.toolz import (
     curry,
@@ -85,11 +90,6 @@ from web3.exceptions import (
     Web3ValueError,
 )
 from web3.types import (
-    ABI,
-    ABIEvent,
-    ABIEventParams,
-    ABIFunction,
-    ABIFunctionParams,
     TReturn,
 )
 from web3.utils import (  # public utils module
@@ -121,14 +121,14 @@ def get_abi_input_types(abi: ABIFunction) -> List[str]:
     if "inputs" not in abi and (abi["type"] == "fallback" or abi["type"] == "receive"):
         return []
     else:
-        return [collapse_if_tuple(cast(Dict[str, Any], arg)) for arg in abi["inputs"]]
+        return [get_normalized_abi_arg_type(arg) for arg in abi["inputs"]]
 
 
 def get_abi_output_types(abi: ABIFunction) -> List[str]:
     if abi["type"] == "fallback":
         return []
     else:
-        return [collapse_if_tuple(cast(Dict[str, Any], arg)) for arg in abi["outputs"]]
+        return [get_normalized_abi_arg_type(arg) for arg in abi["outputs"]]
 
 
 def get_receive_func_abi(contract_abi: ABI) -> ABIFunction:
@@ -155,22 +155,22 @@ def receive_func_abi_exists(contract_abi: ABI) -> List[Union[ABIFunction, ABIEve
     return filter_by_type("receive", contract_abi)
 
 
-def get_indexed_event_inputs(event_abi: ABIEvent) -> List[ABIEventParams]:
+def get_indexed_event_inputs(event_abi: ABIEvent) -> List[ABIEventParam]:
     return [arg for arg in event_abi["inputs"] if arg["indexed"] is True]
 
 
-def exclude_indexed_event_inputs(event_abi: ABIEvent) -> List[ABIEventParams]:
+def exclude_indexed_event_inputs(event_abi: ABIEvent) -> List[ABIEventParam]:
     return [arg for arg in event_abi["inputs"] if arg["indexed"] is False]
 
 
-def get_normalized_abi_arg_type(abi_arg: ABIEventParams) -> str:
+def get_normalized_abi_arg_type(abi_arg: ABIEventParam) -> str:
     """
     Return the normalized type for the abi argument provided.
     In order to account for tuple argument types, this abstraction
-    makes use of `collapse_if_tuple()` to collapse the appropriate component
+    makes use of `get_normalized_abi_arg_type()` to collapse the appropriate component
     types within a tuple type, if present.
     """
-    return collapse_if_tuple(dict(abi_arg))
+    return get_normalized_abi_arg_type(abi_arg)
 
 
 def filter_by_argument_count(
@@ -468,7 +468,7 @@ def get_tuple_type_str_parts(s: str) -> Optional[Tuple[str, Optional[str]]]:
     return None
 
 
-def _align_abi_input(arg_abi: ABIFunctionParams, arg: Any) -> Tuple[Any, ...]:
+def _align_abi_input(arg_abi: ABIFunctionParam, arg: Any) -> Tuple[Any, ...]:
     """
     Aligns the values of any mapping at any level of nesting in ``arg``
     according to the layout of the corresponding abi spec.
@@ -532,7 +532,7 @@ def get_aligned_abi_inputs(
         args = tuple(args[abi["name"]] for abi in input_abis)
 
     return (
-        tuple(collapse_if_tuple(abi) for abi in input_abis),
+        tuple(get_normalized_abi_arg_type(abi) for abi in input_abis),
         type(args)(_align_abi_input(abi, arg) for abi, arg in zip(input_abis, args)),
     )
 
@@ -671,8 +671,8 @@ def is_probably_enum(abi_type: TypeStr) -> bool:
 
 @to_tuple
 def normalize_event_input_types(
-    abi_args: Collection[Union[ABIFunction, ABIEvent]]
-) -> Iterable[Union[ABIFunction, ABIEvent, Dict[TypeStr, Any]]]:
+    abi_args: Collection[Union[ABIFunctionParam, ABIEventParam]]
+) -> Iterable[Union[ABIFunctionParam, ABIEventParam, Dict[TypeStr, Any]]]:
     for arg in abi_args:
         if is_recognized_type(arg["type"]):
             yield arg
@@ -682,11 +682,12 @@ def normalize_event_input_types(
             yield arg
 
 
+# TODO: Make this a public utility
 def abi_to_signature(abi: Union[ABIFunction, ABIEvent]) -> str:
     function_signature = "{fn_name}({fn_input_types})".format(
         fn_name=abi["name"],
         fn_input_types=",".join(
-            collapse_if_tuple(dict(arg))
+            get_normalized_abi_arg_type(dict(arg))
             for arg in normalize_event_input_types(abi.get("inputs", []))
         ),
     )
@@ -913,7 +914,7 @@ def build_strict_registry() -> ABIRegistry:
 
 
 def named_tree(
-    abi: Iterable[Union[ABIFunctionParams, ABIFunction, ABIEvent, Dict[TypeStr, Any]]],
+    abi: Iterable[Union[ABIFunctionParam, ABIFunction, ABIEvent, Dict[TypeStr, Any]]],
     data: Iterable[Tuple[Any, ...]],
 ) -> Dict[str, Any]:
     """
@@ -926,10 +927,10 @@ def named_tree(
 
 
 def _named_subtree(
-    abi: Union[ABIFunctionParams, ABIFunction, ABIEvent, Dict[TypeStr, Any]],
+    abi: Union[ABIFunctionParam, ABIFunction, ABIEvent, Dict[TypeStr, Any]],
     data: Tuple[Any, ...],
 ) -> Union[Dict[str, Any], Tuple[Any, ...], List[Any]]:
-    abi_type = parse(collapse_if_tuple(dict(abi)))
+    abi_type = parse(get_normalized_abi_arg_type(dict(abi)))
 
     if abi_type.is_array:
         item_type = abi_type.item_type.to_type_str()
@@ -938,7 +939,7 @@ def _named_subtree(
         return items
 
     elif isinstance(abi_type, TupleType):
-        abi = cast(ABIFunctionParams, abi)
+        abi = cast(ABIFunctionParam, abi)
         names = [item["name"] for item in abi["components"]]
         items = [_named_subtree(*item) for item in zip(abi["components"], data)]
 

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -163,16 +163,6 @@ def exclude_indexed_event_inputs(event_abi: ABIEvent) -> List[ABIEventParam]:
     return [arg for arg in event_abi["inputs"] if arg["indexed"] is False]
 
 
-def get_normalized_abi_arg_type(abi_arg: ABIEventParam) -> str:
-    """
-    Return the normalized type for the abi argument provided.
-    In order to account for tuple argument types, this abstraction
-    makes use of `get_normalized_abi_arg_type()` to collapse the appropriate component
-    types within a tuple type, if present.
-    """
-    return get_normalized_abi_arg_type(abi_arg)
-
-
 def filter_by_argument_count(
     num_arguments: int, contract_abi: ABI
 ) -> List[Union[ABIFunction, ABIEvent]]:

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -482,7 +482,7 @@ def _align_abi_input(arg_abi: ABIFunctionParam, arg: Any) -> Tuple[Any, ...]:
         new_abi = copy.copy(arg_abi)
         new_abi["type"] = tuple_prefix + "[]" * (num_dims - 1)
 
-        sub_abis = itertools.repeat(new_abi)  # type: ignore
+        sub_abis = itertools.repeat(new_abi)
 
     if isinstance(arg, abc.Mapping):
         # Arg is mapping.  Align values according to abi order.

--- a/web3/_utils/contracts.py
+++ b/web3/_utils/contracts.py
@@ -42,6 +42,9 @@ from hexbytes import (
     HexBytes,
 )
 
+from web3.utils.abi import (
+    get_abi_input_types,
+)
 from web3._utils.abi import (
     abi_to_signature,
     check_if_arguments_can_be_encoded,
@@ -50,7 +53,6 @@ from web3._utils.abi import (
     filter_by_encodability,
     filter_by_name,
     filter_by_type,
-    get_abi_input_types,
     get_aligned_abi_inputs,
     get_fallback_func_abi,
     get_receive_func_abi,

--- a/web3/_utils/contracts.py
+++ b/web3/_utils/contracts.py
@@ -70,6 +70,7 @@ from web3._utils.normalizers import (
 )
 from web3.exceptions import (
     BlockNumberOutOfRange,
+    MismatchedABI,
     Web3TypeError,
     Web3ValidationError,
     Web3ValueError,
@@ -168,9 +169,12 @@ def prepare_transaction(
     TODO: add new prepare_deploy_transaction API
     """
     if fn_abi is None:
-        fn_abi = get_function_abi(
-            contract_abi, fn_identifier, fn_args, fn_kwargs, abi_codec=w3.codec
-        )
+        try:
+            fn_abi = get_function_abi(
+                contract_abi, fn_identifier, fn_args, fn_kwargs, abi_codec=w3.codec
+            )
+        except (MismatchedABI, TypeError):
+            raise
 
     validate_payable(transaction, fn_abi)
 

--- a/web3/_utils/contracts.py
+++ b/web3/_utils/contracts.py
@@ -19,6 +19,9 @@ from eth_abi.registry import (
     registry as default_registry,
 )
 from eth_typing import (
+    ABI,
+    ABIEvent,
+    ABIFunction,
     ChecksumAddress,
     HexStr,
     TypeStr,
@@ -81,9 +84,6 @@ from web3.exceptions import (
     Web3ValueError,
 )
 from web3.types import (
-    ABI,
-    ABIEvent,
-    ABIFunction,
     BlockIdentifier,
     BlockNumber,
     TxParams,

--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -44,6 +44,9 @@ from eth_utils import (
     to_hex,
     to_tuple,
 )
+from eth_utils.abi import (
+    get_normalized_abi_arg_type,
+)
 from eth_utils.curried import (
     apply_formatter_if,
 )
@@ -59,7 +62,6 @@ import web3
 from web3._utils.abi import (
     exclude_indexed_event_inputs,
     get_indexed_event_inputs,
-    get_normalized_abi_arg_type,
     map_abi_data,
     named_tree,
     normalize_event_input_types,

--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -247,7 +247,9 @@ def get_event_data(
     log_topics_abi = get_indexed_event_inputs(event_abi)
     log_topic_normalized_inputs = normalize_event_input_types(log_topics_abi)
     log_topic_types = get_event_abi_types_for_decoding(log_topic_normalized_inputs)
-    log_topic_names = get_abi_input_names(ABIEvent({"inputs": log_topics_abi}))
+    log_topic_names = get_abi_input_names(
+        ABIEvent({"type": "event", "inputs": log_topics_abi})
+    )
 
     if len(log_topics_bytes) != len(log_topic_types):
         raise LogTopicError(
@@ -258,7 +260,9 @@ def get_event_data(
     log_data_abi = exclude_indexed_event_inputs(event_abi)
     log_data_normalized_inputs = normalize_event_input_types(log_data_abi)
     log_data_types = get_event_abi_types_for_decoding(log_data_normalized_inputs)
-    log_data_names = get_abi_input_names(ABIEvent({"inputs": log_data_abi}))
+    log_data_names = get_abi_input_names(
+        ABIEvent({"type": "event", "inputs": log_data_abi})
+    )
 
     # sanity check that there are not name intersections between the topic
     # names and the data argument names.

--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -27,6 +27,8 @@ from eth_abi.codec import (
     ABICodec,
 )
 from eth_typing import (
+    ABIEvent,
+    ABIEventParam,
     ChecksumAddress,
     HexStr,
     Primitives,
@@ -79,8 +81,6 @@ from web3.exceptions import (
     Web3ValueError,
 )
 from web3.types import (
-    ABIEvent,
-    ABIEventParams,
     BlockIdentifier,
     EventData,
     FilterParams,
@@ -206,7 +206,7 @@ def is_dynamic_sized_type(type_str: TypeStr) -> bool:
 
 @to_tuple
 def get_event_abi_types_for_decoding(
-    event_inputs: Sequence[ABIEventParams],
+    event_inputs: Sequence[ABIEventParam],
 ) -> Iterable[TypeStr]:
     """
     Event logs use the `keccak(value)` for indexed inputs of type `bytes` or

--- a/web3/_utils/filters.py
+++ b/web3/_utils/filters.py
@@ -19,6 +19,7 @@ from eth_abi.grammar import (
     parse as parse_type_string,
 )
 from eth_typing import (
+    ABIEvent,
     ChecksumAddress,
     HexStr,
     TypeStr,
@@ -55,7 +56,6 @@ from web3.exceptions import (
     Web3ValueError,
 )
 from web3.types import (
-    ABIEvent,
     BlockIdentifier,
     FilterParams,
     LogReceipt,

--- a/web3/_utils/normalizers.py
+++ b/web3/_utils/normalizers.py
@@ -19,6 +19,7 @@ from eth_abi.grammar import (
     parse,
 )
 from eth_typing import (
+    ABI,
     ChecksumAddress,
     HexStr,
     TypeStr,
@@ -61,9 +62,6 @@ from web3.exceptions import (
     InvalidAddress,
     NameNotFound,
     Web3ValueError,
-)
-from web3.types import (
-    ABI,
 )
 
 if TYPE_CHECKING:

--- a/web3/_utils/validation.py
+++ b/web3/_utils/validation.py
@@ -5,6 +5,8 @@ from typing import (
 )
 
 from eth_typing import (
+    ABI,
+    ABIFunction,
     HexStr,
     TypeStr,
 )
@@ -55,10 +57,6 @@ from web3.exceptions import (
     InvalidAddress,
     Web3TypeError,
     Web3ValueError,
-)
-from web3.types import (
-    ABI,
-    ABIFunction,
 )
 
 

--- a/web3/contract/async_contract.py
+++ b/web3/contract/async_contract.py
@@ -14,6 +14,7 @@ from typing import (
 )
 
 from eth_typing import (
+    ABI,
     ChecksumAddress,
 )
 from eth_utils import (
@@ -88,7 +89,6 @@ from web3.exceptions import (
     Web3ValueError,
 )
 from web3.types import (
-    ABI,
     BlockIdentifier,
     EventData,
     StateOverride,

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -17,6 +17,9 @@ from typing import (
 import warnings
 
 from eth_typing import (
+    ABI,
+    ABIEvent,
+    ABIFunction,
     Address,
     ChecksumAddress,
     HexStr,
@@ -105,9 +108,6 @@ from web3.logs import (
     EventLogErrorFlags,
 )
 from web3.types import (
-    ABI,
-    ABIEvent,
-    ABIFunction,
     BlockIdentifier,
     EventData,
     FilterParams,

--- a/web3/contract/contract.py
+++ b/web3/contract/contract.py
@@ -13,6 +13,7 @@ from typing import (
 )
 
 from eth_typing import (
+    ABI,
     ChecksumAddress,
 )
 from eth_utils import (
@@ -87,7 +88,6 @@ from web3.exceptions import (
     Web3ValueError,
 )
 from web3.types import (
-    ABI,
     BlockIdentifier,
     EventData,
     StateOverride,

--- a/web3/contract/utils.py
+++ b/web3/contract/utils.py
@@ -23,9 +23,11 @@ from hexbytes import (
     HexBytes,
 )
 
+from web3.utils.abi import (
+    get_abi_output_types,
+)
 from web3._utils.abi import (
     filter_by_type,
-    get_abi_output_types,
     map_abi_data,
     named_tree,
     recursive_dict_to_namedtuple,

--- a/web3/contract/utils.py
+++ b/web3/contract/utils.py
@@ -108,7 +108,13 @@ def call_contract_function(
             contract_abi, w3.codec, function_identifier, args, kwargs
         )
 
-    output_types = get_abi_output_types(fn_abi)
+    try:
+        output_types = get_abi_output_types(fn_abi)
+    except ValueError:
+        # constructor, fallback and receive functions do not have arguments
+        # proceed with decoding data without arguments
+        output_types = []
+        pass
 
     try:
         output_data = w3.codec.decode(output_types, return_data)
@@ -319,7 +325,13 @@ async def async_call_contract_function(
             contract_abi, async_w3.codec, function_identifier, args, kwargs
         )
 
-    output_types = get_abi_output_types(fn_abi)
+    try:
+        output_types = get_abi_output_types(fn_abi)
+    except ValueError:
+        # constructor, fallback and receive functions do not have arguments
+        # proceed with decoding data without arguments
+        output_types = []
+        pass
 
     try:
         output_data = async_w3.codec.decode(output_types, return_data)

--- a/web3/contract/utils.py
+++ b/web3/contract/utils.py
@@ -36,7 +36,6 @@ from web3._utils.async_transactions import (
     async_fill_transaction_defaults,
 )
 from web3._utils.contracts import (
-    find_matching_fn_abi,
     prepare_transaction,
 )
 from web3._utils.normalizers import (
@@ -55,6 +54,9 @@ from web3.types import (
     StateOverride,
     TContractFn,
     TxParams,
+)
+from web3.utils.abi import (
+    get_function_abi,
 )
 
 if TYPE_CHECKING:
@@ -104,8 +106,8 @@ def call_contract_function(
     )
 
     if fn_abi is None:
-        fn_abi = find_matching_fn_abi(
-            contract_abi, w3.codec, function_identifier, args, kwargs
+        fn_abi = get_function_abi(
+            contract_abi, function_identifier, args, kwargs, abi_codec=w3.codec
         )
 
     try:
@@ -321,8 +323,8 @@ async def async_call_contract_function(
     )
 
     if fn_abi is None:
-        fn_abi = find_matching_fn_abi(
-            contract_abi, async_w3.codec, function_identifier, args, kwargs
+        fn_abi = get_function_abi(
+            contract_abi, function_identifier, args, kwargs, abi_codec=async_w3.codec
         )
 
     try:

--- a/web3/contract/utils.py
+++ b/web3/contract/utils.py
@@ -15,6 +15,8 @@ from eth_abi.exceptions import (
     DecodingError,
 )
 from eth_typing import (
+    ABI,
+    ABIFunction,
     ChecksumAddress,
 )
 from hexbytes import (
@@ -46,8 +48,6 @@ from web3.exceptions import (
     Web3ValueError,
 )
 from web3.types import (
-    ABI,
-    ABIFunction,
     BlockIdentifier,
     FunctionIdentifier,
     StateOverride,

--- a/web3/contract/utils.py
+++ b/web3/contract/utils.py
@@ -46,6 +46,7 @@ from web3._utils.transactions import (
 )
 from web3.exceptions import (
     BadFunctionCallOutput,
+    MismatchedABI,
     Web3ValueError,
 )
 from web3.types import (
@@ -106,9 +107,12 @@ def call_contract_function(
     )
 
     if fn_abi is None:
-        fn_abi = get_function_abi(
-            contract_abi, function_identifier, args, kwargs, abi_codec=w3.codec
-        )
+        try:
+            fn_abi = get_function_abi(
+                contract_abi, function_identifier, args, kwargs, abi_codec=w3.codec
+            )
+        except TypeError:
+            raise
 
     try:
         output_types = get_abi_output_types(fn_abi)
@@ -323,9 +327,16 @@ async def async_call_contract_function(
     )
 
     if fn_abi is None:
-        fn_abi = get_function_abi(
-            contract_abi, function_identifier, args, kwargs, abi_codec=async_w3.codec
-        )
+        try:
+            fn_abi = get_function_abi(
+                contract_abi,
+                function_identifier,
+                args,
+                kwargs,
+                abi_codec=async_w3.codec,
+            )
+        except TypeError:
+            raise
 
     try:
         output_types = get_abi_output_types(fn_abi)

--- a/web3/types.py
+++ b/web3/types.py
@@ -73,46 +73,6 @@ class AccessListEntry(TypedDict):
 AccessList = NewType("AccessList", Sequence[AccessListEntry])
 
 
-# todo: move these to eth_typing once web3 is type hinted
-class ABIEventParams(TypedDict, total=False):
-    indexed: bool
-    name: str
-    type: str
-
-
-class ABIEvent(TypedDict, total=False):
-    anonymous: bool
-    inputs: Sequence["ABIEventParams"]
-    name: str
-    type: Literal["event"]
-
-
-class ABIFunctionComponents(TypedDict, total=False):
-    components: Sequence["ABIFunctionComponents"]
-    name: str
-    type: str
-
-
-class ABIFunctionParams(TypedDict, total=False):
-    components: Sequence["ABIFunctionComponents"]
-    name: str
-    type: str
-
-
-class ABIFunction(TypedDict, total=False):
-    constant: bool
-    inputs: Sequence["ABIFunctionParams"]
-    name: str
-    outputs: Sequence["ABIFunctionParams"]
-    payable: bool
-    stateMutability: Literal["pure", "view", "nonpayable", "payable"]
-    type: Literal["function", "constructor", "fallback", "receive"]
-
-
-ABIElement = Union[ABIFunction, ABIEvent]
-ABI = Sequence[Union[ABIFunction, ABIEvent]]
-
-
 class EventData(TypedDict):
     address: ChecksumAddress
     args: Dict[str, Any]

--- a/web3/utils/__init__.py
+++ b/web3/utils/__init__.py
@@ -4,8 +4,21 @@ classify as breaking changes.
 """
 
 from .abi import (  # NOQA
+    event_abi_to_log_topic,
+    event_signature_to_log_topic,
+    function_abi_to_4byte_selector,
+    function_signature_to_4byte_selector,
     get_abi_input_names,
+    get_abi_input_types,
     get_abi_output_names,
+    get_abi_output_types,
+    get_all_event_abis,
+    get_all_function_abis,
+    get_event_abi,
+    get_event_log_topics,
+    get_function_abi,
+    get_function_info,
+    get_normalized_abi_arg_type,
 )
 from .address import get_create_address  # NOQA
 from .async_exception_handling import (  # NOQA

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -1,13 +1,3 @@
-from typing import (
-    List,
-    Union,
-)
-
-from web3.types import (
-    ABIEvent,
-    ABIFunction,
-)
-
 from eth_utils import (
     event_abi_to_log_topic,
     event_signature_to_log_topic,
@@ -25,15 +15,3 @@ from eth_utils import (
     get_function_info,
     get_normalized_abi_arg_type,
 )
-
-
-def get_abi_input_names(abi: Union[ABIFunction, ABIEvent]) -> List[str]:
-    if "inputs" not in abi and abi["type"] == "fallback":
-        return []
-    return [arg["name"] for arg in abi["inputs"]]
-
-
-def get_abi_output_names(abi: Union[ABIFunction]) -> List[str]:
-    if "outputs" not in abi and abi["type"] == "fallback":
-        return []
-    return [arg["name"] for arg in abi["outputs"]]

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -1,4 +1,4 @@
-from eth_utils import (
+from eth_utils.abi import (  # NOQA
     event_abi_to_log_topic,
     event_signature_to_log_topic,
     function_abi_to_4byte_selector,

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -8,6 +8,24 @@ from web3.types import (
     ABIFunction,
 )
 
+from eth_utils import (
+    event_abi_to_log_topic,
+    event_signature_to_log_topic,
+    function_abi_to_4byte_selector,
+    function_signature_to_4byte_selector,
+    get_abi_input_names,
+    get_abi_input_types,
+    get_abi_output_names,
+    get_abi_output_types,
+    get_all_event_abis,
+    get_all_function_abis,
+    get_event_abi,
+    get_event_log_topics,
+    get_function_abi,
+    get_function_info,
+    get_normalized_abi_arg_type,
+)
+
 
 def get_abi_input_names(abi: Union[ABIFunction, ABIEvent]) -> List[str]:
     if "inputs" not in abi and abi["type"] == "fallback":

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -15,3 +15,21 @@ from eth_utils.abi import (  # NOQA
     get_function_info,
     get_normalized_abi_arg_type,
 )
+
+__all__ = [
+    "event_abi_to_log_topic",
+    "event_signature_to_log_topic",
+    "function_abi_to_4byte_selector",
+    "function_signature_to_4byte_selector",
+    "get_abi_input_names",
+    "get_abi_input_types",
+    "get_abi_output_names",
+    "get_abi_output_types",
+    "get_all_event_abis",
+    "get_all_function_abis",
+    "get_event_abi",
+    "get_event_log_topics",
+    "get_function_abi",
+    "get_function_info",
+    "get_normalized_abi_arg_type",
+]


### PR DESCRIPTION
### What was wrong?

ABI utilities are now public. Web3.py should be updated to import the public utilities.

Closes #3036

### How was it fixed?

Makes web3 compatible with `eth-utils` @ 4.2.2

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="621" alt="Screen Shot 2024-05-01 at 12 12 28 PM" src="https://github.com/ethereum/web3.py/assets/435903/18fa5b0f-9383-4469-8eeb-28d341308082">

