### PR TITLE
Update filters.rst

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -156,7 +156,7 @@ Filter Class
     Hook for subclasses to modify the format of the log entries this filter
     returns, or passes to its callback functions.
 
-    By default this returns the ``entry`` parameter umodified.
+    By default this returns the ``entry`` parameter unmodified.
 
 
 .. py:method:: Filter.is_valid_entry(entry)

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -7,7 +7,7 @@ v7 Breaking Changes Summary
 .. towncrier release notes start
 
 web3.py v7.0.0-beta.7 (2024-06-26)
------------------------------
+----------------------------------
 
 Bugfixes
 ~~~~~~~~


### PR DESCRIPTION
There was a spelling mistake in the filters.rst file that affected the clarity of the documentation for new users.

How was it fixed?
Corrected the spelling mistake in the filters.rst file.
Reviewed the surrounding text for additional errors and improved overall clarity.



#### Cute Animal Picture

