### PR TITLE
Use owning classe instance when generating session cache keys:

### DIFF
--- a/tests/core/utilities/test_request.py
+++ b/tests/core/utilities/test_request.py
@@ -97,7 +97,7 @@ def test_json_make_get_request(mocker):
     response = request.json_make_get_request(TEST_URI)
     assert response == json.dumps({"data": "content"})
     assert len(request._session_cache) == 1
-    cache_key = generate_cache_key(f"{threading.get_ident()}:{TEST_URI}")
+    cache_key = generate_cache_key(f"None:{threading.get_ident()}:{TEST_URI}")
     session = request._session_cache.get_cache_entry(cache_key)
     session.get.assert_called_once_with(TEST_URI, timeout=30)
 
@@ -117,7 +117,7 @@ def test_make_post_request_no_args(mocker):
     response = request.make_post_request(TEST_URI, data=b"request")
     assert response == "content"
     assert len(request._session_cache) == 1
-    cache_key = generate_cache_key(f"{threading.get_ident()}:{TEST_URI}")
+    cache_key = generate_cache_key(f"None:{threading.get_ident()}:{TEST_URI}")
     session = request._session_cache.get_cache_entry(cache_key)
     session.post.assert_called_once_with(TEST_URI, data=b"request", timeout=30)
 
@@ -261,11 +261,12 @@ async def test_async_json_make_get_request(mocker):
     response = await request.async_json_make_get_request(TEST_URI)
     assert response == json.dumps({"data": "content"})
     assert len(request._async_session_cache) == 1
-    cache_key = generate_cache_key(f"{threading.get_ident()}:{TEST_URI}")
+    cache_key = generate_cache_key(f"None:{threading.get_ident()}:{TEST_URI}")
     session = request._async_session_cache.get_cache_entry(cache_key)
     assert isinstance(session, ClientSession)
     session.get.assert_called_once_with(
         TEST_URI,
+        owning_class=None,
         timeout=ClientTimeout(
             total=30, connect=None, sock_read=None, sock_connect=None
         ),
@@ -282,7 +283,7 @@ async def test_async_make_post_request(mocker):
     response = await request.async_make_post_request(TEST_URI, data=b"request")
     assert response == "content"
     assert len(request._async_session_cache) == 1
-    cache_key = generate_cache_key(f"{threading.get_ident()}:{TEST_URI}")
+    cache_key = generate_cache_key(f"None:{threading.get_ident()}:{TEST_URI}")
     session = request._async_session_cache.get_cache_entry(cache_key)
     assert isinstance(session, ClientSession)
     session.post.assert_called_once_with(
@@ -411,8 +412,8 @@ async def test_async_use_new_session_if_loop_closed_for_cached_session():
 
     await async_cache_and_return_session(TEST_URI, session=session1)
 
-    # assert session1 was cached
-    cache_key = generate_cache_key(f"{threading.get_ident()}:{TEST_URI}")
+    # assert session1 was cached; None bc no owning_class
+    cache_key = generate_cache_key(f"None:{threading.get_ident()}:{TEST_URI}")
 
     assert len(request._async_session_cache) == 1
     cached_session = request._async_session_cache.get_cache_entry(cache_key)
@@ -448,7 +449,7 @@ async def test_async_use_new_session_if_session_closed_for_cached_session():
     await async_cache_and_return_session(TEST_URI, session=session1)
 
     # assert session1 was cached
-    cache_key = generate_cache_key(f"{threading.get_ident()}:{TEST_URI}")
+    cache_key = generate_cache_key(f"None:{threading.get_ident()}:{TEST_URI}")
 
     assert len(request._async_session_cache) == 1
     cached_session = request._async_session_cache.get_cache_entry(cache_key)

--- a/web3/beacon/async_beacon.py
+++ b/web3/beacon/async_beacon.py
@@ -208,7 +208,7 @@ class AsyncBeacon:
 
     async def get_health(self) -> int:
         url = URI(self.base_url + GET_HEALTH)
-        response = await async_get_response_from_get_request(url)
+        response = await async_get_response_from_get_request(url, owning_class=self)
         return response.status
 
     async def get_version(self) -> Dict[str, Any]:

--- a/web3/beacon/beacon.py
+++ b/web3/beacon/beacon.py
@@ -64,7 +64,9 @@ class Beacon:
 
     def _make_get_request(self, endpoint_url: str) -> Dict[str, Any]:
         uri = URI(self.base_url + endpoint_url)
-        return json_make_get_request(uri, timeout=self.request_timeout)
+        return json_make_get_request(
+            uri, owning_class=self, timeout=self.request_timeout
+        )
 
     # [ BEACON endpoints ]
 
@@ -196,7 +198,7 @@ class Beacon:
 
     def get_health(self) -> int:
         url = URI(self.base_url + GET_HEALTH)
-        response = get_response_from_get_request(url)
+        response = get_response_from_get_request(self, url)
         return response.status_code
 
     def get_version(self) -> Dict[str, Any]:

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -300,6 +300,7 @@ class AsyncEth(BaseEth):
                 durin_calldata = await async_handle_offchain_lookup(
                     offchain_lookup.payload,
                     transaction,
+                    owning_class=self.w3,
                 )
                 transaction["data"] = durin_calldata
 

--- a/web3/eth/eth.py
+++ b/web3/eth/eth.py
@@ -285,7 +285,9 @@ class Eth(BaseEth):
                 return self._call(transaction, block_identifier, state_override)
             except OffchainLookup as offchain_lookup:
                 durin_calldata = handle_offchain_lookup(
-                    offchain_lookup.payload, transaction
+                    offchain_lookup.payload,
+                    transaction,
+                    self.w3,
                 )
                 transaction["data"] = durin_calldata
 

--- a/web3/providers/rpc/async_rpc.py
+++ b/web3/providers/rpc/async_rpc.py
@@ -79,7 +79,9 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
         super().__init__(**kwargs)
 
     async def cache_async_session(self, session: ClientSession) -> ClientSession:
-        return await _async_cache_and_return_session(self.endpoint_uri, session)
+        return await _async_cache_and_return_session(
+            self.endpoint_uri, session, owning_class=self
+        )
 
     def __str__(self) -> str:
         return f"RPC connection {self.endpoint_uri}"
@@ -124,7 +126,10 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
             for i in range(self.exception_retry_configuration.retries):
                 try:
                     return await async_make_post_request(
-                        self.endpoint_uri, request_data, **self.get_request_kwargs()
+                        self.endpoint_uri,
+                        request_data,
+                        owning_class=self,
+                        **self.get_request_kwargs(),
                     )
                 except tuple(self.exception_retry_configuration.errors):
                     if i < self.exception_retry_configuration.retries - 1:
@@ -137,7 +142,10 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
             return None
         else:
             return await async_make_post_request(
-                self.endpoint_uri, request_data, **self.get_request_kwargs()
+                self.endpoint_uri,
+                request_data,
+                owning_class=self,
+                **self.get_request_kwargs(),
             )
 
     @async_handle_request_caching
@@ -160,7 +168,10 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
         self.logger.debug(f"Making batch request HTTP - uri: `{self.endpoint_uri}`")
         request_data = self.encode_batch_rpc_request(batch_requests)
         raw_response = await async_make_post_request(
-            self.endpoint_uri, request_data, **self.get_request_kwargs()
+            self.endpoint_uri,
+            request_data,
+            owning_class=self,
+            **self.get_request_kwargs(),
         )
         self.logger.debug("Received batch response HTTP.")
         responses_list = cast(List[RPCResponse], self.decode_rpc_response(raw_response))

--- a/web3/providers/rpc/rpc.py
+++ b/web3/providers/rpc/rpc.py
@@ -81,7 +81,7 @@ class HTTPProvider(JSONBaseProvider):
         self._exception_retry_configuration = exception_retry_configuration
 
         if session:
-            cache_and_return_session(self.endpoint_uri, session)
+            cache_and_return_session(self.endpoint_uri, session, owning_class=self)
 
         super().__init__(**kwargs)
 
@@ -132,7 +132,10 @@ class HTTPProvider(JSONBaseProvider):
             for i in range(self.exception_retry_configuration.retries):
                 try:
                     return make_post_request(
-                        self.endpoint_uri, request_data, **self.get_request_kwargs()
+                        self.endpoint_uri,
+                        request_data,
+                        owning_class=self,
+                        **self.get_request_kwargs(),
                     )
                 except tuple(self.exception_retry_configuration.errors) as e:
                     if i < self.exception_retry_configuration.retries - 1:
@@ -145,7 +148,10 @@ class HTTPProvider(JSONBaseProvider):
             return None
         else:
             return make_post_request(
-                self.endpoint_uri, request_data, **self.get_request_kwargs()
+                self.endpoint_uri,
+                request_data,
+                owning_class=self,
+                **self.get_request_kwargs(),
             )
 
     @handle_request_caching
@@ -168,7 +174,10 @@ class HTTPProvider(JSONBaseProvider):
         self.logger.debug(f"Making batch request HTTP, uri: `{self.endpoint_uri}`")
         request_data = self.encode_batch_rpc_request(batch_requests)
         raw_response = make_post_request(
-            self.endpoint_uri, request_data, **self.get_request_kwargs()
+            self.endpoint_uri,
+            request_data,
+            owning_class=self,
+            **self.get_request_kwargs(),
         )
         self.logger.debug("Received batch response HTTP.")
         responses_list = cast(List[RPCResponse], self.decode_rpc_response(raw_response))

--- a/web3/utils/async_exception_handling.py
+++ b/web3/utils/async_exception_handling.py
@@ -1,4 +1,5 @@
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
 )
@@ -27,10 +28,16 @@ from web3.types import (
     TxParams,
 )
 
+if TYPE_CHECKING:
+    from web3 import (
+        AsyncWeb3,
+    )
+
 
 async def async_handle_offchain_lookup(
     offchain_lookup_payload: Dict[str, Any],
     transaction: TxParams,
+    owning_class: "AsyncWeb3" = None,
 ) -> bytes:
     formatted_sender = to_hex_if_bytes(offchain_lookup_payload["sender"]).lower()
     formatted_data = to_hex_if_bytes(offchain_lookup_payload["callData"]).lower()
@@ -50,11 +57,14 @@ async def async_handle_offchain_lookup(
 
         try:
             if "{data}" in url and "{sender}" in url:
-                response = await async_get_response_from_get_request(formatted_url)
+                response = await async_get_response_from_get_request(
+                    formatted_url, owning_class=owning_class
+                )
             elif "{sender}" in url:
                 response = await async_get_response_from_post_request(
                     formatted_url,
                     data={"data": formatted_data, "sender": formatted_sender},
+                    owning_class=owning_class,
                 )
             else:
                 raise Web3ValidationError("url not formatted properly.")

--- a/web3/utils/exception_handling.py
+++ b/web3/utils/exception_handling.py
@@ -1,4 +1,5 @@
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
 )
@@ -26,10 +27,16 @@ from web3.types import (
     TxParams,
 )
 
+if TYPE_CHECKING:
+    from web3 import (
+        Web3,
+    )
+
 
 def handle_offchain_lookup(
     offchain_lookup_payload: Dict[str, Any],
     transaction: TxParams,
+    owning_class: "Web3" = None,
 ) -> bytes:
     formatted_sender = to_hex_if_bytes(offchain_lookup_payload["sender"]).lower()
     formatted_data = to_hex_if_bytes(offchain_lookup_payload["callData"]).lower()
@@ -49,7 +56,9 @@ def handle_offchain_lookup(
 
         try:
             if "{data}" in url and "{sender}" in url:
-                response = get_response_from_get_request(formatted_url)
+                response = get_response_from_get_request(
+                    formatted_url, owning_class=owning_class
+                )
             elif "{sender}" in url:
                 response = get_response_from_post_request(
                     formatted_url,
@@ -57,6 +66,7 @@ def handle_offchain_lookup(
                         "data": formatted_data,
                         "sender": formatted_sender,
                     },
+                    owning_class=owning_class,
                 )
             else:
                 raise Web3ValidationError("url not formatted properly.")


### PR DESCRIPTION
### What was wrong?

- We need a unique identifier per instance of ``Web3``, ``HTTPProvider``, or ``Beacon`` when generating session cache keys. Pass this value as a kwarg when available in order to create unique cache keys.
- The same as the above is true for the async counterparts.

Closes #3265

### How was it fixed?

- If request methods are called from within a class, use this `owning_class` instance to generate a unique session cache key for the url, along with the threading id.

### Todo:

- [ ] Clean up commit history
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
