### PR TITLE
Docs improvement

### DIFF
--- a/docs/code_of_conduct.rst
+++ b/docs/code_of_conduct.rst
@@ -31,7 +31,7 @@ Examples of unacceptable behavior by participants include:
 * Public or private harassment
 * Publishing others' private information, such as a physical or electronic
   address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+* Other conduct that could reasonably be considered inappropriate in a
   professional setting
 
 Our Responsibilities

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,7 @@ project = "web3.py"
 copyright = "2016-2024, The Ethereum Foundation"
 
 __version__ = setup_version
-# The version info for the project you're documenting, acts as replacement for
+# The version info for the project you're documenting, acts as a replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -212,12 +212,12 @@ Integration Testing
 Our integration test suite setup lives under the ``/tests/integration`` directory.
 The integration test suite is dependent on what we call "fixtures" (not to be
 confused with pytest fixtures). These zip file fixtures, which also live in the
-``/tests/integration`` directory, are configured to run the specific client we are
+``/tests/integration`` directory, is configured to run the specific client we are
 testing against along with a genesis configuration that gives our tests some
 pre-determined useful objects (like unlocked, pre-loaded accounts) to be able to
 interact with the client when we run our tests.
 
-The parent ``/integration`` directory houses some common configuration shared across
+The parent ``/integration`` directory houses some common configurations shared across
 all client tests, whereas the ``/go_ethereum`` directory houses common code to be
 shared across geth-specific provider tests. Though the setup and run configurations
 exist across the different files within ``/tests/integration``, our integration module

--- a/docs/ens_overview.rst
+++ b/docs/ens_overview.rst
@@ -82,7 +82,7 @@ The first time it's used, web3.py will create the  ``ens`` instance using
     this flag. For more examples, see :ref:`disable-strict-byte-check`
 
     If instantiating a standalone ENS instance using ``ENS.from_web3()``, the ENS
-    instance will inherit the value of the flag on the Web3 instance at time of
+    instance will inherit the value of the flag on the Web3 instance at the time of
     instantiation.
 
     .. doctest::

--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -156,7 +156,7 @@ Filter Class
     Hook for subclasses to modify the format of the log entries this filter
     returns, or passes to its callback functions.
 
-    By default this returns the ``entry`` parameter umodified.
+    By default this returns the ``entry`` parameter unmodified.
 
 
 .. py:method:: Filter.is_valid_entry(entry)


### PR DESCRIPTION
Rectify typographical inaccuracies

This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.
