### PR TITLE
[v6] Update provider explicit exports for `__all__`

### DIFF
--- a/newsfragments/3410.feature.rst
+++ b/newsfragments/3410.feature.rst
@@ -1,0 +1,1 @@
+Provide explicit ``__all__`` exports for providers in `web3/providers/__init__.py`; update `web3/__init__.py` to include all provider classes including base classes.

--- a/web3/__init__.py
+++ b/web3/__init__.py
@@ -1,6 +1,15 @@
 from eth_account import Account  # noqa: E402
 import sys
 
+from web3.providers import (
+    AsyncBaseProvider,
+    AutoProvider,
+    BaseProvider,
+    JSONBaseProvider,
+    PersistentConnectionProvider,
+)
+
+
 if sys.version_info.major == 3 and sys.version_info.minor < 8:
     import pkg_resources
 
@@ -19,6 +28,7 @@ from web3.providers.async_rpc import (  # noqa: E402
     AsyncHTTPProvider,
 )
 from web3.providers.eth_tester import (  # noqa: E402
+    AsyncEthereumTesterProvider,
     EthereumTesterProvider,
 )
 from web3.providers.ipc import (  # noqa: E402
@@ -35,13 +45,21 @@ from web3.providers.websocket import (  # noqa: E402
 
 __all__ = [
     "__version__",
+    "Account",
+    # web3:
     "AsyncWeb3",
     "Web3",
+    # providers:
+    "AsyncBaseProvider",
+    "AsyncEthereumTesterProvider",
+    "AsyncHTTPProvider",
+    "AutoProvider",
+    "BaseProvider",
+    "EthereumTesterProvider",
     "HTTPProvider",
     "IPCProvider",
+    "JSONBaseProvider",
+    "PersistentConnectionProvider",
     "WebsocketProvider",
     "WebsocketProviderV2",
-    "EthereumTesterProvider",
-    "Account",
-    "AsyncHTTPProvider",
 ]

--- a/web3/providers/__init__.py
+++ b/web3/providers/__init__.py
@@ -8,6 +8,10 @@ from .base import (
     BaseProvider,
     JSONBaseProvider,
 )
+from .eth_tester import (
+    AsyncEthereumTesterProvider,
+    EthereumTesterProvider,
+)
 from .ipc import (
     IPCProvider,
 )
@@ -24,3 +28,18 @@ from .persistent import (
 from .auto import (
     AutoProvider,
 )
+
+__all__ = [
+    "AsyncBaseProvider",
+    "AsyncEthereumTesterProvider",
+    "AsyncHTTPProvider",
+    "AutoProvider",
+    "BaseProvider",
+    "EthereumTesterProvider",
+    "HTTPProvider",
+    "IPCProvider",
+    "JSONBaseProvider",
+    "PersistentConnectionProvider",
+    "WebsocketProvider",
+    "WebsocketProviderV2",
+]


### PR DESCRIPTION
### What was wrong?

closes #3396 together with #3409

### How was it fixed?

- Adds `AsyncEthereumTesterProvider` to _web3/\_\_init\_\_.py_.
- Adds `EthereumTesterProvider` and `AsyncEthereumTesterProvider` to _web3/providers/\_\_init\_\_.py_.
- Update `__all__` in _web3/\_\_init\_\_.py_ to include all provider classes, including base classes.
- Add `__all__` for _web3/providers/\_\_init\_\_.py_ including all explicit exports.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20240529_124042](https://github.com/ethereum/web3.py/assets/3532824/d63bab7e-1ce1-46ca-b2b1-a894ae9093fc)
