### PR TITLE
`v6` `ABIError` type

### DIFF
--- a/newsfragments/3419.feature.rst
+++ b/newsfragments/3419.feature.rst
@@ -1,0 +1,1 @@
+Created ``ABIError`` type in the ``web3.types`` module and added as a valid type of ``ABIElement``.

--- a/web3/types.py
+++ b/web3/types.py
@@ -112,6 +112,19 @@ class ABIFunction(TypedDict, total=False):
     type: Literal["function", "constructor", "fallback", "receive"]
 
 
+class ABIComponent(TypedDict):
+    """
+    TypedDict representing an `ABIElement` component.
+    """
+
+    name: str
+    """Name of the component."""
+    type: str
+    """Type of the component."""
+    components: NotRequired[Sequence["ABIComponent"]]
+    """List of nested `ABI` components for ABI types."""
+
+
 class ABIError(TypedDict):
     """
     TypedDict representing the `ABI` for an error.
@@ -121,7 +134,7 @@ class ABIError(TypedDict):
     """Type of the error."""
     name: str
     """Name of the error."""
-    inputs: NotRequired[Sequence["ABIFunctionParams"]]
+    inputs: NotRequired[Sequence["ABIComponent"]]
     """Error input components."""
 
 

--- a/web3/types.py
+++ b/web3/types.py
@@ -112,6 +112,19 @@ class ABIFunction(TypedDict, total=False):
     type: Literal["function", "constructor", "fallback", "receive"]
 
 
+class ABIError(TypedDict):
+    """
+    TypedDict representing the `ABI` for an error.
+    """
+
+    type: Literal["error"]
+    """Type of the error."""
+    name: str
+    """Name of the error."""
+    inputs: NotRequired[Sequence["ABIFunctionParams"]]
+    """Error input components."""
+
+
 ABIElement = Union[ABIFunction, ABIEvent]
 ABI = Sequence[Union[ABIFunction, ABIEvent]]
 

--- a/web3/types.py
+++ b/web3/types.py
@@ -125,7 +125,7 @@ class ABIError(TypedDict):
     """Error input components."""
 
 
-ABIElement = Union[ABIFunction, ABIEvent]
+ABIElement = Union[ABIFunction, ABIEvent, ABIError]
 ABI = Sequence[Union[ABIFunction, ABIEvent]]
 
 


### PR DESCRIPTION
### What was wrong?

Encountering type errors when parsing contracts with `"error"` type ABI elements.

Related to Issue #3419

### How was it fixed?

Created ``ABIError`` type in the ``web3.types`` module and added as a valid type of ``ABIElement``.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.globaltimes.cn/Portals/0//attachment/2018/2018-07-22/e8f7999f-dbad-4541-ad63-b0450faad337.jpeg)
