### PR TITLE
bump mypy to 1.10 and update type-ignores

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
         additional_dependencies:
         -   mdformat-gfm
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v1.10.0
     hooks:
     -   id: mypy
         exclude: 'tests/|conftest.py'

--- a/newsfragments/3377.internal.rst
+++ b/newsfragments/3377.internal.rst
@@ -1,0 +1,1 @@
+Bump to ``mypy==1.10.0`` for ``pre-commit``

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -765,7 +765,7 @@ class AsyncEth(BaseEth):
 
     @overload
     # mypy error: Overloaded function signatures 1 and 2 overlap with incompatible return types  # noqa: E501
-    def contract(self, address: None = None, **kwargs: Any) -> Type[AsyncContract]:  # type: ignore[misc]  # noqa: E501
+    def contract(self, address: None = None, **kwargs: Any) -> Type[AsyncContract]:  # type: ignore[overload-overlap]  # noqa: E501
         ...
 
     @overload

--- a/web3/eth/eth.py
+++ b/web3/eth/eth.py
@@ -680,7 +680,7 @@ class Eth(BaseEth):
 
     @overload
     # type error: Overloaded function signatures 1 and 2 overlap with incompatible return types  # noqa: E501
-    def contract(self, address: None = None, **kwargs: Any) -> Type[Contract]:  # type: ignore[misc]  # noqa: E501
+    def contract(self, address: None = None, **kwargs: Any) -> Type[Contract]:  # type: ignore[overload-overlap]  # noqa: E501
         ...
 
     @overload

--- a/web3/gas_strategies/time_based.py
+++ b/web3/gas_strategies/time_based.py
@@ -110,11 +110,11 @@ def _aggregate_miner_data(
             # types ignored b/c mypy has trouble inferring gas_prices: Sequence[Wei]
             price_percentile = percentile(gas_prices, percentile=20)  # type: ignore
         except InsufficientData:
-            price_percentile = min(gas_prices)  # type: ignore
+            price_percentile = min(gas_prices)
         yield MinerData(
             miner,
             len(set(block_hashes)),
-            min(gas_prices),  # type: ignore
+            min(gas_prices),
             price_percentile,
         )
 


### PR DESCRIPTION
### What was wrong?

Looking at #2849, there are some nice features (specifically `Unpack`) that were experimental in the `mypy=1.5.1` we were using that are good to go in more recent versions.

Bumped `mypy` in `.precommitconfig.yaml` to `1.10`. Minimal new errors, just some `# type: ignore`s that we get to remove or make more specific.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/c215bbe1-9e93-4568-9cb0-b29322d9e992)
