### PR TITLE
Support blob_sidecars endpoint

### DIFF
--- a/docs/web3.beacon.rst
+++ b/docs/web3.beacon.rst
@@ -432,6 +432,51 @@ Methods
           ]
         }
 
+.. py:method:: Beacon.get_blob_sidecars(block_id, indices=[])
+
+    .. code-block:: python
+
+        >>> beacon.get_blob_sidecars(1, indices=[1])
+        {
+          "data": [
+            {
+              "index": "1",
+              "blob": ..., # ommitted
+              "kzg_commitment": "0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a",
+              "kzg_proof": "0x7FB0A12D11Ffe8A48c2fF80dCA17adbCC1da5F6aADaAEF2b338717dcDEECf6DaB9FD7C4e4265CfBc097cD31dCB19E836",
+              "signed_block_header": {
+                "message": {
+                  "slot": "1",
+                  "proposer_index": "1",
+                  "parent_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                  "state_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                  "body_root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
+                },
+                "signature": "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"
+              },
+              "kzg_commitment_inclusion_proof": [
+                "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2",
+                "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
+              ]
+            }
+          ]
+        }
+
 .. py:method:: Beacon.get_node_identity()
 
     .. code-block:: python

--- a/newsfragments/3407.feature.rst
+++ b/newsfragments/3407.feature.rst
@@ -1,0 +1,1 @@
+Add support for Beacon ``/eth/v1/beacon/blob_sidecars`` endpoint at :meth:`~web3.beacon.Beacon.get_blob_sidecars`.

--- a/tests/beacon/test_async_beacon.py
+++ b/tests/beacon/test_async_beacon.py
@@ -268,3 +268,12 @@ async def test_async_cl_node_get_version(async_beacon):
 async def test_async_cl_node_get_syncing(async_beacon):
     response = await async_beacon.get_syncing()
     _assert_valid_response(response)
+
+
+# Blob endpoint tests
+
+
+@pytest.mark.asyncio
+def test_cl_node_get_blob_sidecars(async_beacon):
+    response = await async_beacon.get_blob_sidecars()
+    _assert_valid_response(response)

--- a/tests/beacon/test_beacon.py
+++ b/tests/beacon/test_beacon.py
@@ -232,3 +232,11 @@ def test_cl_node_get_version(beacon):
 def test_cl_node_get_syncing(beacon):
     response = beacon.get_syncing()
     _assert_valid_response(response)
+
+
+# Blob endpoint tests
+
+
+def test_cl_node_get_blob_sidecars(beacon):
+    response = beacon.get_blob_sidecars()
+    _assert_valid_response(response)

--- a/web3/beacon/api_endpoints.py
+++ b/web3/beacon/api_endpoints.py
@@ -26,6 +26,9 @@ GET_BLINDED_BLOCKS = "/eth/v1/beacon/blinded_blocks/{0}"
 # rewards
 GET_REWARDS = "/eth/v1/beacon/rewards/blocks/{0}"
 
+# blobs
+GET_BLOB_SIDECARS = "/eth/v1/beacon/blob_sidecars/{0}"
+
 # light client
 GET_LIGHT_CLIENT_BOOTSTRAP_STRUCTURE = "/eth/v1/beacon/light_client/bootstrap/{0}"
 GET_LIGHT_CLIENT_UPDATES = "/eth/v1/beacon/light_client/updates"

--- a/web3/beacon/async_beacon.py
+++ b/web3/beacon/async_beacon.py
@@ -67,7 +67,7 @@ class AsyncBeacon:
         self.request_timeout = request_timeout
 
     async def _async_make_get_request(
-        self, endpoint_uri: str, params: Dict[str, str] = {}
+        self, endpoint_uri: str, params: Dict[str, str] = None
     ) -> Dict[str, Any]:
         uri = URI(self.base_url + endpoint_uri)
         return await async_json_make_get_request(
@@ -226,7 +226,7 @@ class AsyncBeacon:
     # [ BLOB endpoints ]
 
     async def get_blob_sidecars(
-        self, block_id: str, indices: List[int] = []
+        self, block_id: str, indices: List[int] = None
     ) -> Dict[str, Any]:
         return await self._async_make_get_request(
             GET_BLOB_SIDECARS.format(block_id),

--- a/web3/beacon/async_beacon.py
+++ b/web3/beacon/async_beacon.py
@@ -1,6 +1,7 @@
 from typing import (
     Any,
     Dict,
+    List,
 )
 
 from eth_typing import (
@@ -18,6 +19,7 @@ from web3.beacon.api_endpoints import (
     GET_BEACON_HEADS,
     GET_BEACON_STATE,
     GET_BLINDED_BLOCKS,
+    GET_BLOB_SIDECARS,
     GET_BLOCK,
     GET_BLOCK_ATTESTATIONS,
     GET_BLOCK_HEADER,
@@ -64,9 +66,13 @@ class AsyncBeacon:
         self.base_url = base_url
         self.request_timeout = request_timeout
 
-    async def _async_make_get_request(self, endpoint_uri: str) -> Dict[str, Any]:
+    async def _async_make_get_request(
+        self, endpoint_uri: str, params: Dict[str, str] = {}
+    ) -> Dict[str, Any]:
         uri = URI(self.base_url + endpoint_uri)
-        return await async_json_make_get_request(uri, timeout=self.request_timeout)
+        return await async_json_make_get_request(
+            uri, timeout=self.request_timeout, params=params
+        )
 
     # [ BEACON endpoints ]
 
@@ -216,3 +222,13 @@ class AsyncBeacon:
 
     async def get_syncing(self) -> Dict[str, Any]:
         return await self._async_make_get_request(GET_SYNCING)
+
+    # [ BLOB endpoints ]
+
+    async def get_blob_sidecars(
+        self, block_id: str, indices: List[int] = []
+    ) -> Dict[str, Any]:
+        return await self._async_make_get_request(
+            GET_BLOB_SIDECARS.format(block_id),
+            {"indices": ",".join(map(str, indices))} if indices else {},
+        )

--- a/web3/beacon/beacon.py
+++ b/web3/beacon/beacon.py
@@ -1,6 +1,7 @@
 from typing import (
     Any,
     Dict,
+    List,
 )
 
 from eth_typing import (
@@ -18,6 +19,7 @@ from web3.beacon.api_endpoints import (
     GET_BEACON_HEADS,
     GET_BEACON_STATE,
     GET_BLINDED_BLOCKS,
+    GET_BLOB_SIDECARS,
     GET_BLOCK,
     GET_BLOCK_ATTESTATIONS,
     GET_BLOCK_HEADER,
@@ -62,9 +64,11 @@ class Beacon:
         self.base_url = base_url
         self.request_timeout = request_timeout
 
-    def _make_get_request(self, endpoint_url: str) -> Dict[str, Any]:
+    def _make_get_request(
+        self, endpoint_url: str, params: Dict[str, str] = {}
+    ) -> Dict[str, Any]:
         uri = URI(self.base_url + endpoint_url)
-        return json_make_get_request(uri, timeout=self.request_timeout)
+        return json_make_get_request(uri, timeout=self.request_timeout, params=params)
 
     # [ BEACON endpoints ]
 
@@ -204,3 +208,13 @@ class Beacon:
 
     def get_syncing(self) -> Dict[str, Any]:
         return self._make_get_request(GET_SYNCING)
+
+    # [ BLOB endpoints ]
+
+    def get_blob_sidecars(
+        self, block_id: str, indices: List[int] = []
+    ) -> Dict[str, Any]:
+        return self._make_get_request(
+            GET_BLOB_SIDECARS.format(block_id),
+            {"indices": ",".join(map(str, indices))} if indices else {},
+        )

--- a/web3/beacon/beacon.py
+++ b/web3/beacon/beacon.py
@@ -65,7 +65,7 @@ class Beacon:
         self.request_timeout = request_timeout
 
     def _make_get_request(
-        self, endpoint_url: str, params: Dict[str, str] = {}
+        self, endpoint_url: str, params: Dict[str, str] = None
     ) -> Dict[str, Any]:
         uri = URI(self.base_url + endpoint_url)
         return json_make_get_request(uri, timeout=self.request_timeout, params=params)
@@ -212,7 +212,7 @@ class Beacon:
     # [ BLOB endpoints ]
 
     def get_blob_sidecars(
-        self, block_id: str, indices: List[int] = []
+        self, block_id: str, indices: List[int] = None
     ) -> Dict[str, Any]:
         return self._make_get_request(
             GET_BLOB_SIDECARS.format(block_id),


### PR DESCRIPTION
### What was wrong?

Adds support for [`/eth/v1/beacon/blob_sidecars/`](https://ethereum.github.io/beacon-APIs/#/Beacon/getBlobSidecars) endpoint.

Beacon API updated in https://github.com/ethereum/beacon-APIs/issues/282.

### How was it fixed?

Adds an endpoint and passes query params to `requests` to support optional indices parameter.

#### Cute Animal Picture

<img src="https://github.com/user-attachments/assets/7608fdec-605e-4d48-b5b8-5fbbf6a24780" alt="long-tailed tit" width="400"/>
