### PR TITLE
Allow provider init with cache configuration & add tests

### DIFF
--- a/docs/gas_price.rst
+++ b/docs/gas_price.rst
@@ -110,10 +110,10 @@ Available gas price strategies
 
     .. code-block:: python
 
-        from web3 import Web3, middleware
+        from web3 import Web3
         from web3.gas_strategies.time_based import medium_gas_price_strategy
 
-        w3 = Web3()
+        w3 = Web3(...)
         w3.eth.set_gas_price_strategy(medium_gas_price_strategy)
 
         w3.provider.cache_allowed_requests = True

--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -184,7 +184,7 @@ The following properties are available on the ``web3.eth`` namespace.
 
        .. code-block:: python
 
-          >>> w3.provider.cache_allowed_requests
+          >>> w3.provider.cache_allowed_requests = True
 
 
 .. _web3-eth-methods:

--- a/newsfragments/3395.feature.rst
+++ b/newsfragments/3395.feature.rst
@@ -1,0 +1,1 @@
+Allow request cache configuration on provider ``__init__()`` for all provider classes.

--- a/web3/_utils/caching.py
+++ b/web3/_utils/caching.py
@@ -8,9 +8,11 @@ from typing import (
     Coroutine,
     Dict,
     List,
+    Set,
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from eth_utils import (
@@ -92,7 +94,24 @@ def is_cacheable_request(
     return False
 
 
-# -- request caching decorators -- #
+# -- request caching -- #
+
+
+CACHEABLE_REQUESTS = cast(
+    Set["RPCEndpoint"],
+    (
+        "eth_chainId",
+        "eth_getBlockByHash",
+        "eth_getBlockTransactionCountByHash",
+        "eth_getRawTransactionByHash",
+        "eth_getTransactionByBlockHashAndIndex",
+        "eth_getTransactionByHash",
+        "eth_getUncleByBlockHashAndIndex",
+        "eth_getUncleCountByBlockHash",
+        "net_version",
+        "web3_clientVersion",
+    ),
+)
 
 
 def _should_cache_response(response: "RPCResponse") -> bool:

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -141,7 +141,6 @@ class IPCProvider(JSONBaseProvider):
         self,
         ipc_path: Union[str, Path] = None,
         timeout: int = 30,
-        *args: Any,
         **kwargs: Any,
     ) -> None:
         if ipc_path is None:
@@ -154,7 +153,7 @@ class IPCProvider(JSONBaseProvider):
         self.timeout = timeout
         self._lock = threading.Lock()
         self._socket = PersistantSocket(self.ipc_path)
-        super().__init__()
+        super().__init__(**kwargs)
 
     def __str__(self) -> str:
         return f"<{self.__class__.__name__} {self.ipc_path}>"

--- a/web3/providers/legacy_websocket.py
+++ b/web3/providers/legacy_websocket.py
@@ -31,6 +31,9 @@ from websockets.legacy.client import (
 from web3._utils.batching import (
     sort_batch_response_by_response_ids,
 )
+from web3._utils.caching import (
+    handle_request_caching,
+)
 from web3.exceptions import (
     Web3ValidationError,
 )
@@ -97,6 +100,7 @@ class LegacyWebSocketProvider(JSONBaseProvider):
         endpoint_uri: Optional[Union[URI, str]] = None,
         websocket_kwargs: Optional[Any] = None,
         websocket_timeout: int = DEFAULT_WEBSOCKET_TIMEOUT,
+        **kwargs: Any,
     ) -> None:
         self.endpoint_uri = URI(endpoint_uri)
         self.websocket_timeout = websocket_timeout
@@ -116,7 +120,7 @@ class LegacyWebSocketProvider(JSONBaseProvider):
                     f"in websocket_kwargs, found: {found_restricted_keys}"
                 )
         self.conn = PersistentWebSocket(self.endpoint_uri, websocket_kwargs)
-        super().__init__()
+        super().__init__(**kwargs)
 
     def __str__(self) -> str:
         return f"WS connection {self.endpoint_uri}"
@@ -130,6 +134,7 @@ class LegacyWebSocketProvider(JSONBaseProvider):
                 await asyncio.wait_for(conn.recv(), timeout=self.websocket_timeout)
             )
 
+    @handle_request_caching
     def make_request(self, method: RPCEndpoint, params: Any) -> RPCResponse:
         self.logger.debug(
             f"Making request WebSocket. URI: {self.endpoint_uri}, " f"Method: {method}"

--- a/web3/providers/persistent/persistent.py
+++ b/web3/providers/persistent/persistent.py
@@ -4,6 +4,7 @@ from abc import (
 import asyncio
 import logging
 from typing import (
+    Any,
     List,
     Optional,
     Union,
@@ -52,8 +53,9 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
         subscription_response_queue_size: int = 500,
         silence_listener_task_exceptions: bool = False,
         max_connection_retries: int = 5,
+        **kwargs: Any,
     ) -> None:
-        super().__init__()
+        super().__init__(**kwargs)
         self._request_processor = RequestProcessor(
             self,
             subscription_response_queue_size=subscription_response_queue_size,

--- a/web3/providers/rpc/async_rpc.py
+++ b/web3/providers/rpc/async_rpc.py
@@ -66,6 +66,7 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
         exception_retry_configuration: Union[
             ExceptionRetryConfiguration, Empty
         ] = empty,
+        **kwargs: Any,
     ) -> None:
         if endpoint_uri is None:
             self.endpoint_uri = get_default_http_endpoint()
@@ -75,7 +76,7 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
         self._request_kwargs = request_kwargs or {}
         self._exception_retry_configuration = exception_retry_configuration
 
-        super().__init__()
+        super().__init__(**kwargs)
 
     async def cache_async_session(self, session: ClientSession) -> ClientSession:
         return await _async_cache_and_return_session(self.endpoint_uri, session)

--- a/web3/providers/rpc/rpc.py
+++ b/web3/providers/rpc/rpc.py
@@ -70,6 +70,7 @@ class HTTPProvider(JSONBaseProvider):
         exception_retry_configuration: Union[
             ExceptionRetryConfiguration, Empty
         ] = empty,
+        **kwargs: Any,
     ) -> None:
         if endpoint_uri is None:
             self.endpoint_uri = get_default_http_endpoint()
@@ -82,7 +83,7 @@ class HTTPProvider(JSONBaseProvider):
         if session:
             cache_and_return_session(self.endpoint_uri, session)
 
-        super().__init__()
+        super().__init__(**kwargs)
 
     def __str__(self) -> str:
         return f"RPC connection {self.endpoint_uri}"


### PR DESCRIPTION
### What was wrong?

Closes #3394 

### How was it fixed?

- Allow provider init with request cache configuration
- Add test to test that all providers init without caching by default and can be instantiated with caching configs

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cdn.discordapp.com/attachments/847252147946913792/1240011716884955146/20240514_124326.jpg?ex=66450267&is=6643b0e7&hm=adc4e84cdc7908cdf726d2c18a6edd5175da784f35c0bc120b6ca7c3aa0528f4&)
