### PR TITLE
Fix Beacon API after internal cache rehaul:

### DIFF
--- a/newsfragments/3421.bugfix.rst
+++ b/newsfragments/3421.bugfix.rst
@@ -1,0 +1,1 @@
+A bugfix, pre-release, to update the ``Beacon`` APIs (sync and async) to properly use the new ``HTTPSessionManager``.

--- a/tests/beacon/test_beacon.py
+++ b/tests/beacon/test_beacon.py
@@ -6,15 +6,12 @@ from random import (
 from requests import (
     Timeout,
 )
-
-from web3._utils.request import (
-    _session_cache,
+from requests.exceptions import (
+    InvalidURL,
 )
+
 from web3.beacon import (
     Beacon,
-)
-from web3.exceptions import (
-    Web3ValueError,
 )
 
 # tested against lighthouse which uses port 5052 by default
@@ -32,15 +29,9 @@ def beacon():
     return Beacon(base_url=BASE_URL)
 
 
-@pytest.fixture(autouse=True)
-def _cleanup():
-    yield
-    _session_cache.clear()
-
-
 # sanity check to make sure the positive test cases are valid
 def test_cl_beacon_raises_exception_on_invalid_url(beacon):
-    with pytest.raises(Web3ValueError):
+    with pytest.raises(InvalidURL):
         beacon._make_get_request(BASE_URL + "/eth/v1/beacon/nonexistent")
 
 

--- a/web3/beacon/async_beacon.py
+++ b/web3/beacon/async_beacon.py
@@ -8,6 +8,9 @@ from eth_typing import (
     HexStr,
 )
 
+from web3._utils.http_session_manager import (
+    HTTPSessionManager,
+)
 from web3.beacon.api_endpoints import (
     GET_ATTESTATIONS,
     GET_ATTESTER_SLASHINGS,
@@ -46,9 +49,6 @@ from web3.beacon.api_endpoints import (
     GET_VALIDATORS,
     GET_VERSION,
     GET_VOLUNTARY_EXITS,
-)
-from web3.session_manager import (
-    HTTPSessionManager,
 )
 
 

--- a/web3/beacon/beacon.py
+++ b/web3/beacon/beacon.py
@@ -8,6 +8,9 @@ from eth_typing import (
     HexStr,
 )
 
+from web3._utils.http_session_manager import (
+    HTTPSessionManager,
+)
 from web3.beacon.api_endpoints import (
     GET_ATTESTATIONS,
     GET_ATTESTER_SLASHINGS,
@@ -46,9 +49,6 @@ from web3.beacon.api_endpoints import (
     GET_VALIDATORS,
     GET_VERSION,
     GET_VOLUNTARY_EXITS,
-)
-from web3.session_manager import (
-    HTTPSessionManager,
 )
 
 


### PR DESCRIPTION
### What was wrong?

We moved session caching as internal parts of HTTP providers. Since that change, the ``Beacon`` API was receiving a bad bath for session caching.

### How was it fixed?

These updates fix that (by setting the proper path to the `HTTPSessionManager` class) and raise the timeout for the async tests since some seem to be timing out.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.redd.it/a-bunch-of-adorable-baby-animal-pictures-found-on-google-v0-im4smv2y5kt81.jpg?width=736&format=pjpg&auto=webp&s=5fe04496fef16d124474ed36325243c696ed3f12)
