### PR TITLE
Refactor public API for persistent connection provider socket interactions

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -336,7 +336,7 @@ can be found in the `websockets connection`_ docs.
         ...     logger.setLevel(logging.DEBUG)
         ...     logger.addHandler(logging.StreamHandler())
 
-        >>> async def context_manager_subscriptions_example():
+        >>> async def context_manager_subscription_example():
         ...     #  async with AsyncWeb3(AsyncIPCProvider("./path/to.filename.ipc") as w3:  # for the AsyncIPCProvider
         ...     async with AsyncWeb3(WebSocketProvider(f"ws://127.0.0.1:8546")) as w3:  # for the WebSocketProvider
         ...         # subscribe to new block headers
@@ -482,17 +482,6 @@ Interacting with the Persistent Connection
         Examples on how to use this method can be seen above in the
         `Using Persistent Connection Providers`_ section.
 
-    .. py:method:: recv()
-
-        The ``recv()`` method can be used to receive the next message from the
-        socket. The response from this method is formatted by web3.py formatters
-        and run through the middleware before being returned. This is not the
-        recommended way to receive a message as the ``process_subscriptions()`` method
-        is available for listening to subscriptions and the standard API for making
-        requests via the appropriate module
-        (e.g. ``block_num = await w3.eth.block_number``) is available for receiving
-        responses for one-to-one request-to-response calls.
-
     .. py:method:: send(method: RPCEndpoint, params: Sequence[Any])
 
         This method is available strictly for sending raw requests to the socket,
@@ -501,6 +490,25 @@ Interacting with the Persistent Connection
         middleware. Instead, use the methods available on the respective web3
         module. For example, use ``w3.eth.get_block("latest")`` instead of
         ``w3.socket.send("eth_getBlockByNumber", ["latest", True])``.
+
+    .. py:method:: recv()
+
+        The ``recv()`` method can be used to receive the next response for a request
+        from the socket. The response from this method is the raw response. This is not
+        the recommended way to receive a response for a request, as it is not formatted
+        by *web3.py* formatters or run through the middleware. Instead, use the methods
+        available on the respective web3 module
+        (e.g. ``block_num = await w3.eth.block_number``) for retrieving responses for
+        one-to-one request-to-response calls.
+
+    .. py:method:: make_request(method: RPCEndpoint, params: Sequence[Any])
+
+        This method is available for making requests to the socket and retrieving the
+        response. It is not recommended to use this method directly, as the responses
+        will not be properly formatted by *web3.py* formatters or run through the
+        middleware. Instead, use the methods available on the respective web3 module.
+        For example, use ``w3.eth.get_block("latest")`` instead of
+        ``w3.socket.make_request("eth_getBlockByNumber", ["latest", True])``.
 
 
 LegacyWebSocketProvider

--- a/newsfragments/3433.breaking.rst
+++ b/newsfragments/3433.breaking.rst
@@ -1,0 +1,1 @@
+Refactor the public ``socket`` api for persistent connection providers to properly define ``send()``, ``recv()``, and ``make_request()`` (send and wait for response) methods for interacting with the open socket.

--- a/newsfragments/3433.feature.rst
+++ b/newsfragments/3433.feature.rst
@@ -1,0 +1,1 @@
+Add ``popitem()`` functionality to the ``SimpleCache`` class as well as an async utility method to wait for the next item, ``async_await_and_popitem()``.

--- a/newsfragments/3433.internal.rst
+++ b/newsfragments/3433.internal.rst
@@ -1,0 +1,1 @@
+Refactor some common logic for persistent connection providers back into the base ``PersistentConnectionProvider`` class to reduce code duplication and improve maintainability.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -64,3 +64,14 @@ def event_loop():
     loop = asyncio.get_event_loop_policy().new_event_loop()
     yield loop
     loop.close()
+
+
+@pytest.fixture(autouse=True)
+def _async_test_setup(request) -> None:
+    # Check if the 'async_w3' fixture is available in the current context
+    if "async_w3" in request.fixturenames:
+        async_w3 = request.getfixturevalue("async_w3")
+        if hasattr(async_w3.provider, "_request_processor"):
+            # Clear the request processor cache for persistent connection provider tests
+            async_w3.provider._request_processor.clear_caches()
+    yield

--- a/web3/_utils/module_testing/persistent_connection_provider.py
+++ b/web3/_utils/module_testing/persistent_connection_provider.py
@@ -364,39 +364,10 @@ class PersistentConnectionProviderTest:
         async_w3.middleware_onion.remove("poa_middleware")
 
     @pytest.mark.asyncio
-    async def test_public_socket_api(self, async_w3: "AsyncWeb3") -> None:
-        async_w3.provider._request_processor.clear_caches()
-
-        # send a request over the socket
-        await async_w3.socket.send(
-            RPCEndpoint("eth_getBlockByNumber"), ["latest", True]
-        )
-
-        # recv and validate the unprocessed response
-        response = await async_w3.socket.recv()
-        assert "id" in response, "Expected 'id' key in response."
-        assert "jsonrpc" in response, "Expected 'jsonrpc' key in response."
-        assert "result" in response, "Expected 'result' key in response."
-        assert all(k in response["result"].keys() for k in SOME_BLOCK_KEYS)
-        assert not isinstance(response["result"]["number"], int)  # assert not processed
-
-        # make a request over the socket
-        response = await async_w3.socket.make_request(
-            RPCEndpoint("eth_getBlockByNumber"), ["latest", True]
-        )
-        assert "id" in response, "Expected 'id' key in response."
-        assert "jsonrpc" in response, "Expected 'jsonrpc' key in response."
-        assert "result" in response, "Expected 'result' key in response."
-        assert all(k in response["result"].keys() for k in SOME_BLOCK_KEYS)
-        assert not isinstance(response["result"]["number"], int)  # assert not processed
-
-    @pytest.mark.asyncio
     async def test_asyncio_gather_for_multiple_requests_matches_the_responses(
         self,
         async_w3: "AsyncWeb3",
     ) -> None:
-        async_w3.provider._request_processor.clear_caches()
-
         (
             latest,
             chain_id,
@@ -427,3 +398,28 @@ class PersistentConnectionProviderTest:
         assert isinstance(chain_id, int)
         assert isinstance(chain_id2, int)
         assert isinstance(chain_id3, int)
+
+    @pytest.mark.asyncio
+    async def test_public_socket_api(self, async_w3: "AsyncWeb3") -> None:
+        # send a request over the socket
+        await async_w3.socket.send(
+            RPCEndpoint("eth_getBlockByNumber"), ["latest", True]
+        )
+
+        # recv and validate the unprocessed response
+        response = await async_w3.socket.recv()
+        assert "id" in response, "Expected 'id' key in response."
+        assert "jsonrpc" in response, "Expected 'jsonrpc' key in response."
+        assert "result" in response, "Expected 'result' key in response."
+        assert all(k in response["result"].keys() for k in SOME_BLOCK_KEYS)
+        assert not isinstance(response["result"]["number"], int)  # assert not processed
+
+        # make a request over the socket
+        response = await async_w3.socket.make_request(
+            RPCEndpoint("eth_getBlockByNumber"), ["latest", True]
+        )
+        assert "id" in response, "Expected 'id' key in response."
+        assert "jsonrpc" in response, "Expected 'jsonrpc' key in response."
+        assert "result" in response, "Expected 'result' key in response."
+        assert all(k in response["result"].keys() for k in SOME_BLOCK_KEYS)
+        assert not isinstance(response["result"]["number"], int)  # assert not processed

--- a/web3/_utils/module_testing/persistent_connection_provider.py
+++ b/web3/_utils/module_testing/persistent_connection_provider.py
@@ -23,12 +23,29 @@ from web3.middleware import (
 )
 from web3.types import (
     FormattedEthSubscriptionResponse,
+    RPCEndpoint,
 )
 
 if TYPE_CHECKING:
     from web3.main import (
         AsyncWeb3,
     )
+
+
+SOME_BLOCK_KEYS = [
+    "number",
+    "hash",
+    "parentHash",
+    "transactionsRoot",
+    "stateRoot",
+    "receiptsRoot",
+    "size",
+    "gasLimit",
+    "gasUsed",
+    "timestamp",
+    "transactions",
+    "baseFeePerGas",
+]
 
 
 class PersistentConnectionProviderTest:
@@ -347,10 +364,39 @@ class PersistentConnectionProviderTest:
         async_w3.middleware_onion.remove("poa_middleware")
 
     @pytest.mark.asyncio
+    async def test_public_socket_api(self, async_w3: "AsyncWeb3") -> None:
+        async_w3.provider._request_processor.clear_caches()
+
+        # send a request over the socket
+        await async_w3.socket.send(
+            RPCEndpoint("eth_getBlockByNumber"), ["latest", True]
+        )
+
+        # recv and validate the unprocessed response
+        response = await async_w3.socket.recv()
+        assert "id" in response, "Expected 'id' key in response."
+        assert "jsonrpc" in response, "Expected 'jsonrpc' key in response."
+        assert "result" in response, "Expected 'result' key in response."
+        assert all(k in response["result"].keys() for k in SOME_BLOCK_KEYS)
+        assert not isinstance(response["result"]["number"], int)  # assert not processed
+
+        # make a request over the socket
+        response = await async_w3.socket.make_request(
+            RPCEndpoint("eth_getBlockByNumber"), ["latest", True]
+        )
+        assert "id" in response, "Expected 'id' key in response."
+        assert "jsonrpc" in response, "Expected 'jsonrpc' key in response."
+        assert "result" in response, "Expected 'result' key in response."
+        assert all(k in response["result"].keys() for k in SOME_BLOCK_KEYS)
+        assert not isinstance(response["result"]["number"], int)  # assert not processed
+
+    @pytest.mark.asyncio
     async def test_asyncio_gather_for_multiple_requests_matches_the_responses(
         self,
         async_w3: "AsyncWeb3",
     ) -> None:
+        async_w3.provider._request_processor.clear_caches()
+
         (
             latest,
             chain_id,
@@ -372,22 +418,8 @@ class PersistentConnectionProviderTest:
         assert isinstance(pending, AttributeDict)
 
         # assert block values
-        some_block_keys = [
-            "number",
-            "hash",
-            "parentHash",
-            "transactionsRoot",
-            "stateRoot",
-            "receiptsRoot",
-            "size",
-            "gasLimit",
-            "gasUsed",
-            "timestamp",
-            "transactions",
-            "baseFeePerGas",
-        ]
-        assert all(k in latest.keys() for k in some_block_keys)
-        assert all(k in pending.keys() for k in some_block_keys)
+        assert all(k in latest.keys() for k in SOME_BLOCK_KEYS)
+        assert all(k in pending.keys() for k in SOME_BLOCK_KEYS)
 
         assert isinstance(block_num, int)
         assert latest["number"] == block_num

--- a/web3/module.py
+++ b/web3/module.py
@@ -138,7 +138,7 @@ def retrieve_async_method_call_fn(
 
             try:
                 method_str = cast(RPCEndpoint, method_str)
-                return await async_w3.manager.send(method_str, params)
+                return await async_w3.manager.socket_request(method_str, params)
             except Exception as e:
                 if (
                     cache_key is not None

--- a/web3/providers/persistent/persistent.py
+++ b/web3/providers/persistent/persistent.py
@@ -1,13 +1,17 @@
 from abc import (
     ABC,
+    abstractmethod,
 )
 import asyncio
+import json
 import logging
 from typing import (
     Any,
     List,
     Optional,
+    Tuple,
     Union,
+    cast,
 )
 
 from websockets import (
@@ -15,7 +19,12 @@ from websockets import (
     WebSocketException,
 )
 
+from web3._utils.batching import (
+    BATCH_REQUEST_ID,
+    sort_batch_response_by_response_ids,
+)
 from web3._utils.caching import (
+    async_handle_request_caching,
     generate_cache_key,
 )
 from web3.exceptions import (
@@ -31,6 +40,7 @@ from web3.providers.persistent.request_processor import (
     RequestProcessor,
 )
 from web3.types import (
+    RPCEndpoint,
     RPCId,
     RPCResponse,
 )
@@ -129,6 +139,44 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
             f"Successfully disconnected from: {self.get_endpoint_uri_or_ipc_path()}"
         )
 
+    @async_handle_request_caching
+    async def make_request(self, method: RPCEndpoint, params: Any) -> RPCResponse:
+        request_data = self.encode_rpc_request(method, params)
+        await self.socket_send(request_data)
+
+        current_request_id = json.loads(request_data)["id"]
+        response = await self._get_response_for_request_id(current_request_id)
+
+        return response
+
+    async def make_batch_request(
+        self, requests: List[Tuple[RPCEndpoint, Any]]
+    ) -> List[RPCResponse]:
+        request_data = self.encode_batch_rpc_request(requests)
+        await self.socket_send(request_data)
+
+        response = cast(
+            List[RPCResponse], await self._get_response_for_request_id(BATCH_REQUEST_ID)
+        )
+        return response
+
+    # -- abstract methods -- #
+
+    @abstractmethod
+    async def socket_send(self, request_data: bytes) -> None:
+        """
+        Send an encoded RPC request to the provider over the persistent connection.
+        """
+        raise NotImplementedError("Must be implemented by subclasses")
+
+    @abstractmethod
+    async def socket_recv(self) -> RPCResponse:
+        """
+        Receive, decode, and return an RPC response from the provider over the
+        persistent connection.
+        """
+        raise NotImplementedError("Must be implemented by subclasses")
+
     # -- private methods -- #
 
     async def _provider_specific_connect(self) -> None:
@@ -137,7 +185,7 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
     async def _provider_specific_disconnect(self) -> None:
         raise NotImplementedError("Must be implemented by subclasses")
 
-    async def _provider_specific_message_listener(self) -> None:
+    async def _provider_specific_socket_reader(self) -> RPCResponse:
         raise NotImplementedError("Must be implemented by subclasses")
 
     def _message_listener_callback(
@@ -159,8 +207,21 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
             # the use of sleep(0) seems to be the most efficient way to yield control
             # back to the event loop to share the loop with other tasks.
             await asyncio.sleep(0)
+
             try:
-                await self._provider_specific_message_listener()
+                response = await self._provider_specific_socket_reader()
+
+                if isinstance(response, list):
+                    response = sort_batch_response_by_response_ids(response)
+
+                subscription = (
+                    response.get("method") == "eth_subscription"
+                    if not isinstance(response, list)
+                    else False
+                )
+                await self._request_processor.cache_raw_response(
+                    response, subscription=subscription
+                )
             except PersistentConnectionClosedOK as e:
                 self.logger.info(
                     "Message listener background task has ended gracefully: "

--- a/web3/providers/persistent/persistent_connection.py
+++ b/web3/providers/persistent/persistent_connection.py
@@ -39,7 +39,7 @@ class PersistentConnection:
 
     async def make_request(self, method: RPCEndpoint, params: Any) -> RPCResponse:
         """
-        Make a request to the persistent connection, returning the response. This method
+        Make a request to the persistent connection and return the response. This method
         does not process the response as it would when invoking a method via the
         appropriate module on the `AsyncWeb3` instance,
         e.g. `w3.eth.get_block("latest")`.
@@ -68,8 +68,9 @@ class PersistentConnection:
         Receive the next unprocessed response for a request from the persistent
         connection.
 
-        :return: RPCResponse: The raw, unprocessed message from the
-                                        persistent connection.
+        :return: The next unprocessed response for a request from the persistent
+                 connection.
+        :rtype: RPCResponse
         """
         return await self._manager.recv()
 
@@ -77,6 +78,7 @@ class PersistentConnection:
         """
         Asynchronous iterator that yields messages from the subscription message stream.
 
-        :return: _AsyncPersistentMessageStream: The subscription message stream.
+        :return: The subscription message stream.
+        :rtype: _AsyncPersistentMessageStream
         """
         return self._manager._persistent_message_stream()

--- a/web3/utils/caching.py
+++ b/web3/utils/caching.py
@@ -1,6 +1,8 @@
+import asyncio
 from collections import (
     OrderedDict,
 )
+import time
 from typing import (
     Any,
     Dict,
@@ -46,8 +48,30 @@ class SimpleCache:
 
         return self._data.pop(key)
 
+    def popitem(self, last: bool = True) -> Tuple[str, Any]:
+        return self._data.popitem(last=last)
+
     def __contains__(self, key: str) -> bool:
         return key in self._data
 
     def __len__(self) -> int:
         return len(self._data)
+
+    # -- async utility methods -- #
+
+    async def async_await_and_popitem(
+        self, last: bool = True, timeout: float = 10.0
+    ) -> Tuple[str, Any]:
+        start = time.time()
+        end_time = start + timeout
+        while True:
+            await asyncio.sleep(0)
+            try:
+                return self.popitem(last=last)
+            except KeyError:
+                now = time.time()
+                if now >= end_time:
+                    raise asyncio.TimeoutError(
+                        "Timeout waiting for item to be available"
+                    )
+                await asyncio.sleep(min(0.1, end_time - now))


### PR DESCRIPTION
- Refactor shared logic for persistent connection providers back into the `PersistentConnectionProvider` base class.
- Refactor reading from and sending to the socket into their own methods. Add these as abstract methods on the base class and force subclasses to implement them.

Important:

- Refactor the public `socket` API (`PersistentConnection` class) to properly define a `send()`, `recv()`, and `make_request()` which do what they say they do. Previously, `send()` was actually a "send_and_recv()" method. This was confusing and not a good API design. Note, these methods don't and cannot process the response in the way that invoking a method via its module within the web3 class does.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20240717_100804](https://github.com/user-attachments/assets/6321a033-a9f5-40cb-9d49-9e1e1ddb6e9c)