### PR TITLE
Add deprecation of `eth-typing.ethpm` types to the migration guide.

### DIFF
--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -229,6 +229,11 @@ The EthPM module has been removed from the library. It was not widely used and h
 been functional since around October 2022. It was deprecated in ``v6`` and has been
 completely removed in ``v7``.
 
+Types in the
+`eth_typing.ethpm <https://github.com/ethereum/eth-typing/blob/ef9c2d566b7747bb6799214e2c89006b8cde4c36/eth_typing/ethpm.py>`_
+module have been deprecated and will be removed from ``eth-typing`` in the next major
+release.
+
 
 Geth Miner Namespace Removed
 ````````````````````````````


### PR DESCRIPTION
### What was wrong?

EthPM is removed in v7 and the types in `eth-typing` should also be removed. Before removal, the types should be deprecated. The `deprecated` decorator doesnt work for variable or type declarations so just documenting them as deprecated should be sufficient.

Related to https://github.com/ethereum/eth-typing/pull/67

### How was it fixed?

This adds info to the `EthPM` section about the deprecation and future removal of type declarations for `ContractName`, `Manifest` and `URI`.

### Todo:

- [X] Clean up commit history
- [X] Add or update documentation related to these changes
- [X] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.chzbgr.com/full/9544007424/hB3AAAF2E/sculpture)
