### PR TITLE
catch InsufficientDataBytes errors when processing receipts

### DIFF
--- a/newsfragments/3388.feature.rst
+++ b/newsfragments/3388.feature.rst
@@ -1,0 +1,1 @@
+Properly handle ``InsufficientDataBytes`` errors when processing receipts

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -16,6 +16,9 @@ from typing import (
 )
 import warnings
 
+from eth_abi.exceptions import (
+    InsufficientDataBytes,
+)
 from eth_typing import (
     Address,
     ChecksumAddress,
@@ -174,7 +177,13 @@ class BaseContractEvent:
         for log in txn_receipt["logs"]:
             try:
                 rich_log = get_event_data(self.w3.codec, self.abi, log)
-            except (MismatchedABI, LogTopicError, InvalidEventABI, TypeError) as e:
+            except (
+                MismatchedABI,
+                LogTopicError,
+                InvalidEventABI,
+                TypeError,
+                InsufficientDataBytes,
+            ) as e:
                 if errors == DISCARD:
                     continue
                 elif errors == IGNORE:


### PR DESCRIPTION
### What was wrong?

PR #3256 aimed to catch this error as well as allow decoding of data shorter than expected. The decoding will be more complicated, but at least we can handle an additional error type better.

### How was it fixed?
Added `InsufficientDataBytes` to types of errors handled by `_parse_logs`.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/5199899/7afb0ad6-c2e4-4bfc-af76-60849167bc41)
