### PR TITLE
rawTransaction -> raw_transaction

### DIFF
--- a/newsfragments/3380.internal.rst
+++ b/newsfragments/3380.internal.rst
@@ -1,0 +1,1 @@
+Move signed.rawTransaction -> signed.raw_transaction in eth module tests

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -721,7 +721,7 @@ class AsyncEthModuleTest:
             "gasPrice": 10**9,
         }
         signed = keyfile_account.sign_transaction(txn)
-        txn_hash = await async_w3.eth.send_raw_transaction(signed.rawTransaction)
+        txn_hash = await async_w3.eth.send_raw_transaction(signed.raw_transaction)
         assert txn_hash == HexBytes(signed.hash)
 
     @pytest.mark.asyncio
@@ -3720,7 +3720,7 @@ class EthModuleTest:
             "gasPrice": 10**9,
         }
         signed = keyfile_account.sign_transaction(txn)
-        txn_hash = w3.eth.send_raw_transaction(signed.rawTransaction)
+        txn_hash = w3.eth.send_raw_transaction(signed.raw_transaction)
         assert txn_hash == HexBytes(signed.hash)
 
     def test_eth_call(self, w3: "Web3", math_contract: "Contract") -> None:


### PR DESCRIPTION
### What was wrong?
eth-account moved the last few camelCase-s to snake_case.


### How was it fixed?
Updated here. 

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://bigcatrescue.org/wp-content/uploads/2010/04/pixlr-image-generator-b2b77841-c6de-4cb8-9717-3e694a48a08f.png)
