### PR TITLE
add py312 support - v6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -931,6 +931,146 @@ jobs:
         environment:
           TOXENV: py311-wheel-cli
 
+  #
+  # Python 3.12
+  #
+  py312-lint:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+    environment:
+      TOXENV: py312-lint
+
+  py312-core:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+    environment:
+      TOXENV: py312-core
+
+  py312-core_async:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+    environment:
+      TOXENV: py312-core_async
+
+  py312-ens:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+    environment:
+      TOXENV: py312-ens
+
+  py312-ensip15:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+    environment:
+      TOXENV: py312-ensip15
+
+  py312-ethpm:
+    <<: *ethpm_steps
+    docker:
+      - image: cimg/python:3.12
+    environment:
+      TOXENV: py312-ethpm
+      # Please don't use this key for any shenanigans
+      WEB3_INFURA_PROJECT_ID: $WEB3_INFURA_PROJECT_ID
+
+  py312-integration-goethereum-ipc:
+    <<: *geth_steps
+    docker:
+      - image: cimg/python:3.12
+    environment:
+      TOXENV: py312-integration-goethereum-ipc
+
+  py312-integration-goethereum-ipc_flaky:
+    <<: *geth_steps
+    docker:
+      - image: cimg/python:3.12
+    environment:
+      TOXENV: py312-integration-goethereum-ipc_flaky
+
+  py312-integration-goethereum-http:
+    <<: *geth_steps
+    docker:
+      - image: cimg/python:3.12
+    environment:
+      TOXENV: py312-integration-goethereum-http
+
+  py312-integration-goethereum-http_async:
+    <<: *geth_steps
+    docker:
+      - image: cimg/python:3.12
+    environment:
+      TOXENV: py312-integration-goethereum-http_async
+
+  py312-integration-goethereum-http_async_flaky:
+    <<: *geth_steps
+    docker:
+      - image: cimg/python:3.12
+    environment:
+      TOXENV: py312-integration-goethereum-http_async_flaky
+
+  py312-integration-goethereum-http_flaky:
+    <<: *geth_steps
+    docker:
+      - image: cimg/python:3.12
+    environment:
+      TOXENV: py312-integration-goethereum-http_flaky
+
+  py312-integration-goethereum-ws:
+    <<: *geth_steps
+    docker:
+      - image: cimg/python:3.12
+    environment:
+      TOXENV: py312-integration-goethereum-ws
+
+  py312-integration-goethereum-ws_flaky:
+    <<: *geth_steps
+    docker:
+      - image: cimg/python:3.12
+    environment:
+      TOXENV: py312-integration-goethereum-ws_flaky
+
+  py312-integration-goethereum-ws-v2:
+    <<: *geth_steps
+    docker:
+      - image: cimg/python:3.12
+    environment:
+      TOXENV: py312-integration-goethereum-ws_v2
+
+  py312-integration-goethereum-ws-v2_flaky:
+    <<: *geth_steps
+    docker:
+      - image: cimg/python:3.12
+    environment:
+      TOXENV: py312-integration-goethereum-ws_v2_flaky
+
+  py312-integration-ethtester-pyevm:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+    environment:
+      TOXENV: py312-integration-ethtester
+      ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
+
+  py312-integration-ethtester-pyevm_flaky:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+    environment:
+      TOXENV: py312-integration-ethtester_flaky
+      ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
+
+  py312-wheel-cli:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          TOXENV: py312-wheel-cli
+
   benchmark:
     <<: *geth_steps
     docker:
@@ -948,11 +1088,13 @@ workflows:
       - py39-core
       - py310-core
       - py311-core
+      - py312-core
       - py37-core_async
       - py38-core_async
       - py39-core_async
       - py310-core_async
       - py311-core_async
+      - py312-core_async
       - docs
       - benchmark
       - py37-ens
@@ -1040,3 +1182,20 @@ workflows:
       - py311-integration-ethtester-pyevm_flaky
       - py311-wheel-cli
       - py311-wheel-cli-windows
+      - py312-lint
+      - py312-ens
+      - py312-ensip15
+      - py312-ethpm
+      - py312-integration-goethereum-ipc
+      - py312-integration-goethereum-ipc_flaky
+      - py312-integration-goethereum-http
+      - py312-integration-goethereum-http_async
+      - py312-integration-goethereum-http_async_flaky
+      - py312-integration-goethereum-http_flaky
+      - py312-integration-goethereum-ws
+      - py312-integration-goethereum-ws_flaky
+      - py312-integration-goethereum-ws-v2
+      - py312-integration-goethereum-ws-v2_flaky
+      - py312-integration-ethtester-pyevm
+      - py312-integration-ethtester-pyevm_flaky
+      - py312-wheel-cli

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/PyCQA/flake8
-    rev: 3.8.3
+    rev: 6.1.0
     hooks:
     -   id: flake8
         exclude: setup.py

--- a/newsfragments/3373.internal.rst
+++ b/newsfragments/3373.internal.rst
@@ -1,0 +1,1 @@
+Add ``py312`` support by adding it to CI testing

--- a/tests/core/web3-module/test_providers.py
+++ b/tests/core/web3-module/test_providers.py
@@ -24,7 +24,7 @@ def test_auto_provider_none():
     # non-node requests succeed
     w3.to_hex(0) == "0x0"
 
-    type(w3.provider) == AutoProvider
+    assert type(w3.provider) is AutoProvider
 
 
 def test_provider_default_value_for_ccip_read_redirect(w3):

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 envlist=
-    py{37,38,39,310,311}-ens
-    py{37,38,39,310,311}-ethpm
-    py{37,38,39,310,311}-core
-    py{37,38,39,310,311}-integration-{goethereum,ethtester}
-    py{38,39,310,311}-lint
-    py{37,38,39,310,311}-wheel-cli
+    py{37,38,39,310,311,312}-ens
+    py{37,38,39,310,311,312}-ethpm
+    py{37,38,39,310,311,312}-core
+    py{37,38,39,310,311,312}-integration-{goethereum,ethtester}
+    py{38,39,310,311,312}-lint
+    py{37,38,39,310,311,312}-wheel-cli
     docs
     benchmark
 
@@ -56,8 +56,9 @@ basepython =
     py39: python3.9
     py310: python3.10
     py311: python3.11
+    py312: python3.12
 
-[testenv:py{38,39,310,311}-lint]
+[testenv:py{38,39,310,311,312}-lint]
 deps=pre-commit
 commands=
     pre-commit install    

--- a/web3/tools/pytest_ethereum/deployer.py
+++ b/web3/tools/pytest_ethereum/deployer.py
@@ -27,7 +27,7 @@ class Deployer:
                 f"Expected a Package object, instead received {type(package)}."
             )
         self.package = package
-        self.strategies = {}  # type: Dict[str, Callable[[Package], Package]]
+        self.strategies: Dict[str, Callable[[Package], Package]] = {}
 
     def deploy(self, contract_type: ContractName, *args: Any, **kwargs: Any) -> Package:
         factory = self.package.get_contract_factory(contract_type)


### PR DESCRIPTION
### What was wrong?

Support py312 in v6. Bumped `flake8` version to one that supports py312, fixed a couple errors that came up.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/d4972de5-669b-47d6-9ecc-7d5a67f1c16f)
