### PR TITLE
Strap a `RequestSessionManager` to each instance of http providers

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -144,6 +144,29 @@ options on the provider instance:
 Retry Requests for HTTP Providers
 `````````````````````````````````
 
+.. py:class:: web3.providers.rpc.utils.ExceptionRetryConfiguration
+
+    .. py:attribute:: errors
+
+        A tuple of exceptions that the provider should retry on. The default is
+        ``HTTPProvider``: ``(ConnectionError, requests.HTTPError, requests.Timeout)``
+        and ``AsyncHTTPProvider``: ``(aiohttp.ClientError, asyncio.TimeoutError)``.
+
+    .. py:attribute:: retries
+
+        The number of retries to attempt. The default is 5.
+
+    .. py:attribute:: backoff_factor
+
+        The initial delay multiplier, which doubles with each retry attempt. The default
+        is 0.125.
+
+    .. py:attribute:: method_allowlist
+
+        A list of retryable methods. The default is an in-house list of deemed-safe-to-
+        retry methods.
+
+
 ``HTTPProvider`` and ``AsyncHTTPProvider`` instances retry certain requests by default
 on exceptions. This can be configured via configuration options on the provider
 instance. The retry mechanism employs an exponential backoff strategy, starting from

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -144,6 +144,16 @@ options on the provider instance:
 Retry Requests for HTTP Providers
 `````````````````````````````````
 
+``HTTPProvider`` and ``AsyncHTTPProvider`` instances retry certain requests by default
+on exceptions. This can be configured via the ``exception_retry_configuration``
+property on the provider instance, which takes a
+:class:`~web3.providers.rpc.utils.ExceptionRetryConfiguration` class as its value. The
+retry mechanism employs an exponential backoff strategy, starting from the initial
+value determined by the ``backoff_factor``, and doubling the delay with each attempt,
+up to the ``retries`` value. Below is an example showing the default options for the
+retry configuration and how to override them.
+
+
 .. py:class:: web3.providers.rpc.utils.ExceptionRetryConfiguration
 
     .. py:attribute:: errors
@@ -165,14 +175,6 @@ Retry Requests for HTTP Providers
 
         A list of retryable methods. The default is an in-house list of deemed-safe-to-
         retry methods.
-
-
-``HTTPProvider`` and ``AsyncHTTPProvider`` instances retry certain requests by default
-on exceptions. This can be configured via configuration options on the provider
-instance. The retry mechanism employs an exponential backoff strategy, starting from
-the initial value determined by the ``backoff_factor``, and doubling the delay with
-each attempt, up to the ``retries`` value. Below is an example showing the default
-options for the retry configuration and how to override them.
 
 .. code-block:: python
 

--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -107,7 +107,7 @@ local and remote JSON-RPC servers.
 HTTPProvider
 ~~~~~~~~~~~~
 
-.. py:class:: web3.providers.rpc.HTTPProvider(endpoint_uri[, request_kwargs, session])
+.. py:class:: web3.providers.rpc.HTTPProvider(endpoint_uri, request_kwargs={}, session=None, exception_retry_configuration=ExceptionRetryConfiguration())
 
     This provider handles interactions with an HTTP or HTTPS based JSON-RPC server.
 
@@ -119,6 +119,11 @@ HTTPProvider
       will be passed onto each http/https POST request made to your node.
     * ``session`` allows you to pass a ``requests.Session`` object initialized
       as desired.
+    * ``exception_retry_configuration`` is an instance of the
+      :class:`~web3.providers.rpc.utils.ExceptionRetryConfiguration`
+      class which allows you to configure how the provider should handle exceptions
+      when making certain requests. Setting this to ``None`` will disable
+      exception retries.
 
     .. code-block:: python
 
@@ -180,7 +185,7 @@ IPCProvider
 AsyncHTTPProvider
 ~~~~~~~~~~~~~~~~~
 
-.. py:class:: web3.providers.async_rpc.AsyncHTTPProvider(endpoint_uri[, request_kwargs])
+.. py:class:: web3.providers.rpc.AsyncHTTPProvider(endpoint_uri, request_kwargs={}, exception_retry_configuration=ExceptionRetryConfiguration())
 
     This provider handles interactions with an HTTP or HTTPS based JSON-RPC server asynchronously.
 
@@ -190,7 +195,14 @@ AsyncHTTPProvider
       be omitted from the URI.
     * ``request_kwargs`` should be a dictionary of keyword arguments which
       will be passed onto each http/https POST request made to your node.
-    * the ``cache_async_session()`` method allows you to use your own ``aiohttp.ClientSession`` object. This is an async method and not part of the constructor
+    * ``exception_retry_configuration`` is an instance of the
+      :class:`~web3.providers.rpc.utils.ExceptionRetryConfiguration`
+      class which allows you to configure how the provider should handle exceptions
+      when making certain requests. Setting this to ``None`` will disable
+      exception retries.
+
+    The ``cache_async_session()`` method allows you to use your own
+    ``aiohttp.ClientSession`` object.
 
     .. code-block:: python
 

--- a/newsfragments/3412.bugfix.rst
+++ b/newsfragments/3412.bugfix.rst
@@ -1,0 +1,1 @@
+Change the ``exception_retry_configuration`` typing on http providers to be an ``Optional``, as setting this property to ``None`` effectively turns off retries on exceptions for requests.

--- a/newsfragments/3412.internal.rst
+++ b/newsfragments/3412.internal.rst
@@ -1,1 +1,1 @@
-Use a ``RequestSessionManager`` to manage sessions for http providers, rather than have them share a single session manager / cache.
+Use a ``HTTPSessionManager`` to manage sessions for http providers, rather than have them share a single session manager / cache.

--- a/newsfragments/3412.internal.rst
+++ b/newsfragments/3412.internal.rst
@@ -1,0 +1,1 @@
+Use a ``RequestSessionManager`` to manage sessions for http providers, rather than have them share a single session manager / cache.

--- a/tests/core/providers/test_async_http_provider.py
+++ b/tests/core/providers/test_async_http_provider.py
@@ -8,9 +8,6 @@ from web3 import (
     AsyncWeb3,
     __version__ as web3py_version,
 )
-from web3._utils import (
-    request,
-)
 from web3.eth import (
     AsyncEth,
 )
@@ -39,13 +36,6 @@ from web3.providers.rpc import (
 URI = "http://mynode.local:8545"
 
 
-async def clean_async_session_cache():
-    cache_data = request._async_session_cache._data
-    while len(cache_data) > 0:
-        _key, cached_session = cache_data.popitem()
-        await cached_session.close()
-
-
 @pytest.mark.asyncio
 async def test_async_no_args() -> None:
     provider = AsyncHTTPProvider()
@@ -55,9 +45,6 @@ async def test_async_no_args() -> None:
     assert not await w3.is_connected()
     with pytest.raises(ProviderConnectionError):
         await w3.is_connected(show_traceback=True)
-
-    await clean_async_session_cache()
-    assert len(request._async_session_cache) == 0
 
 
 def test_init_kwargs():
@@ -103,7 +90,7 @@ async def test_async_user_provided_session() -> None:
     session = ClientSession()
     provider = AsyncHTTPProvider(endpoint_uri=URI)
     cached_session = await provider.cache_async_session(session)
-    assert len(request._async_session_cache) == 1
+    assert len(provider._request_session_manager.session_cache) == 1
     assert cached_session == session
 
 

--- a/tests/core/providers/test_http_provider.py
+++ b/tests/core/providers/test_http_provider.py
@@ -11,9 +11,6 @@ from web3 import (
     Web3,
     __version__ as web3py_version,
 )
-from web3._utils import (
-    request,
-)
 from web3.eth import (
     Eth,
 )
@@ -94,10 +91,10 @@ def test_user_provided_session():
     session.mount("https://", adapter)
 
     provider = HTTPProvider(endpoint_uri=URI, session=session)
+    session = provider._request_session_manager.cache_and_return_session(URI)
     w3 = Web3(provider)
     assert w3.manager.provider == provider
 
-    session = request.cache_and_return_session(URI)
     adapter = session.get_adapter(URI)
     assert isinstance(adapter, HTTPAdapter)
     assert adapter._pool_connections == 20

--- a/tests/core/providers/test_http_request_retry.py
+++ b/tests/core/providers/test_http_request_retry.py
@@ -53,7 +53,7 @@ def test_check_without_retry_config():
     w3 = Web3(HTTPProvider(exception_retry_configuration=None))
 
     with patch(
-        "web3.providers.rpc.rpc.RequestSessionManager.make_post_request"
+        "web3.providers.rpc.rpc.HTTPSessionManager.make_post_request"
     ) as make_post_request_mock:
         make_post_request_mock.side_effect = Timeout
 
@@ -72,7 +72,7 @@ def test_check_if_retry_on_failure_true():
 
 
 @patch(
-    "web3.providers.rpc.rpc.RequestSessionManager.make_post_request",
+    "web3.providers.rpc.rpc.HTTPSessionManager.make_post_request",
     side_effect=ConnectionError,
 )
 def test_check_send_transaction_called_once(make_post_request_mock, w3):
@@ -84,7 +84,7 @@ def test_check_send_transaction_called_once(make_post_request_mock, w3):
 
 
 @patch(
-    "web3.providers.rpc.rpc.RequestSessionManager.make_post_request",
+    "web3.providers.rpc.rpc.HTTPSessionManager.make_post_request",
     side_effect=ConnectionError,
 )
 def test_valid_method_retried(make_post_request_mock, w3):
@@ -105,7 +105,7 @@ def test_exception_retry_config_is_strictly_on_http_provider():
 
 
 @patch(
-    "web3.providers.rpc.rpc.RequestSessionManager.make_post_request",
+    "web3.providers.rpc.rpc.HTTPSessionManager.make_post_request",
     side_effect=ConnectionError,
 )
 def test_exception_retry_middleware_with_allow_list_kwarg(make_post_request_mock):
@@ -159,7 +159,7 @@ async def test_async_default_request_retry_configuration_for_http_provider():
 )
 async def test_async_check_retry_middleware(async_w3, error):
     with patch(
-        "web3.providers.rpc.async_rpc.RequestSessionManager.async_make_post_request"
+        "web3.providers.rpc.async_rpc.HTTPSessionManager.async_make_post_request"
     ) as async_make_post_request_mock:
         async_make_post_request_mock.side_effect = error
 
@@ -173,7 +173,7 @@ async def test_async_check_without_retry_config():
     w3 = AsyncWeb3(AsyncHTTPProvider(exception_retry_configuration=None))
 
     with patch(
-        "web3.providers.rpc.async_rpc.RequestSessionManager.async_make_post_request"
+        "web3.providers.rpc.async_rpc.HTTPSessionManager.async_make_post_request"
     ) as async_make_post_request_mock:
         async_make_post_request_mock.side_effect = TimeoutError
 
@@ -192,7 +192,7 @@ async def test_async_exception_retry_middleware_with_allow_list_kwarg():
     async_w3 = AsyncWeb3(AsyncHTTPProvider(exception_retry_configuration=config))
 
     with patch(
-        "web3.providers.rpc.async_rpc.RequestSessionManager.async_make_post_request"
+        "web3.providers.rpc.async_rpc.HTTPSessionManager.async_make_post_request"
     ) as async_make_post_request_mock:
         async_make_post_request_mock.side_effect = TimeoutError
 

--- a/tests/core/providers/test_http_request_retry.py
+++ b/tests/core/providers/test_http_request_retry.py
@@ -52,7 +52,9 @@ def test_default_request_retry_configuration_for_http_provider():
 def test_check_without_retry_config():
     w3 = Web3(HTTPProvider(exception_retry_configuration=None))
 
-    with patch("web3.providers.rpc.rpc.make_post_request") as make_post_request_mock:
+    with patch(
+        "web3.providers.rpc.rpc.RequestSessionManager.make_post_request"
+    ) as make_post_request_mock:
         make_post_request_mock.side_effect = Timeout
 
         with pytest.raises(Timeout):
@@ -69,7 +71,10 @@ def test_check_if_retry_on_failure_true():
     assert check_if_retry_on_failure(method)
 
 
-@patch("web3.providers.rpc.rpc.make_post_request", side_effect=ConnectionError)
+@patch(
+    "web3.providers.rpc.rpc.RequestSessionManager.make_post_request",
+    side_effect=ConnectionError,
+)
 def test_check_send_transaction_called_once(make_post_request_mock, w3):
     with pytest.raises(ConnectionError):
         w3.provider.make_request(
@@ -78,7 +83,10 @@ def test_check_send_transaction_called_once(make_post_request_mock, w3):
     assert make_post_request_mock.call_count == 1
 
 
-@patch("web3.providers.rpc.rpc.make_post_request", side_effect=ConnectionError)
+@patch(
+    "web3.providers.rpc.rpc.RequestSessionManager.make_post_request",
+    side_effect=ConnectionError,
+)
 def test_valid_method_retried(make_post_request_mock, w3):
     with pytest.raises(ConnectionError):
         w3.provider.make_request(RPCEndpoint("eth_getBalance"), [f"0x{'00' * 20}"])
@@ -96,7 +104,10 @@ def test_exception_retry_config_is_strictly_on_http_provider():
     assert not hasattr(w3.provider, "exception_retry_configuration")
 
 
-@patch("web3.providers.rpc.rpc.make_post_request", side_effect=ConnectionError)
+@patch(
+    "web3.providers.rpc.rpc.RequestSessionManager.make_post_request",
+    side_effect=ConnectionError,
+)
 def test_exception_retry_middleware_with_allow_list_kwarg(make_post_request_mock):
     config = ExceptionRetryConfiguration(
         errors=(ConnectionError, HTTPError, Timeout, TooManyRedirects),
@@ -148,7 +159,7 @@ async def test_async_default_request_retry_configuration_for_http_provider():
 )
 async def test_async_check_retry_middleware(async_w3, error):
     with patch(
-        "web3.providers.rpc.async_rpc.async_make_post_request"
+        "web3.providers.rpc.async_rpc.RequestSessionManager.async_make_post_request"
     ) as async_make_post_request_mock:
         async_make_post_request_mock.side_effect = error
 
@@ -162,7 +173,7 @@ async def test_async_check_without_retry_config():
     w3 = AsyncWeb3(AsyncHTTPProvider(exception_retry_configuration=None))
 
     with patch(
-        "web3.providers.rpc.async_rpc.async_make_post_request"
+        "web3.providers.rpc.async_rpc.RequestSessionManager.async_make_post_request"
     ) as async_make_post_request_mock:
         async_make_post_request_mock.side_effect = TimeoutError
 
@@ -181,7 +192,7 @@ async def test_async_exception_retry_middleware_with_allow_list_kwarg():
     async_w3 = AsyncWeb3(AsyncHTTPProvider(exception_retry_configuration=config))
 
     with patch(
-        "web3.providers.rpc.async_rpc.async_make_post_request"
+        "web3.providers.rpc.async_rpc.RequestSessionManager.async_make_post_request"
     ) as async_make_post_request_mock:
         async_make_post_request_mock.side_effect = TimeoutError
 

--- a/tests/core/utilities/test_http_session_manager.py
+++ b/tests/core/utilities/test_http_session_manager.py
@@ -75,7 +75,7 @@ def _simulate_call(http_session_manager, uri):
     return _session
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def http_session_manager():
     return HTTPSessionManager()
 
@@ -323,7 +323,6 @@ async def test_session_manager_async_cache_does_not_close_session_before_a_call_
     # set cache size to 1 + set future session close thread time to 0.01s
     http_session_manager.session_cache = SimpleCache(1)
     _timeout_for_testing = 0.01
-    http_session_manager.request_timeout = _timeout_for_testing
 
     async def cache_uri_and_return_session(uri):
         _session = await http_session_manager.async_cache_and_return_session(

--- a/web3/_utils/http.py
+++ b/web3/_utils/http.py
@@ -1,3 +1,6 @@
+DEFAULT_HTTP_TIMEOUT = 30.0
+
+
 def construct_user_agent(class_type: type) -> str:
     from web3 import (
         __version__ as web3_version,

--- a/web3/_utils/http_session_manager.py
+++ b/web3/_utils/http_session_manager.py
@@ -86,7 +86,9 @@ class HTTPSessionManager:
                     f"{evicted_session}",
                 )
             threading.Timer(
-                request_timeout or 0 + 0.1,
+                # If `request_timeout` is `None`, don't wait forever for the closing
+                # session to finish the request. Instead, wait over the default timeout.
+                request_timeout or DEFAULT_HTTP_TIMEOUT + 0.1,
                 self._close_evicted_sessions,
                 args=[evicted_sessions],
             ).start()
@@ -214,7 +216,10 @@ class HTTPSessionManager:
             # is closed.
             asyncio.create_task(
                 self._async_close_evicted_sessions(
-                    request_timeout.total or 0 + 0.1,
+                    # if `ClientTimeout.total` is `None`, don't wait forever for the
+                    # closing session to finish the request. Instead, use the default
+                    # timeout.
+                    request_timeout.total or DEFAULT_HTTP_TIMEOUT + 0.1,
                     evicted_sessions,
                 )
             )

--- a/web3/_utils/module_testing/module_testing_utils.py
+++ b/web3/_utils/module_testing/module_testing_utils.py
@@ -12,9 +12,7 @@ from typing import (
     Union,
 )
 
-from aiohttp import (
-    ClientTimeout,
-)
+import aiohttp
 from eth_typing import (
     ChecksumAddress,
     HexStr,
@@ -28,11 +26,8 @@ from flaky import (
 from hexbytes import (
     HexBytes,
 )
+import requests
 
-from web3._utils.request import (
-    async_cache_and_return_session,
-    cache_and_return_session,
-)
 from web3.types import (
     BlockData,
     LogReceipt,
@@ -102,13 +97,12 @@ def mock_offchain_lookup_request_response(
 
         # mock response only to specified url while validating appropriate fields
         if url_from_args == mocked_request_url:
-            assert kwargs["timeout"] == 30
             if http_method.upper() == "POST":
                 assert kwargs["data"] == {"data": calldata, "sender": sender}
             return MockedResponse()
 
         # else, make a normal request (no mocking)
-        session = cache_and_return_session(url_from_args)
+        session = requests.Session()
         return session.request(method=http_method.upper(), url=url_from_args, **kwargs)
 
     monkeypatch.setattr(
@@ -152,13 +146,12 @@ def async_mock_offchain_lookup_request_response(
 
         # mock response only to specified url while validating appropriate fields
         if url_from_args == mocked_request_url:
-            assert kwargs["timeout"] == ClientTimeout(30)
             if http_method.upper() == "post":
                 assert kwargs["data"] == {"data": calldata, "sender": sender}
             return AsyncMockedResponse()
 
         # else, make a normal request (no mocking)
-        session = await async_cache_and_return_session(url_from_args)
+        session = aiohttp.ClientSession()
         return await session.request(
             method=http_method.upper(), url=url_from_args, **kwargs
         )

--- a/web3/_utils/request.py
+++ b/web3/_utils/request.py
@@ -33,233 +33,228 @@ from web3.utils.caching import (
     SimpleCache,
 )
 
-logger = logging.getLogger(__name__)
-
 DEFAULT_TIMEOUT = 30
 
 
-def get_default_http_endpoint() -> URI:
-    return URI(os.environ.get("WEB3_HTTP_PROVIDER_URI", "http://localhost:8545"))
+class RequestSessionManager:
+    logger = logging.getLogger("web3._utils.request.RequestSessionManager")
+    _lock: threading.Lock = threading.Lock()
 
+    def __init__(self, cache_size: int = 100, session_pool_max_workers: int = 5):
+        self.session_cache = SimpleCache(cache_size)
+        self.session_pool = ThreadPoolExecutor(max_workers=session_pool_max_workers)
 
-_session_cache = SimpleCache()
-_session_cache_lock = threading.Lock()
+    @staticmethod
+    def get_default_http_endpoint() -> URI:
+        return URI(os.environ.get("WEB3_HTTP_PROVIDER_URI", "http://localhost:8545"))
 
+    def cache_and_return_session(
+        self,
+        endpoint_uri: URI,
+        session: requests.Session = None,
+    ) -> requests.Session:
+        # cache key should have a unique thread identifier
+        cache_key = generate_cache_key(f"{threading.get_ident()}:{endpoint_uri}")
 
-def cache_and_return_session(
-    endpoint_uri: URI, session: requests.Session = None
-) -> requests.Session:
-    # cache key should have a unique thread identifier
-    cache_key = generate_cache_key(f"{threading.get_ident()}:{endpoint_uri}")
+        cached_session = self.session_cache.get_cache_entry(cache_key)
+        if cached_session is not None:
+            # If read from cache yields a session, no need to lock; return the session.
+            # Sync is a bit simpler in this way since a `requests.Session` doesn't
+            # really "close" in the same way that an async `ClientSession` does.
+            # When "closed", it still uses http / https adapters successfully if a
+            # request is made.
+            return cached_session
 
-    cached_session = _session_cache.get_cache_entry(cache_key)
-    if cached_session is not None:
-        # If read from cache yields a session, no need to lock; return the session.
-        # Sync is a bit simpler in this way since a `requests.Session` doesn't really
-        # "close" in the same way that an async `ClientSession` does. When "closed", it
-        # still uses http / https adapters successfully if a request is made.
+        if session is None:
+            session = requests.Session()
+
+        with self._lock:
+            cached_session, evicted_items = self.session_cache.cache(cache_key, session)
+            self.logger.debug(f"Session cached: {endpoint_uri}, {cached_session}")
+
+        if evicted_items is not None:
+            evicted_sessions = evicted_items.values()
+            for evicted_session in evicted_sessions:
+                self.logger.debug(
+                    "Session cache full. Session evicted from cache: "
+                    f"{evicted_session}",
+                )
+            threading.Timer(
+                DEFAULT_TIMEOUT + 0.1,
+                self._close_evicted_sessions,
+                args=[evicted_sessions],
+            ).start()
+
         return cached_session
 
-    if session is None:
-        session = requests.Session()
+    def get_response_from_get_request(
+        self, endpoint_uri: URI, *args: Any, **kwargs: Any
+    ) -> requests.Response:
+        kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+        session = self.cache_and_return_session(endpoint_uri)
+        response = session.get(endpoint_uri, *args, **kwargs)
+        return response
 
-    with _session_cache_lock:
-        cached_session, evicted_items = _session_cache.cache(cache_key, session)
-        logger.debug(f"Session cached: {endpoint_uri}, {cached_session}")
+    def json_make_get_request(
+        self, endpoint_uri: URI, *args: Any, **kwargs: Any
+    ) -> Dict[str, Any]:
+        response = self.get_response_from_get_request(endpoint_uri, *args, **kwargs)
+        response.raise_for_status()
+        return response.json()
 
-    if evicted_items is not None:
-        evicted_sessions = evicted_items.values()
-        for evicted_session in evicted_sessions:
-            logger.debug(
-                f"Session cache full. Session evicted from cache: {evicted_session}",
-            )
-        threading.Timer(
-            DEFAULT_TIMEOUT + 0.1,
-            _close_evicted_sessions,
-            args=[evicted_sessions],
-        ).start()
+    def get_response_from_post_request(
+        self, endpoint_uri: URI, *args: Any, **kwargs: Any
+    ) -> requests.Response:
+        kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+        session = self.cache_and_return_session(endpoint_uri)
+        response = session.post(endpoint_uri, *args, **kwargs)
+        return response
 
-    return cached_session
-
-
-def get_response_from_get_request(
-    endpoint_uri: URI, *args: Any, **kwargs: Any
-) -> requests.Response:
-    kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
-    session = cache_and_return_session(endpoint_uri)
-    response = session.get(endpoint_uri, *args, **kwargs)
-    return response
-
-
-def json_make_get_request(
-    endpoint_uri: URI, *args: Any, **kwargs: Any
-) -> Dict[str, Any]:
-    response = get_response_from_get_request(endpoint_uri, *args, **kwargs)
-    response.raise_for_status()
-    return response.json()
-
-
-def get_response_from_post_request(
-    endpoint_uri: URI, *args: Any, **kwargs: Any
-) -> requests.Response:
-    kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
-    session = cache_and_return_session(endpoint_uri)
-    response = session.post(endpoint_uri, *args, **kwargs)
-    return response
-
-
-def make_post_request(
-    endpoint_uri: URI, data: Union[bytes, Dict[str, Any]], **kwargs: Any
-) -> bytes:
-    response = get_response_from_post_request(endpoint_uri, data=data, **kwargs)
-    response.raise_for_status()
-    return response.content
-
-
-def _close_evicted_sessions(evicted_sessions: List[requests.Session]) -> None:
-    for evicted_session in evicted_sessions:
-        evicted_session.close()
-        logger.debug(f"Closed evicted session: {evicted_session}")
-
-
-# --- async --- #
-
-
-_async_session_cache = SimpleCache()
-_async_session_cache_lock = threading.Lock()
-_async_session_pool = ThreadPoolExecutor(max_workers=1)
-
-
-async def async_cache_and_return_session(
-    endpoint_uri: URI,
-    session: Optional[ClientSession] = None,
-) -> ClientSession:
-    # cache key should have a unique thread identifier
-    cache_key = generate_cache_key(f"{threading.get_ident()}:{endpoint_uri}")
-
-    evicted_items = None
-    async with async_lock(_async_session_pool, _async_session_cache_lock):
-        if cache_key not in _async_session_cache:
-            if session is None:
-                session = ClientSession(raise_for_status=True)
-
-            cached_session, evicted_items = _async_session_cache.cache(
-                cache_key, session
-            )
-            logger.debug(f"Async session cached: {endpoint_uri}, {cached_session}")
-
-        else:
-            # get the cached session
-            cached_session = _async_session_cache.get_cache_entry(cache_key)
-            session_is_closed = cached_session.closed
-            session_loop_is_closed = cached_session._loop.is_closed()
-
-            warning = (
-                "Async session was closed"
-                if session_is_closed
-                else (
-                    "Loop was closed for async session"
-                    if session_loop_is_closed
-                    else None
-                )
-            )
-            if warning:
-                logger.debug(
-                    f"{warning}: {endpoint_uri}, {cached_session}. "
-                    f"Creating and caching a new async session for uri."
-                )
-
-                _async_session_cache._data.pop(cache_key)
-                if not session_is_closed:
-                    # if loop was closed but not the session, close the session
-                    await cached_session.close()
-                logger.debug(
-                    f"Async session closed and evicted from cache: {cached_session}"
-                )
-
-                # replace stale session with a new session at the cache key
-                _session = ClientSession(raise_for_status=True)
-                cached_session, evicted_items = _async_session_cache.cache(
-                    cache_key, _session
-                )
-                logger.debug(f"Async session cached: {endpoint_uri}, {cached_session}")
-
-    if evicted_items is not None:
-        # At this point the evicted sessions are already popped out of the cache and
-        # just stored in the `evicted_sessions` dict. So we can kick off a future task
-        # to close them and it should be safe to pop out of the lock here.
-        evicted_sessions = evicted_items.values()
-        for evicted_session in evicted_sessions:
-            logger.debug(
-                "Async session cache full. Session evicted from cache: "
-                f"{evicted_session}",
-            )
-        # Kick off a future task, in a separate thread, to close the evicted
-        # sessions. In the case that the cache filled very quickly and some
-        # sessions have been evicted before their original request has been made,
-        # we set the timer to a bit more than the `DEFAULT_TIMEOUT` for a call. This
-        # should make it so that any call from an evicted session can still be made
-        # before the session is closed.
-        threading.Timer(
-            DEFAULT_TIMEOUT + 0.1,
-            _async_close_evicted_sessions,
-            args=[evicted_sessions],
-        ).start()
-
-    return cached_session
-
-
-async def async_get_response_from_get_request(
-    endpoint_uri: URI, *args: Any, **kwargs: Any
-) -> ClientResponse:
-    kwargs.setdefault("timeout", ClientTimeout(DEFAULT_TIMEOUT))
-    session = await async_cache_and_return_session(endpoint_uri)
-    response = await session.get(endpoint_uri, *args, **kwargs)
-    return response
-
-
-async def async_json_make_get_request(
-    endpoint_uri: URI, *args: Any, **kwargs: Any
-) -> Dict[str, Any]:
-    response = await async_get_response_from_get_request(endpoint_uri, *args, **kwargs)
-    response.raise_for_status()
-    return await response.json()
-
-
-async def async_get_response_from_post_request(
-    endpoint_uri: URI, *args: Any, **kwargs: Any
-) -> ClientResponse:
-    kwargs.setdefault("timeout", ClientTimeout(DEFAULT_TIMEOUT))
-    session = await async_cache_and_return_session(endpoint_uri)
-    response = await session.post(endpoint_uri, *args, **kwargs)
-    return response
-
-
-async def async_make_post_request(
-    endpoint_uri: URI, data: Union[bytes, Dict[str, Any]], **kwargs: Any
-) -> bytes:
-    response = await async_get_response_from_post_request(
-        endpoint_uri, data=data, **kwargs
-    )
-    response.raise_for_status()
-    return await response.read()
-
-
-async def async_get_json_from_client_response(
-    response: ClientResponse,
-) -> Dict[str, Any]:
-    return await response.json()
-
-
-def _async_close_evicted_sessions(evicted_sessions: List[ClientSession]) -> None:
-    loop = asyncio.new_event_loop()
-
-    for evicted_session in evicted_sessions:
-        loop.run_until_complete(evicted_session.close())
-        logger.debug(f"Closed evicted async session: {evicted_session}")
-
-    if any(not evicted_session.closed for evicted_session in evicted_sessions):
-        logger.warning(
-            f"Some evicted async sessions were not properly closed: {evicted_sessions}"
+    def make_post_request(
+        self, endpoint_uri: URI, data: Union[bytes, Dict[str, Any]], **kwargs: Any
+    ) -> bytes:
+        response = self.get_response_from_post_request(
+            endpoint_uri, data=data, **kwargs
         )
-    loop.close()
+        response.raise_for_status()
+        return response.content
+
+    def _close_evicted_sessions(self, evicted_sessions: List[requests.Session]) -> None:
+        for evicted_session in evicted_sessions:
+            evicted_session.close()
+            self.logger.debug(f"Closed evicted session: {evicted_session}")
+
+    # -- async -- #
+
+    async def async_cache_and_return_session(
+        self,
+        endpoint_uri: URI,
+        session: Optional[ClientSession] = None,
+    ) -> ClientSession:
+        # cache key should have a unique thread identifier
+        cache_key = generate_cache_key(f"{threading.get_ident()}:{endpoint_uri}")
+
+        evicted_items = None
+        async with async_lock(self.session_pool, self._lock):
+            if cache_key not in self.session_cache:
+                if session is None:
+                    session = ClientSession(raise_for_status=True)
+
+                cached_session, evicted_items = self.session_cache.cache(
+                    cache_key, session
+                )
+                self.logger.debug(
+                    f"Async session cached: {endpoint_uri}, {cached_session}"
+                )
+
+            else:
+                # get the cached session
+                cached_session = self.session_cache.get_cache_entry(cache_key)
+                session_is_closed = cached_session.closed
+                session_loop_is_closed = cached_session._loop.is_closed()
+
+                warning = (
+                    "Async session was closed"
+                    if session_is_closed
+                    else (
+                        "Loop was closed for async session"
+                        if session_loop_is_closed
+                        else None
+                    )
+                )
+                if warning:
+                    self.logger.debug(
+                        f"{warning}: {endpoint_uri}, {cached_session}. "
+                        f"Creating and caching a new async session for uri."
+                    )
+
+                    self.session_cache._data.pop(cache_key)
+                    if not session_is_closed:
+                        # if loop was closed but not the session, close the session
+                        await cached_session.close()
+                    self.logger.debug(
+                        f"Async session closed and evicted from cache: {cached_session}"
+                    )
+
+                    # replace stale session with a new session at the cache key
+                    _session = ClientSession(raise_for_status=True)
+                    cached_session, evicted_items = self.session_cache.cache(
+                        cache_key, _session
+                    )
+                    self.logger.debug(
+                        f"Async session cached: {endpoint_uri}, {cached_session}"
+                    )
+
+        if evicted_items is not None:
+            # At this point the evicted sessions are already popped out of the cache and
+            # just stored in the `evicted_sessions` dict. So we can kick off a future
+            # task to close them and it should be safe to pop out of the lock here.
+            evicted_sessions = evicted_items.values()
+            for evicted_session in evicted_sessions:
+                self.logger.debug(
+                    "Async session cache full. Session evicted from cache: "
+                    f"{evicted_session}",
+                )
+            # Kick off a future task, in a separate thread, to close the evicted
+            # sessions. In the case that the cache filled very quickly and some
+            # sessions have been evicted before their original request has been made,
+            # we set the timer to a bit more than the `DEFAULT_TIMEOUT` for a call. This
+            # should make it so that any call from an evicted session can still be made
+            # before the session is closed.
+            threading.Timer(
+                DEFAULT_TIMEOUT + 0.1,
+                self._async_close_evicted_sessions,
+                args=[evicted_sessions],
+            ).start()
+
+        return cached_session
+
+    async def async_get_response_from_get_request(
+        self, endpoint_uri: URI, *args: Any, **kwargs: Any
+    ) -> ClientResponse:
+        kwargs.setdefault("timeout", ClientTimeout(DEFAULT_TIMEOUT))
+        session = await self.async_cache_and_return_session(endpoint_uri)
+        response = await session.get(endpoint_uri, *args, **kwargs)
+        return response
+
+    async def async_json_make_get_request(
+        self, endpoint_uri: URI, *args: Any, **kwargs: Any
+    ) -> Dict[str, Any]:
+        response = await self.async_get_response_from_get_request(
+            endpoint_uri, *args, **kwargs
+        )
+        response.raise_for_status()
+        return await response.json()
+
+    async def async_get_response_from_post_request(
+        self, endpoint_uri: URI, *args: Any, **kwargs: Any
+    ) -> ClientResponse:
+        kwargs.setdefault("timeout", ClientTimeout(DEFAULT_TIMEOUT))
+        session = await self.async_cache_and_return_session(endpoint_uri)
+        response = await session.post(endpoint_uri, *args, **kwargs)
+        return response
+
+    async def async_make_post_request(
+        self, endpoint_uri: URI, data: Union[bytes, Dict[str, Any]], **kwargs: Any
+    ) -> bytes:
+        response = await self.async_get_response_from_post_request(
+            endpoint_uri, data=data, **kwargs
+        )
+        response.raise_for_status()
+        return await response.read()
+
+    def _async_close_evicted_sessions(
+        self, evicted_sessions: List[ClientSession]
+    ) -> None:
+        loop = asyncio.new_event_loop()
+
+        for evicted_session in evicted_sessions:
+            loop.run_until_complete(evicted_session.close())
+            self.logger.debug(f"Closed evicted async session: {evicted_session}")
+
+        if any(not evicted_session.closed for evicted_session in evicted_sessions):
+            self.logger.warning(
+                "Some evicted async sessions were not properly closed: "
+                f"{evicted_sessions}"
+            )
+        loop.close()

--- a/web3/beacon/async_beacon.py
+++ b/web3/beacon/async_beacon.py
@@ -9,8 +9,7 @@ from eth_typing import (
 )
 
 from web3._utils.request import (
-    async_get_response_from_get_request,
-    async_json_make_get_request,
+    RequestSessionManager,
 )
 from web3.beacon.api_endpoints import (
     GET_ATTESTATIONS,
@@ -63,10 +62,13 @@ class AsyncBeacon:
     ) -> None:
         self.base_url = base_url
         self.request_timeout = request_timeout
+        self._request_session_manager = RequestSessionManager()
 
     async def _async_make_get_request(self, endpoint_uri: str) -> Dict[str, Any]:
         uri = URI(self.base_url + endpoint_uri)
-        return await async_json_make_get_request(uri, timeout=self.request_timeout)
+        return await self._request_session_manager.async_json_make_get_request(
+            uri, timeout=self.request_timeout
+        )
 
     # [ BEACON endpoints ]
 
@@ -208,7 +210,9 @@ class AsyncBeacon:
 
     async def get_health(self) -> int:
         url = URI(self.base_url + GET_HEALTH)
-        response = await async_get_response_from_get_request(url)
+        response = (
+            await self._request_session_manager.async_get_response_from_get_request(url)
+        )
         return response.status
 
     async def get_version(self) -> Dict[str, Any]:

--- a/web3/beacon/async_beacon.py
+++ b/web3/beacon/async_beacon.py
@@ -8,9 +8,6 @@ from eth_typing import (
     HexStr,
 )
 
-from web3._utils.request import (
-    RequestSessionManager,
-)
 from web3.beacon.api_endpoints import (
     GET_ATTESTATIONS,
     GET_ATTESTER_SLASHINGS,
@@ -50,6 +47,9 @@ from web3.beacon.api_endpoints import (
     GET_VERSION,
     GET_VOLUNTARY_EXITS,
 )
+from web3.session_manager import (
+    HTTPSessionManager,
+)
 
 
 class AsyncBeacon:
@@ -62,7 +62,7 @@ class AsyncBeacon:
     ) -> None:
         self.base_url = base_url
         self.request_timeout = request_timeout
-        self._request_session_manager = RequestSessionManager()
+        self._request_session_manager = HTTPSessionManager()
 
     async def _async_make_get_request(self, endpoint_uri: str) -> Dict[str, Any]:
         uri = URI(self.base_url + endpoint_uri)

--- a/web3/beacon/beacon.py
+++ b/web3/beacon/beacon.py
@@ -9,8 +9,7 @@ from eth_typing import (
 )
 
 from web3._utils.request import (
-    get_response_from_get_request,
-    json_make_get_request,
+    RequestSessionManager,
 )
 from web3.beacon.api_endpoints import (
     GET_ATTESTATIONS,
@@ -61,10 +60,13 @@ class Beacon:
     ) -> None:
         self.base_url = base_url
         self.request_timeout = request_timeout
+        self._request_session_manager = RequestSessionManager()
 
     def _make_get_request(self, endpoint_url: str) -> Dict[str, Any]:
         uri = URI(self.base_url + endpoint_url)
-        return json_make_get_request(uri, timeout=self.request_timeout)
+        return self._request_session_manager.json_make_get_request(
+            uri, timeout=self.request_timeout
+        )
 
     # [ BEACON endpoints ]
 
@@ -196,7 +198,7 @@ class Beacon:
 
     def get_health(self) -> int:
         url = URI(self.base_url + GET_HEALTH)
-        response = get_response_from_get_request(url)
+        response = self._request_session_manager.get_response_from_get_request(url)
         return response.status_code
 
     def get_version(self) -> Dict[str, Any]:

--- a/web3/beacon/beacon.py
+++ b/web3/beacon/beacon.py
@@ -8,9 +8,6 @@ from eth_typing import (
     HexStr,
 )
 
-from web3._utils.request import (
-    RequestSessionManager,
-)
 from web3.beacon.api_endpoints import (
     GET_ATTESTATIONS,
     GET_ATTESTER_SLASHINGS,
@@ -50,6 +47,9 @@ from web3.beacon.api_endpoints import (
     GET_VERSION,
     GET_VOLUNTARY_EXITS,
 )
+from web3.session_manager import (
+    HTTPSessionManager,
+)
 
 
 class Beacon:
@@ -60,7 +60,7 @@ class Beacon:
     ) -> None:
         self.base_url = base_url
         self.request_timeout = request_timeout
-        self._request_session_manager = RequestSessionManager()
+        self._request_session_manager = HTTPSessionManager()
 
     def _make_get_request(self, endpoint_url: str) -> Dict[str, Any]:
         uri = URI(self.base_url + endpoint_url)

--- a/web3/eth/eth.py
+++ b/web3/eth/eth.py
@@ -285,7 +285,8 @@ class Eth(BaseEth):
                 return self._call(transaction, block_identifier, state_override)
             except OffchainLookup as offchain_lookup:
                 durin_calldata = handle_offchain_lookup(
-                    offchain_lookup.payload, transaction
+                    offchain_lookup.payload,
+                    transaction,
                 )
                 transaction["data"] = durin_calldata
 

--- a/web3/providers/rpc/async_rpc.py
+++ b/web3/providers/rpc/async_rpc.py
@@ -55,9 +55,7 @@ from .utils import (
 class AsyncHTTPProvider(AsyncJSONBaseProvider):
     logger = logging.getLogger("web3.providers.AsyncHTTPProvider")
     endpoint_uri = None
-
     _request_kwargs = None
-    _request_session_manager = RequestSessionManager()
 
     def __init__(
         self,
@@ -68,6 +66,8 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
         ] = empty,
         **kwargs: Any,
     ) -> None:
+        self._request_session_manager = RequestSessionManager()
+
         if endpoint_uri is None:
             self.endpoint_uri = (
                 self._request_session_manager.get_default_http_endpoint()

--- a/web3/providers/rpc/async_rpc.py
+++ b/web3/providers/rpc/async_rpc.py
@@ -40,8 +40,8 @@ from ..._utils.batching import (
 from ..._utils.caching import (
     async_handle_request_caching,
 )
-from ..._utils.request import (
-    RequestSessionManager,
+from ..._utils.http_session_manager import (
+    HTTPSessionManager,
 )
 from ..async_base import (
     AsyncJSONBaseProvider,
@@ -66,7 +66,7 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
         ] = empty,
         **kwargs: Any,
     ) -> None:
-        self._request_session_manager = RequestSessionManager()
+        self._request_session_manager = HTTPSessionManager()
 
         if endpoint_uri is None:
             self.endpoint_uri = (

--- a/web3/providers/rpc/async_rpc.py
+++ b/web3/providers/rpc/async_rpc.py
@@ -61,8 +61,8 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
         self,
         endpoint_uri: Optional[Union[URI, str]] = None,
         request_kwargs: Optional[Any] = None,
-        exception_retry_configuration: Union[
-            ExceptionRetryConfiguration, Empty
+        exception_retry_configuration: Optional[
+            Union[ExceptionRetryConfiguration, Empty]
         ] = empty,
         **kwargs: Any,
     ) -> None:

--- a/web3/providers/rpc/rpc.py
+++ b/web3/providers/rpc/rpc.py
@@ -58,9 +58,7 @@ if TYPE_CHECKING:
 class HTTPProvider(JSONBaseProvider):
     logger = logging.getLogger("web3.providers.HTTPProvider")
     endpoint_uri = None
-
     _request_kwargs = None
-    _request_session_manager = RequestSessionManager()
 
     def __init__(
         self,
@@ -72,6 +70,8 @@ class HTTPProvider(JSONBaseProvider):
         ] = empty,
         **kwargs: Any,
     ) -> None:
+        self._request_session_manager = RequestSessionManager()
+
         if endpoint_uri is None:
             self.endpoint_uri = (
                 self._request_session_manager.get_default_http_endpoint()

--- a/web3/providers/rpc/rpc.py
+++ b/web3/providers/rpc/rpc.py
@@ -38,8 +38,8 @@ from ..._utils.batching import (
 from ..._utils.caching import (
     handle_request_caching,
 )
-from ..._utils.request import (
-    RequestSessionManager,
+from ..._utils.http_session_manager import (
+    HTTPSessionManager,
 )
 from ..base import (
     JSONBaseProvider,
@@ -70,7 +70,7 @@ class HTTPProvider(JSONBaseProvider):
         ] = empty,
         **kwargs: Any,
     ) -> None:
-        self._request_session_manager = RequestSessionManager()
+        self._request_session_manager = HTTPSessionManager()
 
         if endpoint_uri is None:
             self.endpoint_uri = (

--- a/web3/providers/rpc/rpc.py
+++ b/web3/providers/rpc/rpc.py
@@ -65,8 +65,8 @@ class HTTPProvider(JSONBaseProvider):
         endpoint_uri: Optional[Union[URI, str]] = None,
         request_kwargs: Optional[Any] = None,
         session: Optional[Any] = None,
-        exception_retry_configuration: Union[
-            ExceptionRetryConfiguration, Empty
+        exception_retry_configuration: Optional[
+            Union[ExceptionRetryConfiguration, Empty]
         ] = empty,
         **kwargs: Any,
     ) -> None:

--- a/web3/utils/async_exception_handling.py
+++ b/web3/utils/async_exception_handling.py
@@ -5,6 +5,7 @@ from typing import (
 
 from aiohttp import (
     ClientSession,
+    ClientTimeout,
 )
 from eth_abi import (
     abi,
@@ -13,6 +14,9 @@ from eth_typing import (
     URI,
 )
 
+from web3._utils.http import (
+    DEFAULT_HTTP_TIMEOUT,
+)
 from web3._utils.type_conversion import (
     to_bytes_if_hex,
     to_hex_if_bytes,
@@ -49,11 +53,14 @@ async def async_handle_offchain_lookup(
 
         try:
             if "{data}" in url and "{sender}" in url:
-                response = await session.get(formatted_url)
+                response = await session.get(
+                    formatted_url, timeout=DEFAULT_HTTP_TIMEOUT
+                )
             elif "{sender}" in url:
                 response = await session.post(
                     formatted_url,
                     data={"data": formatted_data, "sender": formatted_sender},
+                    timeout=ClientTimeout(DEFAULT_HTTP_TIMEOUT),
                 )
             else:
                 raise Web3ValidationError("url not formatted properly.")

--- a/web3/utils/exception_handling.py
+++ b/web3/utils/exception_handling.py
@@ -9,11 +9,8 @@ from eth_abi import (
 from eth_typing import (
     URI,
 )
+import requests
 
-from web3._utils.request import (
-    get_response_from_get_request,
-    get_response_from_post_request,
-)
 from web3._utils.type_conversion import (
     to_bytes_if_hex,
     to_hex_if_bytes,
@@ -40,6 +37,7 @@ def handle_offchain_lookup(
             "Returned `sender` value does not equal `to` address in transaction."
         )
 
+    session = requests.Session()
     for url in offchain_lookup_payload["urls"]:
         formatted_url = URI(
             str(url)
@@ -49,9 +47,9 @@ def handle_offchain_lookup(
 
         try:
             if "{data}" in url and "{sender}" in url:
-                response = get_response_from_get_request(formatted_url)
+                response = session.get(formatted_url)
             elif "{sender}" in url:
-                response = get_response_from_post_request(
+                response = session.post(
                     formatted_url,
                     data={
                         "data": formatted_data,

--- a/web3/utils/exception_handling.py
+++ b/web3/utils/exception_handling.py
@@ -11,6 +11,9 @@ from eth_typing import (
 )
 import requests
 
+from web3._utils.http import (
+    DEFAULT_HTTP_TIMEOUT,
+)
 from web3._utils.type_conversion import (
     to_bytes_if_hex,
     to_hex_if_bytes,
@@ -47,7 +50,7 @@ def handle_offchain_lookup(
 
         try:
             if "{data}" in url and "{sender}" in url:
-                response = session.get(formatted_url)
+                response = session.get(formatted_url, timeout=DEFAULT_HTTP_TIMEOUT)
             elif "{sender}" in url:
                 response = session.post(
                     formatted_url,
@@ -55,6 +58,7 @@ def handle_offchain_lookup(
                         "data": formatted_data,
                         "sender": formatted_sender,
                     },
+                    timeout=DEFAULT_HTTP_TIMEOUT,
                 )
             else:
                 raise Web3ValidationError("url not formatted properly.")


### PR DESCRIPTION
### What was wrong?

Though #3265 is not reproducible, this hopefully closes #3265 as there should be no more conflicts across separate instances due to unique instantiation of session managing per provider.

### How was it fixed?

- Use a unique session manager for each instance of HTTPProvider, and AsyncHTTPProvider, by moving all the shared session cache logic into a class and strapping it to each provider instance.
- Update tests related to session caching
- Update docs and update the typing for `request_retry_configuration` along the way (`Optional`)

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20240528_215358~2](https://github.com/ethereum/web3.py/assets/3532824/ea75d536-536d-4db0-820f-24439253f4c7)
