### PR TITLE
Increase eth-tester range

### DIFF
--- a/newsfragments/3400.internal.rst
+++ b/newsfragments/3400.internal.rst
@@ -1,0 +1,1 @@
+Increase allowable range of eth-tester: 0.11.x and 0.12.x

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ extras_require = {
         "towncrier>=21,<22",
     ],
     "test": [
-        "eth-tester[py-evm]>=0.11.0b1,<0.12.0b1",
+        "eth-tester[py-evm]>=0.11.0b1,<0.13.0b1",
         "py-geth>=4.1.0",
         "pytest-asyncio>=0.18.1,<0.23",
         "pytest-mock>=1.10",


### PR DESCRIPTION
### What was wrong?
eth-tester 0.12.x didn't break anything in web3, so we can increase the range. 


### How was it fixed?
setup.py now allows `eth-tester>=0.11.x,<0.13.x`

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://storage.newspark.ca/storage/34488185/15)
