### PR TITLE
Disallow infinity on cache key generation

### DIFF
--- a/tests/core/caching-utils/test_generate_cache_key.py
+++ b/tests/core/caching-utils/test_generate_cache_key.py
@@ -28,7 +28,12 @@ def extend_fn(children):
 
 
 all_st = st.recursive(
-    st.none() | st.integers() | st.booleans() | st.floats() | st.text() | st.binary(),
+    st.none()
+    | st.integers()
+    | st.booleans()
+    | st.floats(allow_infinity=False)
+    | st.text()
+    | st.binary(),
     extend_fn,
 )
 


### PR DESCRIPTION
### What was wrong?
The hypothesis float strategy was periodically generating a `-inf` value, which was causing an intermittent failure on CI.


### How was it fixed?
Disallowed

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
