### PR TITLE
Fix websocket provider receives nothing forever when the peer server is closed or gone

### DIFF
--- a/newsfragments/3424.bugfix.rst
+++ b/newsfragments/3424.bugfix.rst
@@ -1,0 +1,1 @@
+Propagate ``ConnectionClosedOK`` exception for ``WebsocketProviderV2`` to properly break the loop when listening for messages over the socket.

--- a/web3/_utils/module_testing/module_testing_utils.py
+++ b/web3/_utils/module_testing/module_testing_utils.py
@@ -191,7 +191,7 @@ class WebsocketMessageStreamMock:
         messages: Optional[Collection[bytes]] = None,
         raise_exception: Optional[Exception] = None,
     ) -> None:
-        self.queue = asyncio.Queue[bytes]()
+        self.queue = asyncio.Queue()  # type: ignore  # py38 issue
         for msg in messages or []:
             self.queue.put_nowait(msg)
         self.raise_exception = raise_exception

--- a/web3/providers/persistent.py
+++ b/web3/providers/persistent.py
@@ -191,10 +191,6 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
             request_cache_key = generate_cache_key(request_id)
 
             while True:
-                # check if an exception was recorded in the listener task and raise it
-                # in the main loop if so
-                self._handle_listener_task_exceptions()
-
                 if request_cache_key in self._request_processor._request_response_cache:
                     self.logger.debug(
                         f"Popping response for id {request_id} from cache."
@@ -204,6 +200,9 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
                     )
                     return popped_response
                 else:
+                    # check if an exception was recorded in the listener task and raise
+                    # it in the main loop if so
+                    self._handle_listener_task_exceptions()
                     await asyncio.sleep(0)
 
         try:

--- a/web3/providers/websocket/websocket_v2.py
+++ b/web3/providers/websocket/websocket_v2.py
@@ -136,9 +136,8 @@ class WebsocketProviderV2(PersistentConnectionProvider):
         return response
 
     async def _provider_specific_message_listener(self) -> None:
-        async for raw_message in self._ws:
-            await asyncio.sleep(0)
-
+        while True:
+            raw_message = await self._ws.recv()
             response = json.loads(raw_message)
             subscription = response.get("method") == "eth_subscription"
             await self._request_processor.cache_raw_response(


### PR DESCRIPTION
This should fix websocket provider receives nothing forever when the peer server is closed or gone.

When receiving websocket messages using iterator pattern, [websockets.py suppresses `ConnectionClosedOK` errors](https://github.com/python-websockets/websockets/blob/main/src/websockets/legacy/protocol.py#L496-L500). so [`_provider_specific_message_listener`](https://github.com/ethereum/web3.py/blob/616212e3bf9d4ff7c24edc7db2a98d03e5616626/web3/providers/websocket/websocket_v2.py#L139) will stop iterating without an error, and [`_message_listener`](https://github.com/ethereum/web3.py/blob/616212e3bf9d4ff7c24edc7db2a98d03e5616626/web3/providers/persistent.py#L139) will continue the `while` loop without knowing that the connection is closed and will not receive any messages.

The fix use `recv()` function to allow the websocket to throw the `ConnectionClosedOK` exception.

(After merging this PR, I'll port the fix to the main branch)