### PR TITLE
Update provider explicit exports

### DIFF
--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -218,8 +218,7 @@ is provided by :meth:`w3.eth.sign() <web3.eth.Eth.sign>`.
     >>> message = encode_defunct(text=msg)
     >>> signed_message = w3.eth.account.sign_message(message, private_key=private_key)
     >>> signed_message
-    SignedMessage(messageHash=HexBytes('0x1476abb745d423bf09273f1afd887d951181d25adc66c4834a70491911b7f750'),
-    message_hash=HexBytes('0x1476abb745d423bf09273f1afd887d951181d25adc66c4834a70491911b7f750'),
+    SignedMessage(message_hash=HexBytes('0x1476abb745d423bf09273f1afd887d951181d25adc66c4834a70491911b7f750'),
      r=104389933075820307925104709181714897380569894203213074526835978196648170704563,
      s=28205917190874851400050446352651915501321657673772411533993420917949420456142,
      v=28,

--- a/ens/__init__.py
+++ b/ens/__init__.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-
 from .async_ens import (
     AsyncENS,
 )
@@ -18,3 +16,16 @@ from .exceptions import (
     UnderfundedBid,
     UnownedName,
 )
+
+__all__ = [
+    "AsyncENS",
+    "BaseENS",
+    "ENS",
+    "AddressMismatch",
+    "BidTooLow",
+    "InvalidLabel",
+    "InvalidName",
+    "UnauthorizedError",
+    "UnderfundedBid",
+    "UnownedName",
+]

--- a/newsfragments/3403.docs.rst
+++ b/newsfragments/3403.docs.rst
@@ -1,0 +1,1 @@
+Add an ``eth_subscribe`` example to the events guide

--- a/newsfragments/3404.internal.rst
+++ b/newsfragments/3404.internal.rst
@@ -1,0 +1,1 @@
+Remove uses of signHash in tests, require eth-account >=0.13.0 in doctests

--- a/newsfragments/3409.feature.rst
+++ b/newsfragments/3409.feature.rst
@@ -1,0 +1,1 @@
+Provide explicit ``__all__`` exports for providers in `web3/providers/__init__.py`; update `web3/__init__.py` to include all provider classes including base classes.

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ extras_require = {
         "sphinx-autobuild>=2021.3.14",
         "sphinx_rtd_theme>=1.0.0",
         "towncrier>=21,<22",
+        # web3 will work but emit warnings with eth-account>=0.12.2,
+        # but doctests fail between 0.12.2 and 0.13.0
+        "eth-account>=0.13.0",
     ],
     "test": [
         "eth-tester[py-evm]>=0.11.0b1,<0.13.0b1",

--- a/tests/core/eth-module/test_accounts.py
+++ b/tests/core/eth-module/test_accounts.py
@@ -132,7 +132,7 @@ def test_eth_account_from_key_seed_restrictions(acct):
 
 def test_eth_account_from_key_properties(acct, PRIVATE_BYTES):
     account = acct.from_key(PRIVATE_BYTES)
-    assert callable(account.signHash)
+    assert callable(account.unsafe_sign_hash)
     assert callable(account.sign_transaction)
     assert is_checksum_address(account.address)
     assert account.address == "0xa79F6f349C853F9Ea0B29636779ae3Cb4E3BA729"
@@ -141,7 +141,7 @@ def test_eth_account_from_key_properties(acct, PRIVATE_BYTES):
 
 def test_eth_account_create_properties(acct):
     account = acct.create()
-    assert callable(account.signHash)
+    assert callable(account.unsafe_sign_hash)
     assert callable(account.sign_transaction)
     assert is_checksum_address(account.address)
     assert isinstance(account.key, bytes) and len(account.key) == 32

--- a/web3/__init__.py
+++ b/web3/__init__.py
@@ -1,5 +1,4 @@
 from eth_account import Account  # noqa: E402
-import sys
 
 from importlib.metadata import version
 
@@ -10,12 +9,20 @@ from web3.main import (
     AsyncWeb3,
     Web3,
 )
+from web3.providers import (
+    AsyncBaseProvider,
+    AutoProvider,
+    BaseProvider,
+    JSONBaseProvider,
+    PersistentConnection,
+)
 from web3.providers.persistent import (  # noqa: E402
     AsyncIPCProvider,
     PersistentConnectionProvider,
     WebSocketProvider,
 )
 from web3.providers.eth_tester import (  # noqa: E402
+    AsyncEthereumTesterProvider,
     EthereumTesterProvider,
 )
 from web3.providers.ipc import (  # noqa: E402
@@ -32,14 +39,23 @@ from web3.providers.legacy_websocket import (  # noqa: E402
 
 __all__ = [
     "__version__",
+    "Account",
+    # web3:
     "AsyncWeb3",
     "Web3",
-    "HTTPProvider",
-    "IPCProvider",
-    "LegacyWebSocketProvider",
-    "WebSocketProvider",
-    "EthereumTesterProvider",
-    "Account",
+    # providers:
+    "AsyncBaseProvider",
+    "AsyncEthereumTesterProvider",
     "AsyncHTTPProvider",
     "AsyncIPCProvider",
+    "AutoProvider",
+    "BaseProvider",
+    "EthereumTesterProvider",
+    "HTTPProvider",
+    "IPCProvider",
+    "JSONBaseProvider",
+    "LegacyWebSocketProvider",
+    "PersistentConnection",
+    "PersistentConnectionProvider",
+    "WebSocketProvider",
 ]

--- a/web3/beacon/__init__.py
+++ b/web3/beacon/__init__.py
@@ -1,2 +1,7 @@
 from .async_beacon import AsyncBeacon
 from .beacon import Beacon
+
+__all__ = [
+    "AsyncBeacon",
+    "Beacon",
+]

--- a/web3/contract/__init__.py
+++ b/web3/contract/__init__.py
@@ -7,3 +7,10 @@ from web3.contract.contract import (
     ContractCaller,
     ContractConstructor,
 )
+
+__all__ = [
+    "AsyncContract",
+    "AsyncContractCaller",
+    "Contract",
+    "ContractConstructor",
+]

--- a/web3/eth/__init__.py
+++ b/web3/eth/__init__.py
@@ -8,3 +8,10 @@ from .eth import (
     Contract,
     Eth,
 )
+
+__all__ = [
+    "AsyncEth",
+    "BaseEth",
+    "Contract",
+    "Eth",
+]

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -108,9 +108,4 @@ __all__ = [
     "SignAndSendRawMiddlewareBuilder",
     "StalecheckMiddlewareBuilder",
     "ValidationMiddleware",
-    "AsyncWeb3",
-    "Web3",
-    "RPCResponse",
-    "combine_middleware",
-    "async_combine_middleware",
 ]

--- a/web3/middleware/__init__.py
+++ b/web3/middleware/__init__.py
@@ -92,3 +92,25 @@ async def async_combine_middleware(
         initialized = mw(async_w3)
         accumulator_fn = await initialized.async_wrap_make_request(accumulator_fn)
     return accumulator_fn
+
+
+__all__ = [
+    "AttributeDictMiddleware",
+    "Middleware",
+    "Web3Middleware",
+    "BufferedGasEstimateMiddleware",
+    "LocalFilterMiddleware",
+    "FormattingMiddlewareBuilder",
+    "GasPriceStrategyMiddleware",
+    "ENSNameToAddressMiddleware",
+    "ExtraDataToPOAMiddleware",
+    "PythonicMiddleware",
+    "SignAndSendRawMiddlewareBuilder",
+    "StalecheckMiddlewareBuilder",
+    "ValidationMiddleware",
+    "AsyncWeb3",
+    "Web3",
+    "RPCResponse",
+    "combine_middleware",
+    "async_combine_middleware",
+]

--- a/web3/providers/__init__.py
+++ b/web3/providers/__init__.py
@@ -8,6 +8,10 @@ from .base import (
     BaseProvider,
     JSONBaseProvider,
 )
+from .eth_tester import (
+    AsyncEthereumTesterProvider,
+    EthereumTesterProvider,
+)
 from .ipc import (
     IPCProvider,
 )
@@ -29,15 +33,17 @@ from .auto import (
 
 __all__ = [
     "AsyncBaseProvider",
+    "AsyncEthereumTesterProvider",
     "AsyncHTTPProvider",
-    "BaseProvider",
-    "JSONBaseProvider",
-    "IPCProvider",
-    "HTTPProvider",
-    "LegacyWebSocketProvider",
     "AsyncIPCProvider",
+    "AutoProvider",
+    "BaseProvider",
+    "EthereumTesterProvider",
+    "HTTPProvider",
+    "IPCProvider",
+    "JSONBaseProvider",
+    "LegacyWebSocketProvider",
     "PersistentConnection",
     "PersistentConnectionProvider",
     "WebSocketProvider",
-    "AutoProvider",
 ]

--- a/web3/providers/__init__.py
+++ b/web3/providers/__init__.py
@@ -26,3 +26,18 @@ from .persistent import (
 from .auto import (
     AutoProvider,
 )
+
+__all__ = [
+    "AsyncBaseProvider",
+    "AsyncHTTPProvider",
+    "BaseProvider",
+    "JSONBaseProvider",
+    "IPCProvider",
+    "HTTPProvider",
+    "LegacyWebSocketProvider",
+    "AsyncIPCProvider",
+    "PersistentConnection",
+    "PersistentConnectionProvider",
+    "WebSocketProvider",
+    "AutoProvider",
+]

--- a/web3/providers/eth_tester/__init__.py
+++ b/web3/providers/eth_tester/__init__.py
@@ -2,3 +2,8 @@ from .main import (
     AsyncEthereumTesterProvider,
     EthereumTesterProvider,
 )
+
+__all__ = [
+    "AsyncEthereumTesterProvider",
+    "EthereumTesterProvider",
+]

--- a/web3/providers/persistent/__init__.py
+++ b/web3/providers/persistent/__init__.py
@@ -13,3 +13,11 @@ from .async_ipc import (
 from .websocket import (
     WebSocketProvider,
 )
+
+__all__ = [
+    "PersistentConnectionProvider",
+    "PersistentConnection",
+    "RequestProcessor",
+    "AsyncIPCProvider",
+    "WebSocketProvider",
+]

--- a/web3/providers/persistent/__init__.py
+++ b/web3/providers/persistent/__init__.py
@@ -17,7 +17,6 @@ from .websocket import (
 __all__ = [
     "PersistentConnectionProvider",
     "PersistentConnection",
-    "RequestProcessor",
     "AsyncIPCProvider",
     "WebSocketProvider",
 ]

--- a/web3/providers/rpc/__init__.py
+++ b/web3/providers/rpc/__init__.py
@@ -4,3 +4,8 @@ from .async_rpc import (
 from .rpc import (
     HTTPProvider,
 )
+
+__all__ = [
+    "AsyncHTTPProvider",
+    "HTTPProvider",
+]

--- a/web3/utils/__init__.py
+++ b/web3/utils/__init__.py
@@ -19,10 +19,10 @@ from .exception_handling import (
 )
 
 __all__ = [
+    "SimpleCache",
+    "async_handle_offchain_lookup",
     "get_abi_input_names",
     "get_abi_output_names",
     "get_create_address",
-    "async_handle_offchain_lookup",
-    "SimpleCache",
     "handle_offchain_lookup",
 ]

--- a/web3/utils/__init__.py
+++ b/web3/utils/__init__.py
@@ -3,17 +3,26 @@ NOTE: This is a public utility module. Any changes to these utility methods woul
 classify as breaking changes.
 """
 
-from .abi import (  # NOQA
+from .abi import (
     get_abi_input_names,
     get_abi_output_names,
 )
-from .address import get_create_address  # NOQA
-from .async_exception_handling import (  # NOQA
+from .address import get_create_address
+from .async_exception_handling import (
     async_handle_offchain_lookup,
 )
-from .caching import (  # NOQA
+from .caching import (
     SimpleCache,
 )
-from .exception_handling import (  # NOQA
+from .exception_handling import (
     handle_offchain_lookup,
 )
+
+__all__ = [
+    "get_abi_input_names",
+    "get_abi_output_names",
+    "get_create_address",
+    "async_handle_offchain_lookup",
+    "SimpleCache",
+    "handle_offchain_lookup",
+]


### PR DESCRIPTION
### What was wrong?

closes #3396 together with #3410

### How was it fixed?

- Adds `AsyncEthereumTesterProvider` to _web3/\_\_init\_\_.py_.
- Adds `EthereumTesterProvider` and `AsyncEthereumTesterProvider` to _web3/providers/\_\_init\_\_.py_.
- Update `__all__` in _web3/\_\_init\_\_.py_ to include all provider classes, including base classes.
- Add `__all__` for _web3/providers/\_\_init\_\_.py_ including all explicit exports.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20240529_124042](https://github.com/ethereum/web3.py/assets/3532824/d63bab7e-1ce1-46ca-b2b1-a894ae9093fc)
