### PR TITLE
docs: add subscribe to logs page

### DIFF
--- a/newsfragments/3403.docs.rst
+++ b/newsfragments/3403.docs.rst
@@ -1,0 +1,1 @@
+Add an ``eth_subscribe`` example to the events guide


### PR DESCRIPTION
### What was wrong?

event/log guide lacking mention of subscriptions via persistent connection providers. v1 here; could do with a richer explanation of how to build and scope topics, but will leave for a follow-on PR.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSRYSxzIVP3fxtWC2WEAV_ECJNefPvUt5MRkOgOG3U4jkxGlibEER9GxIF6RyNyVq27suk&usqp=CAU)
