### PR TITLE
Port similar changes from #3424 to main / v7:

### DIFF
--- a/newsfragments/3432.bugfix.rst
+++ b/newsfragments/3432.bugfix.rst
@@ -1,0 +1,1 @@
+Handle ``ConnectionClosedOK`` case for ``WebSocketProvider``. If a persistent connection is closed gracefully, log and raise a silent ``PersistentConnectionClosedOK`` exception, triggering an end to the message listener task and breaking out of the ``process_subscriptions()`` iterator.

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -327,6 +327,12 @@ class TaskNotRunning(Web3Exception):
         super().__init__(message)
 
 
+class PersistentConnectionClosedOK(Web3Exception):
+    """
+    Raised when a persistent connection is closed gracefully by the server.
+    """
+
+
 class Web3RPCError(Web3Exception):
     """
     Raised when a JSON-RPC response contains an error field.

--- a/web3/providers/persistent/persistent_connection.py
+++ b/web3/providers/persistent/persistent_connection.py
@@ -2,6 +2,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
+    Optional,
 )
 
 from web3.types import (
@@ -35,7 +36,7 @@ class PersistentConnection:
     async def send(self, method: RPCEndpoint, params: Any) -> RPCResponse:
         return await self._manager.send(method, params)
 
-    async def recv(self) -> Any:
+    async def recv(self) -> Optional[RPCResponse]:
         return await self._manager._get_next_message()
 
     def process_subscriptions(self) -> "_AsyncPersistentMessageStream":


### PR DESCRIPTION
### What was wrong?

Implement similar logic made in #3424 for `v7` / `main` branch, gracefully handling the case of `ConnectionClosedOK` for websocket connections.

### How was it fixed?

- If a persistent connection is closed gracefully, log and raise a silent ``PersistentConnectionClosedOK`` exception, triggering an end to the message listener task and breaking out of the ``process_subscriptions()`` iterator.

Since we have very different socket logic between `AsyncIPCProvider` and `WebSocketProvider`, handle the specific websocket case inside the `_provider_specific_message_listener()` method. For WebSocket case, if a `ConnectionClosedOK` is raised, silence it and re-raise a `PersistentConnectionClosedOK`.

I don't currently see an equivalent case for `AsyncIPCProvider` so this pattern isn't utilized for that specific provider.

### Todo:

- [x] Add specific test
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20240714_125244](https://github.com/user-attachments/assets/56261fca-9745-4153-a196-4fb814c4a136)
