### PR TITLE
Use `__all__` in `__init__.py`

### DIFF
--- a/ens/__init__.py
+++ b/ens/__init__.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-
 from .async_ens import (
     AsyncENS,
 )
@@ -18,3 +16,16 @@ from .exceptions import (
     UnderfundedBid,
     UnownedName,
 )
+
+__all__ = [
+    "AsyncENS",
+    "BaseENS",
+    "ENS",
+    "AddressMismatch",
+    "BidTooLow",
+    "InvalidLabel",
+    "InvalidName",
+    "UnauthorizedError",
+    "UnderfundedBid",
+    "UnownedName",
+]

--- a/web3/beacon/__init__.py
+++ b/web3/beacon/__init__.py
@@ -1,2 +1,7 @@
 from .async_beacon import AsyncBeacon
 from .beacon import Beacon
+
+__all__ = [
+    "AsyncBeacon",
+    "Beacon",
+]

--- a/web3/contract/__init__.py
+++ b/web3/contract/__init__.py
@@ -7,3 +7,10 @@ from web3.contract.contract import (
     ContractCaller,
     ContractConstructor,
 )
+
+__all__ = [
+    "AsyncContract",
+    "AsyncContractCaller",
+    "Contract",
+    "ContractConstructor",
+]

--- a/web3/eth/__init__.py
+++ b/web3/eth/__init__.py
@@ -8,3 +8,10 @@ from .eth import (
     Contract,
     Eth,
 )
+
+__all__ = [
+    "AsyncEth",
+    "BaseEth",
+    "Contract",
+    "Eth",
+]

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -92,3 +92,25 @@ async def async_combine_middleware(
         initialized = mw(async_w3)
         accumulator_fn = await initialized.async_wrap_make_request(accumulator_fn)
     return accumulator_fn
+
+
+__all__ = [
+    "AttributeDictMiddleware",
+    "Middleware",
+    "Web3Middleware",
+    "BufferedGasEstimateMiddleware",
+    "LocalFilterMiddleware",
+    "FormattingMiddlewareBuilder",
+    "GasPriceStrategyMiddleware",
+    "ENSNameToAddressMiddleware",
+    "ExtraDataToPOAMiddleware",
+    "PythonicMiddleware",
+    "SignAndSendRawMiddlewareBuilder",
+    "StalecheckMiddlewareBuilder",
+    "ValidationMiddleware",
+    "AsyncWeb3",
+    "Web3",
+    "RPCResponse",
+    "combine_middleware",
+    "async_combine_middleware",
+]

--- a/web3/providers/__init__.py
+++ b/web3/providers/__init__.py
@@ -26,3 +26,18 @@ from .persistent import (
 from .auto import (
     AutoProvider,
 )
+
+__all__ = [
+    "AsyncBaseProvider",
+    "AsyncHTTPProvider",
+    "BaseProvider",
+    "JSONBaseProvider",
+    "IPCProvider",
+    "HTTPProvider",
+    "LegacyWebSocketProvider",
+    "AsyncIPCProvider",
+    "PersistentConnection",
+    "PersistentConnectionProvider",
+    "WebSocketProvider",
+    "AutoProvider",
+]

--- a/web3/providers/eth_tester/__init__.py
+++ b/web3/providers/eth_tester/__init__.py
@@ -2,3 +2,8 @@ from .main import (
     AsyncEthereumTesterProvider,
     EthereumTesterProvider,
 )
+
+__all__ = [
+    "AsyncEthereumTesterProvider",
+    "EthereumTesterProvider",
+]

--- a/web3/providers/persistent/__init__.py
+++ b/web3/providers/persistent/__init__.py
@@ -13,3 +13,11 @@ from .async_ipc import (
 from .websocket import (
     WebSocketProvider,
 )
+
+__all__ = [
+    "PersistentConnectionProvider",
+    "PersistentConnection",
+    "RequestProcessor",
+    "AsyncIPCProvider",
+    "WebSocketProvider",
+]

--- a/web3/providers/rpc/__init__.py
+++ b/web3/providers/rpc/__init__.py
@@ -4,3 +4,8 @@ from .async_rpc import (
 from .rpc import (
     HTTPProvider,
 )
+
+__all__ = [
+    "AsyncHTTPProvider",
+    "HTTPProvider",
+]

--- a/web3/utils/__init__.py
+++ b/web3/utils/__init__.py
@@ -3,17 +3,26 @@ NOTE: This is a public utility module. Any changes to these utility methods woul
 classify as breaking changes.
 """
 
-from .abi import (  # NOQA
+from .abi import (
     get_abi_input_names,
     get_abi_output_names,
 )
-from .address import get_create_address  # NOQA
-from .async_exception_handling import (  # NOQA
+from .address import get_create_address
+from .async_exception_handling import (
     async_handle_offchain_lookup,
 )
-from .caching import (  # NOQA
+from .caching import (
     SimpleCache,
 )
-from .exception_handling import (  # NOQA
+from .exception_handling import (
     handle_offchain_lookup,
 )
+
+__all__ = [
+    "get_abi_input_names",
+    "get_abi_output_names",
+    "get_create_address",
+    "async_handle_offchain_lookup",
+    "SimpleCache",
+    "handle_offchain_lookup",
+]


### PR DESCRIPTION
### What was wrong?
Mypy raising error with `--no-implicit-reexport` flag

Related to Issue #3396
Closes #3396

### How was it fixed?
Defining `__all__` in `__init__.py`
Remove `noqa`

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/web3.py/assets/72649244/0a91abb2-ae7d-4faf-8668-c7211beb3a2d)
