### PR TITLE
Update the ipfs version used in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,8 +170,8 @@ ethpm_steps: &ethpm_steps
     - run:
         name: install ipfs
         command:
-          wget https://dist.ipfs.io/go-ipfs/v0.7.0/go-ipfs_v0.7.0_linux-amd64.tar.gz &&
-          tar xvfz go-ipfs_v0.7.0_linux-amd64.tar.gz &&
+          wget https://dist.ipfs.io/go-ipfs/v0.29.0/go-ipfs_v0.29.0_linux-amd64.tar.gz &&
+          tar xvfz go-ipfs_v0.29.0_linux-amd64.tar.gz &&
           sudo cp go-ipfs/ipfs /usr/local/bin &&
           ipfs init
     - run:

--- a/newsfragments/3437.internal.rst
+++ b/newsfragments/3437.internal.rst
@@ -1,0 +1,1 @@
+Update the ``ipfs`` version used in CircleCI for ``ethpm`` tests from ``v0.7.0`` to ``v0.29.0``.


### PR DESCRIPTION
### What was wrong?

Connecting to `ipfs` started failing as of this morning.

### How was it fixed?

It just took some waiting and re-running the tests.

We are using quite an old version of `ipfs` for CircleCI ``ethpm`` builds though so this PR updates it from ``v0.7.0`` to ``v0.29.0``.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20240718_143926](https://github.com/user-attachments/assets/c73a40b5-07ce-4c4e-9dfc-83cb24731ff3)