### PR TITLE
docs: simplify page titles

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -1,7 +1,7 @@
 .. _filtering:
 
-Monitoring Events
-=================
+Events and Logs
+===============
 
 If you're on this page, you're likely looking for an answer to this question:
 **How do I know when a specific contract is used?** You have at least three options:

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -1,7 +1,7 @@
 .. _providers:
 
-Connecting to Ethereum
-======================
+Providers
+=========
 
 Using Ethereum requires access to an Ethereum node. If you have the means, you're
 encouraged to `run your own node`_. (Note that you do not need to stake ether to

--- a/docs/transactions.rst
+++ b/docs/transactions.rst
@@ -1,5 +1,5 @@
-Sending Transactions
-====================
+Transactions
+============
 
 .. note::
 

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -1,7 +1,7 @@
 .. _eth-account:
 
-Working with Local Private Keys
-===============================
+Accounts
+========
 
 .. _local_vs_hosted:
 

--- a/newsfragments/3381.docs.rst
+++ b/newsfragments/3381.docs.rst
@@ -1,0 +1,1 @@
+Simplify titles of docs guides


### PR DESCRIPTION
### What was wrong?

Original intent with docs page titles was optimizing to help newcomers find what they're looking for (via descriptive/verb titles), but feels meaningfully easier to parse with just the noun (or two). i dont think we lose much of the approachability if they're presented in the 'right' order and the overview + quickstart are good.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.bunnyslippers.com/blog/wp-content/uploads/2014/04/animal-derp-3.jpg)
