### PR TITLE
Propagate listener task exceptions to the main loop.

### DIFF
--- a/newsfragments/3378.bugfix.rst
+++ b/newsfragments/3378.bugfix.rst
@@ -1,0 +1,1 @@
+Properly propagate exceptions from the message listener task to the main loop for persistent connection providers.

--- a/web3/_utils/module_testing/module_testing_utils.py
+++ b/web3/_utils/module_testing/module_testing_utils.py
@@ -177,6 +177,12 @@ class WebSocketMessageStreamMock:
         self.messages = deque(messages) if messages else deque()
         self.raise_exception = raise_exception
 
+    def __await__(self) -> Generator[Any, Any, "Self"]:
+        async def __async_init__() -> "Self":
+            return self
+
+        return __async_init__().__await__()
+
     def __aiter__(self) -> "Self":
         return self
 
@@ -188,6 +194,13 @@ class WebSocketMessageStreamMock:
             raise StopAsyncIteration
 
         return self.messages.popleft()
+
+    @staticmethod
+    async def pong() -> bool:
+        return False
+
+    async def connect(self) -> None:
+        pass
 
     async def send(self, data: bytes) -> None:
         pass

--- a/web3/_utils/module_testing/module_testing_utils.py
+++ b/web3/_utils/module_testing/module_testing_utils.py
@@ -196,7 +196,7 @@ class WebSocketMessageStreamMock:
         return self.messages.popleft()
 
     @staticmethod
-    async def pong() -> bool:
+    async def pong() -> Literal[False]:
         return False
 
     async def connect(self) -> None:

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -1,6 +1,7 @@
 import datetime
 import time
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     Optional,
@@ -15,6 +16,9 @@ from web3.types import (
     BlockData,
     RPCResponse,
 )
+
+if TYPE_CHECKING:
+    import asyncio
 
 
 class Web3Exception(Exception):
@@ -305,6 +309,22 @@ class BadResponseFormat(Web3Exception):
     """
     Raised when a JSON-RPC response comes back in an unexpected format
     """
+
+
+class TaskNotRunning(Web3Exception):
+    """
+    Used to signal between asyncio contexts that a task that is being awaited
+    is not currently running.
+    """
+
+    def __init__(
+        self, task: "asyncio.Task[Any]", message: Optional[str] = None
+    ) -> None:
+        self.task = task
+        if message is None:
+            message = f"Task {task} is not running."
+        self.message = message
+        super().__init__(message)
 
 
 class Web3RPCError(Web3Exception):

--- a/web3/main.py
+++ b/web3/main.py
@@ -85,7 +85,6 @@ from web3.eth import (
     Eth,
 )
 from web3.exceptions import (
-    ProviderConnectionError,
     Web3TypeError,
     Web3ValueError,
 )
@@ -513,17 +512,6 @@ class AsyncWeb3(BaseWeb3):
     )
     async def __aiter__(self) -> AsyncIterator[Self]:
         while True:
-            try:
-                await self.provider.connect()
-                yield self
-            except ProviderConnectionError:
-                # We use an exponential retry in `connect()` so if we raise a
-                # `ProviderConnectionError`, there is likely an issue with the provider
-                # that will likely not be resolved by continuing to iterate.
-                raise
-            except KeyboardInterrupt:
-                # If the user interrupts the iteration, stop iterating.
-                break
-            except Exception:
-                # If we encounter any other exception, continue iterating.
-                continue
+            await self.provider.connect()
+            yield self
+            await self.provider.disconnect()

--- a/web3/main.py
+++ b/web3/main.py
@@ -144,6 +144,7 @@ from web3.types import (
 
 if TYPE_CHECKING:
     from web3._utils.empty import Empty  # noqa: F401
+    from web3.providers.persistent import PersistentConnectionProvider  # noqa: F401
 
 
 def get_async_default_modules() -> Dict[str, Union[Type[Module], Sequence[Any]]]:
@@ -511,7 +512,11 @@ class AsyncWeb3(BaseWeb3):
         "when instantiating via ``async for``."
     )
     async def __aiter__(self) -> AsyncIterator[Self]:
+        provider = self.provider
         while True:
-            await self.provider.connect()
+            await provider.connect()
             yield self
-            await self.provider.disconnect()
+            cast("PersistentConnectionProvider", provider).logger.error(
+                "Connection interrupted, attempting to reconnect..."
+            )
+            await provider.disconnect()

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from typing import (
     TYPE_CHECKING,
@@ -403,47 +402,30 @@ class RequestManager:
                 "can listen to streams."
             )
 
-        msg_listener_task = self._provider._message_listener_task
-        if msg_listener_task is None:
+        if self._provider._message_listener_task is None:
             raise ProviderConnectionError(
                 "No listener found for persistent connection."
             )
 
         while True:
-            # Awaiting a message in the queue will block the loop until a message is
-            # received. If the listener task finishes for any reason, a new message will
-            # never come in. We have to simultaneously heck if the listener task is
-            # done, returning the first completed task.
-            done, pending = await asyncio.wait(
-                [
-                    asyncio.create_task(
-                        self._request_processor.pop_raw_response(subscription=True)
-                    ),
-                    msg_listener_task,
-                ],
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-
-            if msg_listener_task.done():
-                for task in pending:
-                    task.cancel()
-
+            response = await self._request_processor.pop_raw_response(subscription=True)
+            if response is None:
+                # Part of the callback for the listener task is to push `None` to the
+                # subscription queue so that we can pop out of the queue above and
+                # process any exceptions that occurred in the listener task.
                 self._provider._handle_listener_task_exceptions()
-                # if no exceptions raised and listener task is done, stop the stream
-                self.logger.debug(
-                    "Message listener task is not running, stopping message stream."
+                self.logger.error(
+                    "Message listener background task has stopped unexpectedly. "
+                    "Stopping message stream."
                 )
                 raise StopAsyncIteration
-
-            else:
-                response = done.pop().result()
-                if (
-                    response is not None
-                    and response.get("params", {}).get("subscription")
-                    in self._request_processor.active_subscriptions
-                ):
-                    # if response is an active subscription response, process it
-                    yield await self._process_response(response)
+            elif (
+                response is not None
+                and response.get("params", {}).get("subscription")
+                in self._request_processor.active_subscriptions
+            ):
+                # if response is an active subscription response, process it
+                yield await self._process_response(response)
 
     async def _process_response(self, response: RPCResponse) -> RPCResponse:
         provider = cast(PersistentConnectionProvider, self._provider)

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -408,6 +408,10 @@ class RequestManager:
             )
 
         while True:
+            # check if an exception was recorded in the listener task and raise it
+            # in the main loop if so
+            self._provider._handle_message_listener_exceptions()
+
             response = await self._request_processor.pop_raw_response(subscription=True)
             if (
                 response is not None

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -410,7 +410,7 @@ class RequestManager:
         while True:
             # check if an exception was recorded in the listener task and raise it
             # in the main loop if so
-            self._provider._handle_message_listener_exceptions()
+            self._provider._handle_listener_task_exceptions()
 
             response = await self._request_processor.pop_raw_response(subscription=True)
             if (

--- a/web3/providers/persistent/async_ipc.py
+++ b/web3/providers/persistent/async_ipc.py
@@ -177,7 +177,7 @@ class AsyncIPCProvider(PersistentConnectionProvider):
 
         return response
 
-    async def _message_listener_provider_specific_logic(self) -> None:
+    async def _provider_specific_message_listener(self) -> None:
         self._raw_message += to_text(await self._reader.read(4096)).lstrip()
 
         while self._raw_message:

--- a/web3/providers/persistent/persistent.py
+++ b/web3/providers/persistent/persistent.py
@@ -113,9 +113,11 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
         except (asyncio.CancelledError, StopAsyncIteration, ConnectionClosed):
             pass
         finally:
+            self._message_listener_task = None
             self.logger.info("Message listener background task successfully shut down.")
 
         await self._provider_specific_disconnect()
+        self._request_processor.clear_caches()
         self.logger.info(
             f"Successfully disconnected from: {self.get_endpoint_uri_or_ipc_path()}"
         )

--- a/web3/providers/persistent/request_processor.py
+++ b/web3/providers/persistent/request_processor.py
@@ -44,9 +44,9 @@ class RequestProcessor:
 
         self._request_information_cache: SimpleCache = SimpleCache(500)
         self._request_response_cache: SimpleCache = SimpleCache(500)
-        self._subscription_response_queue: asyncio.Queue[RPCResponse] = asyncio.Queue(
-            maxsize=subscription_response_queue_size
-        )
+        self._subscription_response_queue: asyncio.Queue[
+            Optional[RPCResponse]
+        ] = asyncio.Queue(maxsize=subscription_response_queue_size)
 
     @property
     def active_subscriptions(self) -> Dict[str, Any]:
@@ -251,14 +251,14 @@ class RequestProcessor:
             if qsize == 0:
                 if not self._subscription_queue_synced_with_ws_stream:
                     self._subscription_queue_synced_with_ws_stream = True
-                    self._provider.logger.debug(
+                    self._provider.logger.info(
                         "Subscription response queue synced with websocket message "
                         "stream."
                     )
             else:
                 if self._subscription_queue_synced_with_ws_stream:
                     self._subscription_queue_synced_with_ws_stream = False
-                self._provider.logger.debug(
+                self._provider.logger.info(
                     f"Subscription response queue has {qsize} subscriptions. "
                     "Processing as FIFO."
                 )

--- a/web3/providers/persistent/request_processor.py
+++ b/web3/providers/persistent/request_processor.py
@@ -218,7 +218,7 @@ class RequestProcessor:
     ) -> None:
         if subscription:
             if self._subscription_response_queue.full():
-                self._provider.logger.info(
+                self._provider.logger.debug(
                     "Subscription queue is full. Waiting for provider to consume "
                     "messages before caching."
                 )
@@ -251,14 +251,14 @@ class RequestProcessor:
             if qsize == 0:
                 if not self._subscription_queue_synced_with_ws_stream:
                     self._subscription_queue_synced_with_ws_stream = True
-                    self._provider.logger.info(
+                    self._provider.logger.debug(
                         "Subscription response queue synced with websocket message "
                         "stream."
                     )
             else:
                 if self._subscription_queue_synced_with_ws_stream:
                     self._subscription_queue_synced_with_ws_stream = False
-                self._provider.logger.info(
+                self._provider.logger.debug(
                     f"Subscription response queue has {qsize} subscriptions. "
                     "Processing as FIFO."
                 )

--- a/web3/providers/persistent/websocket.py
+++ b/web3/providers/persistent/websocket.py
@@ -147,9 +147,10 @@ class WebSocketProvider(PersistentConnectionProvider):
         if self._message_listener_task is not None:
             try:
                 self._message_listener_task.cancel()
-                await self._message_listener_task
             except (asyncio.CancelledError, StopAsyncIteration):
                 pass
+            finally:
+                self._message_listener_task = None
 
         if self._ws is not None and not self._ws.closed:
             await self._ws.close()
@@ -178,7 +179,7 @@ class WebSocketProvider(PersistentConnectionProvider):
 
         return response
 
-    async def _message_listener_provider_specific_logic(self) -> None:
+    async def _provider_specific_message_listener(self) -> None:
         async for raw_message in self._ws:
             await asyncio.sleep(0)
 

--- a/web3/providers/persistent/websocket.py
+++ b/web3/providers/persistent/websocket.py
@@ -178,31 +178,12 @@ class WebSocketProvider(PersistentConnectionProvider):
 
         return response
 
-    async def _message_listener(self) -> None:
-        self.logger.info(
-            "WebSocket listener background task started. Storing all messages in "
-            "appropriate request processor queues / caches to be processed."
-        )
-        while True:
-            # the use of sleep(0) seems to be the most efficient way to yield control
-            # back to the event loop to share the loop with other tasks.
+    async def _message_listener_provider_specific_logic(self) -> None:
+        async for raw_message in self._ws:
             await asyncio.sleep(0)
 
-            try:
-                async for raw_message in self._ws:
-                    await asyncio.sleep(0)
-
-                    response = json.loads(raw_message)
-                    subscription = response.get("method") == "eth_subscription"
-                    await self._request_processor.cache_raw_response(
-                        response, subscription=subscription
-                    )
-            except Exception as e:
-                if not self.silence_listener_task_exceptions:
-                    raise e
-
-                self.logger.error(
-                    "Exception caught in listener, error logging and keeping "
-                    "listener background task alive."
-                    f"\n    error={e.__class__.__name__}: {e}"
-                )
+            response = json.loads(raw_message)
+            subscription = response.get("method") == "eth_subscription"
+            await self._request_processor.cache_raw_response(
+                response, subscription=subscription
+            )


### PR DESCRIPTION
### What was wrong?

Closes #3375 (along with #3387)

### How was it fixed?

As I understand it, the way asyncio works is each task operates under its own context. Directly communicating with another context and trying to immediately propagate an exception to the main loop, for example, does not seem to be a very straightforward thing to do surprisingly. For better or worse, I think when we poll for messages we should check if the listener task is done and, if it is, if an exception was set. If an exception was set then we can raise it in the main loop where we are polling for messages.

- When we poll for messages, poll to see if the background task is finished. If it is, handle any exceptions in the main loop. On subscription streams, since we hang awaiting a message to appear in the subscription queue, we need to signal when the background task is `done` since no messages will be coming in and we will hang indefinitely. Push a new exception `TaskNotRunning` to the queue. Revamp the queue to raise when this is pushed to it. Handle this exception in the subscription polling.
- Refactor some of the logic. When disconnecting persistent connection providers, shut down the listener task before closing the connection to avoid any sort of errors when the task is still trying to read from the closing connection.

---

I added some nice logging that really shouldn't be too noisy unless the connection is reconnecting all the time (which I forced for the example here).

```
INFO:web3.providers.WebSocketProvider:Connecting to: wss://mainnet.infura.io/ws/v3/c364...
INFO:web3.providers.WebSocketProvider:Successfully connected to: wss://mainnet.infura.io/ws/v3/c364...
INFO:web3.providers.WebSocketProvider:WebSocketProvider listener background task started. Storing all messages in appropriate request processor queues / caches to be processed.
newHeads sub_id: 0xad65c6e2aefa417dafda6999d0bd774b
INFO:web3.providers.WebSocketProvider:Subscription response queue synced with websocket message stream.
blocknum: 19829151
blocknum: 19829152
ERROR:web3.providers.WebSocketProvider:Connection interrupted, attempting to reconnect...
INFO:web3.providers.WebSocketProvider:Message listener background task successfully shut down.
INFO:web3.providers.WebSocketProvider:Successfully disconnected from: wss://mainnet.infura.io/ws/v3/c364...
INFO:web3.providers.WebSocketProvider:Connecting to: wss://mainnet.infura.io/ws/v3/c364...
INFO:web3.providers.WebSocketProvider:Successfully connected to: wss://mainnet.infura.io/ws/v3/c364...
INFO:web3.providers.WebSocketProvider:WebSocketProvider listener background task started. Storing all messages in appropriate request processor queues / caches to be processed.
newHeads sub_id: 0x718852a668ed437fbdc86243db929405
blocknum: 19829153
blocknum: 19829154
ERROR:web3.providers.WebSocketProvider:Connection interrupted, attempting to reconnect...
INFO:web3.providers.WebSocketProvider:Message listener background task successfully shut down.
INFO:web3.providers.WebSocketProvider:Successfully disconnected from: wss://mainnet.infura.io/ws/v3/c364...
INFO:web3.providers.WebSocketProvider:Connecting to: wss://mainnet.infura.io/ws/v3/c364...
INFO:web3.providers.WebSocketProvider:Successfully connected to: wss://mainnet.infura.io/ws/v3/c364...
INFO:web3.providers.WebSocketProvider:WebSocketProvider listener background task started. Storing all messages in appropriate request processor queues / caches to be processed.
newHeads sub_id: 0xf46690d2853c4afba527ac71dd1915e0
blocknum: 19829155
...
```
---
Bonus:

I've been meaning to do this for some time and I think this is an appropriate time. Refactor the commonality of the listener task down to the base `PersistentConnectionProvider` class and define provider-specific methods that either need to be implemented or can be overridden to fine-tune logic specific to each persistent connection provider. This keeps things quite a bit DRYer.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![31205](https://github.com/ethereum/web3.py/assets/3532824/58c5dd6e-13eb-4b18-9203-6c3acda37936)
