### PR TITLE
see what latest eth-account updates break for v6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     install_requires=[
         "aiohttp>=3.7.4.post0",
         "eth-abi>=4.0.0",
-        "eth-account>=0.8.0,<0.13",
+        "eth-account @ git+https://github.com/ethereum/eth-account.git@main#egg=eth-account",
         "eth-hash[pycryptodome]>=0.5.1",
         "eth-typing>=3.0.0,!=4.2.0",
         "eth-utils>=2.1.0",


### PR DESCRIPTION
test PR to see what latest eth-account updates break in v6. Apparently everything. But eth-account is already pinned, so no worries in releasing a new minor there.

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
