### PR TITLE
move v6 windows wheel check to py312

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -786,11 +786,6 @@ jobs:
         environment:
           TOXENV: py310-wheel-cli
 
-  py311-wheel-cli-windows:
-    <<: *windows_steps
-    environment:
-      TOXENV: py311-wheel-cli-windows
-
   #
   # Python 3.11
   #
@@ -1071,6 +1066,12 @@ jobs:
         environment:
           TOXENV: py312-wheel-cli
 
+  py312-wheel-cli-windows:
+    <<: *windows_steps
+    environment:
+      TOXENV: py312-wheel-cli-windows
+
+
   benchmark:
     <<: *geth_steps
     docker:
@@ -1181,7 +1182,6 @@ workflows:
       - py311-integration-ethtester-pyevm
       - py311-integration-ethtester-pyevm_flaky
       - py311-wheel-cli
-      - py311-wheel-cli-windows
       - py312-lint
       - py312-ens
       - py312-ensip15
@@ -1199,3 +1199,4 @@ workflows:
       - py312-integration-ethtester-pyevm
       - py312-integration-ethtester-pyevm_flaky
       - py312-wheel-cli
+      - py312-wheel-cli-windows

--- a/newsfragments/3385.misc.rst
+++ b/newsfragments/3385.misc.rst
@@ -1,0 +1,1 @@
+Update wheel-cli-windows CI test to use py312, due to circle updating their default image

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ commands=
     python {toxinidir}/web3/tools/benchmark/main.py --num-calls 50
     python {toxinidir}/web3/tools/benchmark/main.py --num-calls 100
 
-[testenv:py{37,38,39,310,311}-wheel-cli]
+[testenv:py{37,38,39,310,311,312}-wheel-cli]
 deps=
     wheel
     build
@@ -83,7 +83,7 @@ commands=
     /bin/bash {toxinidir}/web3/scripts/release/test_wheel_install.sh
 skip_install=true
 
-[testenv:py311-wheel-cli-windows]
+[testenv:py312-wheel-cli-windows]
 deps=
     wheel
     build[virtualenv]


### PR DESCRIPTION
### What was wrong?

Circle updated their default image to have py312 instead of py311, causing CI to fail.

### How was it fixed?

Updated existing windows wheel job to use py312 instead (rather than importing the new windows wheel structure that exists in v7 (which won't have this problem))

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/21f16986-ae19-453e-a7a5-45c900674475)
