### PR TITLE
Fix eth-account docs and core tests

### DIFF
--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -218,8 +218,7 @@ is provided by :meth:`w3.eth.sign() <web3.eth.Eth.sign>`.
     >>> message = encode_defunct(text=msg)
     >>> signed_message = w3.eth.account.sign_message(message, private_key=private_key)
     >>> signed_message
-    SignedMessage(messageHash=HexBytes('0x1476abb745d423bf09273f1afd887d951181d25adc66c4834a70491911b7f750'),
-    message_hash=HexBytes('0x1476abb745d423bf09273f1afd887d951181d25adc66c4834a70491911b7f750'),
+    SignedMessage(message_hash=HexBytes('0x1476abb745d423bf09273f1afd887d951181d25adc66c4834a70491911b7f750'),
      r=104389933075820307925104709181714897380569894203213074526835978196648170704563,
      s=28205917190874851400050446352651915501321657673772411533993420917949420456142,
      v=28,

--- a/newsfragments/3404.internal.rst
+++ b/newsfragments/3404.internal.rst
@@ -1,0 +1,1 @@
+Remove uses of signHash in tests, require eth-account >=0.13.0 in doctests

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,8 @@ extras_require = {
         "sphinx-autobuild>=2021.3.14",
         "sphinx_rtd_theme>=1.0.0",
         "towncrier>=21,<22",
+        # web3 will work but emit warnings with eth-account>=0.12.2,
+        # but doctests fail between 0.12.2 and 0.13.0
         "eth-account>=0.13.0",
     ],
     "test": [

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ extras_require = {
         "sphinx-autobuild>=2021.3.14",
         "sphinx_rtd_theme>=1.0.0",
         "towncrier>=21,<22",
+        "eth-account>=0.13.0",
     ],
     "test": [
         "eth-tester[py-evm]>=0.11.0b1,<0.13.0b1",

--- a/tests/core/eth-module/test_accounts.py
+++ b/tests/core/eth-module/test_accounts.py
@@ -132,7 +132,7 @@ def test_eth_account_from_key_seed_restrictions(acct):
 
 def test_eth_account_from_key_properties(acct, PRIVATE_BYTES):
     account = acct.from_key(PRIVATE_BYTES)
-    assert callable(account.signHash)
+    assert callable(account.unsafe_sign_hash)
     assert callable(account.sign_transaction)
     assert is_checksum_address(account.address)
     assert account.address == "0xa79F6f349C853F9Ea0B29636779ae3Cb4E3BA729"
@@ -141,7 +141,7 @@ def test_eth_account_from_key_properties(acct, PRIVATE_BYTES):
 
 def test_eth_account_create_properties(acct):
     account = acct.create()
-    assert callable(account.signHash)
+    assert callable(account.unsafe_sign_hash)
     assert callable(account.sign_transaction)
     assert is_checksum_address(account.address)
     assert isinstance(account.key, bytes) and len(account.key) == 32


### PR DESCRIPTION
### What was wrong/how was it fixed?

- the core tests were still using the deprecated `signHash` instead of the new `unsafe_sign_hash`
- the doctests break between eth-account 0.12.2, and eth-account 0.13.0, so require eth-account 0.13.x in docs dependencies. web3py should work fine with both, just emit warnings. 

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cdn.download.ams.birds.cornell.edu/api/v1/asset/69430011/1800)
