### PR TITLE
Attempt to address some of the consistently flaky integration tests

### DIFF
--- a/newsfragments/3440.feature.rst
+++ b/newsfragments/3440.feature.rst
@@ -1,0 +1,1 @@
+Implement a ``RequestTimedOut`` exception, extending from ``Web3RPCError``, for when requests to the node time out.

--- a/newsfragments/3440.internal.rst
+++ b/newsfragments/3440.internal.rst
@@ -1,0 +1,1 @@
+Mitigate inconsistently failing tests for CI runs with appropriate ``flaky`` or ``pytest.mark.xfail()`` decorators.

--- a/tests/core/manager/test_response_formatters.py
+++ b/tests/core/manager/test_response_formatters.py
@@ -16,6 +16,7 @@ from web3.exceptions import (
     BlockNotFound,
     ContractLogicError,
     MethodUnavailable,
+    RequestTimedOut,
     TransactionNotFound,
     Web3RPCError,
 )
@@ -76,6 +77,10 @@ ERROR_RESPONSE_VALID_ID_NONE = merge(VALID_ERROR_RESPONSE, {"id": None})
 ERROR_RESPONSE_VALID_METHOD_UNAVAILABLE = merge(
     VALID_ERROR_RESPONSE,
     {"error": {"code": -32601, "message": (METHOD_UNAVAILABLE_MSG)}},
+)
+ERROR_RESPONSE_REQUEST_TIMED_OUT = merge(
+    VALID_ERROR_RESPONSE,
+    {"error": {"code": -32002, "message": "Request timed out."}},
 )
 ERROR_RESPONSE_INVALID_ID = merge(VALID_ERROR_RESPONSE, {"id": b"invalid"})
 
@@ -189,6 +194,11 @@ def test_formatted_response_invalid_response_object(w3, response, error, error_m
             ERROR_RESPONSE_VALID_METHOD_UNAVAILABLE,
             MethodUnavailable,
             METHOD_UNAVAILABLE_MSG,
+        ),
+        (
+            ERROR_RESPONSE_REQUEST_TIMED_OUT,
+            RequestTimedOut,
+            f'{ERROR_RESPONSE_REQUEST_TIMED_OUT["error"]}',
         ),
     ),
 )

--- a/tests/core/manager/test_response_formatters.py
+++ b/tests/core/manager/test_response_formatters.py
@@ -84,7 +84,9 @@ ERROR_RESPONSE_REQUEST_TIMED_OUT = merge(
 )
 ERROR_RESPONSE_INVALID_ID = merge(VALID_ERROR_RESPONSE, {"id": b"invalid"})
 
-ERROR_RESPONSE_INVALID_CODE = merge(VALID_ERROR_RESPONSE, {"error": {"code": "-32601"}})
+ERROR_RESPONSE_INVALID_CODE = merge(
+    VALID_ERROR_RESPONSE, {"error": {"code": "-32601", "message": ""}}
+)
 ERROR_RESPONSE_INVALID_MISSING_CODE = merge(
     VALID_ERROR_RESPONSE, {"error": {"message": "msg"}}
 )

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -500,6 +500,7 @@ class AsyncEthModuleTest:
             "maxFeePerGas": async_w3.to_wei(3, "gwei"),
             "maxPriorityFeePerGas": async_w3.to_wei(1, "gwei"),
         }
+
         txn_hash = await async_w3.eth.send_transaction(txn_params)
         txn = await async_w3.eth.get_transaction(txn_hash)
 
@@ -509,7 +510,7 @@ class AsyncEthModuleTest:
         assert txn["gas"] == 21000
         assert txn["maxFeePerGas"] == txn_params["maxFeePerGas"]
         assert txn["maxPriorityFeePerGas"] == txn_params["maxPriorityFeePerGas"]
-        assert txn["gasPrice"] == txn_params["maxFeePerGas"]
+        assert txn["gasPrice"] <= txn["maxFeePerGas"]  # effective gas price
 
     @pytest.mark.asyncio
     async def test_eth_send_transaction_default_fees(
@@ -523,6 +524,7 @@ class AsyncEthModuleTest:
             "value": Wei(1),
             "gas": 21000,
         }
+
         txn_hash = await async_w3.eth.send_transaction(txn_params)
         txn = await async_w3.eth.get_transaction(txn_hash)
 
@@ -532,7 +534,7 @@ class AsyncEthModuleTest:
         assert txn["gas"] == 21000
         assert is_integer(txn["maxPriorityFeePerGas"])
         assert is_integer(txn["maxFeePerGas"])
-        assert txn["gasPrice"] == txn["maxFeePerGas"]
+        assert txn["gasPrice"] <= txn["maxFeePerGas"]  # effective gas price
 
     @pytest.mark.asyncio
     async def test_eth_send_transaction_hex_fees(
@@ -809,7 +811,7 @@ class AsyncEthModuleTest:
             else 2 * latest_block["baseFeePerGas"] + max_priority_fee
         )
         assert txn["maxPriorityFeePerGas"] == max_priority_fee
-        assert txn["gasPrice"] == txn["maxFeePerGas"]
+        assert txn["gasPrice"] <= txn["maxFeePerGas"]  # effective gas price
 
         async_w3.eth.set_gas_price_strategy(None)  # reset strategy
 
@@ -3114,6 +3116,7 @@ class EthModuleTest:
             "maxFeePerGas": w3.to_wei(3, "gwei"),
             "maxPriorityFeePerGas": w3.to_wei(1, "gwei"),
         }
+
         txn_hash = w3.eth.send_transaction(txn_params)
         txn = w3.eth.get_transaction(txn_hash)
 
@@ -3123,7 +3126,7 @@ class EthModuleTest:
         assert txn["gas"] == 21000
         assert txn["maxFeePerGas"] == txn_params["maxFeePerGas"]
         assert txn["maxPriorityFeePerGas"] == txn_params["maxPriorityFeePerGas"]
-        assert txn["gasPrice"] == txn_params["maxFeePerGas"]
+        assert txn["gasPrice"] <= txn["maxFeePerGas"]  # effective gas price
 
     def test_eth_send_transaction_with_nonce(
         self, w3: "Web3", keyfile_account_address: ChecksumAddress
@@ -3174,7 +3177,7 @@ class EthModuleTest:
         assert txn["gas"] == 21000
         assert is_integer(txn["maxPriorityFeePerGas"])
         assert is_integer(txn["maxFeePerGas"])
-        assert txn["gasPrice"] == txn["maxFeePerGas"]
+        assert txn["gasPrice"] <= txn["maxFeePerGas"]  # effective gas price
 
     def test_eth_send_transaction_hex_fees(
         self, w3: "Web3", keyfile_account_address_dual_type: ChecksumAddress
@@ -3340,7 +3343,7 @@ class EthModuleTest:
             else 2 * latest_block["baseFeePerGas"] + max_priority_fee
         )
         assert txn["maxPriorityFeePerGas"] == max_priority_fee
-        assert txn["gasPrice"] == txn["maxFeePerGas"]
+        assert txn["gasPrice"] <= txn["maxFeePerGas"]  # effective gas price
 
         w3.eth.set_gas_price_strategy(None)  # reset strategy
 

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -1692,6 +1692,7 @@ class AsyncEthModuleTest:
         assert isinstance(effective_gas_price, int)
         assert effective_gas_price > 0
 
+    @flaky_geth_dev_mining
     @pytest.mark.asyncio
     async def test_async_eth_get_transaction_receipt_unmined(
         self,
@@ -1757,6 +1758,7 @@ class AsyncEthModuleTest:
         assert isinstance(effective_gas_price, int)
         assert effective_gas_price > 0
 
+    @flaky_geth_dev_mining
     @pytest.mark.asyncio
     async def test_async_eth_wait_for_transaction_receipt_unmined(
         self,
@@ -3596,7 +3598,6 @@ class EthModuleTest:
         self, w3: "Web3", keyfile_account_address: ChecksumAddress
     ) -> None:
         gas_price = w3.to_wei(2, "gwei")
-
         txn_params: TxParams = {
             "from": keyfile_account_address,
             "to": keyfile_account_address,
@@ -4360,6 +4361,7 @@ class EthModuleTest:
         assert isinstance(effective_gas_price, int)
         assert effective_gas_price > 0
 
+    @flaky_geth_dev_mining
     def test_eth_get_transaction_receipt_unmined(
         self, w3: "Web3", keyfile_account_address_dual_type: ChecksumAddress
     ) -> None:
@@ -4417,6 +4419,7 @@ class EthModuleTest:
         assert isinstance(effective_gas_price, int)
         assert effective_gas_price > 0
 
+    @flaky_geth_dev_mining
     def test_eth_wait_for_transaction_receipt_unmined(
         self, w3: "Web3", keyfile_account_address_dual_type: ChecksumAddress
     ) -> None:

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -58,6 +58,7 @@ from web3._utils.module_testing.module_testing_utils import (
     assert_contains_log,
     async_mock_offchain_lookup_request_response,
     flaky_geth_dev_mining,
+    flaky_with_xfail_on_exception,
     mock_offchain_lookup_request_response,
 )
 from web3._utils.module_testing.utils import (
@@ -2359,10 +2360,9 @@ class AsyncEthModuleTest:
         with pytest.raises(Web3ValueError):
             await async_w3.eth.replace_transaction(txn_hash, txn_params)
 
-    @pytest.mark.xfail(
-        reason="Very flaky on CI runs, hard to reproduce locally",
-        strict=False,
-        raises=(RequestTimedOut, asyncio.TimeoutError, Web3ValueError),
+    @flaky_with_xfail_on_exception(
+        reason="Very flaky on CI runs, hard to reproduce locally.",
+        exception=RequestTimedOut,
     )
     @pytest.mark.asyncio
     async def test_async_eth_replace_transaction_gas_price_defaulting_minimum(
@@ -2387,10 +2387,9 @@ class AsyncEthModuleTest:
             gas_price * 1.125
         )  # minimum gas price
 
-    @pytest.mark.xfail(
-        reason="Very flaky on CI runs, hard to reproduce locally",
-        strict=False,
-        raises=(RequestTimedOut, asyncio.TimeoutError, Web3ValueError),
+    @flaky_with_xfail_on_exception(
+        reason="Very flaky on CI runs, hard to reproduce locally.",
+        exception=RequestTimedOut,
     )
     @pytest.mark.asyncio
     async def test_async_eth_replace_transaction_gas_price_defaulting_strategy_higher(
@@ -2420,10 +2419,9 @@ class AsyncEthModuleTest:
         )  # Strategy provides higher gas price
         async_w3.eth.set_gas_price_strategy(None)  # reset strategy
 
-    @pytest.mark.xfail(
-        reason="Very flaky on CI runs, hard to reproduce locally",
-        strict=False,
-        raises=(RequestTimedOut, asyncio.TimeoutError, Web3ValueError),
+    @flaky_with_xfail_on_exception(
+        reason="Very flaky on CI runs, hard to reproduce locally.",
+        exception=RequestTimedOut,
     )
     @pytest.mark.asyncio
     async def test_async_eth_replace_transaction_gas_price_defaulting_strategy_lower(

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -2358,7 +2358,9 @@ class AsyncEthModuleTest:
         with pytest.raises(Web3ValueError):
             await async_w3.eth.replace_transaction(txn_hash, txn_params)
 
-    @flaky_geth_dev_mining
+    @pytest.mark.xfail(
+        reason="Very flaky on CI runs, hard to reproduce locally", strict=False
+    )
     @pytest.mark.asyncio
     async def test_async_eth_replace_transaction_gas_price_defaulting_minimum(
         self, async_w3: "AsyncWeb3", async_keyfile_account_address: ChecksumAddress
@@ -2382,7 +2384,9 @@ class AsyncEthModuleTest:
             gas_price * 1.125
         )  # minimum gas price
 
-    @flaky_geth_dev_mining
+    @pytest.mark.xfail(
+        reason="Very flaky on CI runs, hard to reproduce locally", strict=False
+    )
     @pytest.mark.asyncio
     async def test_async_eth_replace_transaction_gas_price_defaulting_strategy_higher(
         self, async_w3: "AsyncWeb3", async_keyfile_account_address: ChecksumAddress
@@ -2411,7 +2415,9 @@ class AsyncEthModuleTest:
         )  # Strategy provides higher gas price
         async_w3.eth.set_gas_price_strategy(None)  # reset strategy
 
-    @flaky_geth_dev_mining
+    @pytest.mark.xfail(
+        reason="Very flaky on CI runs, hard to reproduce locally", strict=False
+    )
     @pytest.mark.asyncio
     async def test_async_eth_replace_transaction_gas_price_defaulting_strategy_lower(
         self, async_w3: "AsyncWeb3", async_keyfile_account_address: ChecksumAddress

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -76,6 +76,7 @@ from web3.exceptions import (
     MultipleFailedRequests,
     NameNotFound,
     OffchainLookup,
+    RequestTimedOut,
     TimeExhausted,
     TooManyRequests,
     TransactionNotFound,
@@ -2359,7 +2360,9 @@ class AsyncEthModuleTest:
             await async_w3.eth.replace_transaction(txn_hash, txn_params)
 
     @pytest.mark.xfail(
-        reason="Very flaky on CI runs, hard to reproduce locally", strict=False
+        reason="Very flaky on CI runs, hard to reproduce locally",
+        strict=False,
+        raises=(RequestTimedOut, asyncio.TimeoutError, Web3ValueError),
     )
     @pytest.mark.asyncio
     async def test_async_eth_replace_transaction_gas_price_defaulting_minimum(
@@ -2385,7 +2388,9 @@ class AsyncEthModuleTest:
         )  # minimum gas price
 
     @pytest.mark.xfail(
-        reason="Very flaky on CI runs, hard to reproduce locally", strict=False
+        reason="Very flaky on CI runs, hard to reproduce locally",
+        strict=False,
+        raises=(RequestTimedOut, asyncio.TimeoutError, Web3ValueError),
     )
     @pytest.mark.asyncio
     async def test_async_eth_replace_transaction_gas_price_defaulting_strategy_higher(
@@ -2416,7 +2421,9 @@ class AsyncEthModuleTest:
         async_w3.eth.set_gas_price_strategy(None)  # reset strategy
 
     @pytest.mark.xfail(
-        reason="Very flaky on CI runs, hard to reproduce locally", strict=False
+        reason="Very flaky on CI runs, hard to reproduce locally",
+        strict=False,
+        raises=(RequestTimedOut, asyncio.TimeoutError, Web3ValueError),
     )
     @pytest.mark.asyncio
     async def test_async_eth_replace_transaction_gas_price_defaulting_strategy_lower(

--- a/web3/_utils/module_testing/module_testing_utils.py
+++ b/web3/_utils/module_testing/module_testing_utils.py
@@ -1,12 +1,17 @@
 import asyncio
+import functools
+import pytest
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Collection,
     Dict,
     Generator,
     Literal,
     Sequence,
+    Tuple,
+    Type,
     Union,
 )
 
@@ -55,7 +60,44 @@ flaky_geth_dev_mining decorator for tests requiring a pending block
 for the duration of the test. This behavior can be flaky
 due to timing of the test running as a block is mined.
 """
-flaky_geth_dev_mining = flaky(max_runs=3)
+flaky_geth_dev_mining = flaky(max_runs=3, min_passes=1)
+
+
+def flaky_with_xfail_on_exception(
+    reason: str,
+    exception: Union[Type[Exception], Tuple[Type[Exception], ...]],
+    max_runs: int = 3,
+    min_passes: int = 1,
+) -> Callable[[Any], Any]:
+    """
+    Some tests inconsistently fail hard with a particular exception and retrying
+    these tests often times does not get them "unstuck". If we've exhausted all flaky
+    retries and this expected exception is raised, `xfail` the test with the given
+    reason.
+    """
+    runs = max_runs
+
+    def decorator(func: Any) -> Any:
+        @flaky(max_runs=max_runs, min_passes=min_passes)
+        @functools.wraps(func)
+        async def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+            nonlocal runs
+            try:
+                return await func(self, *args, **kwargs)
+            except exception:
+                # xfail the test only if the exception is raised and we have exhausted
+                # all flaky retries
+                if runs == 1:
+                    pytest.xfail(reason)
+                runs -= 1
+                pytest.fail(f"xfailed but {runs} run(s) remaining with flaky...")
+            except Exception as e:
+                # let flaky handle it
+                raise e
+
+        return wrapper
+
+    return decorator
 
 
 def assert_contains_log(

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -364,6 +364,12 @@ class MethodUnavailable(Web3RPCError):
     """
 
 
+class RequestTimedOut(Web3RPCError):
+    """
+    Raised when a request to the node times out.
+    """
+
+
 class TransactionNotFound(Web3RPCError):
     """
     Raised when a tx hash used to look up a tx in a jsonrpc call cannot be found.

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -204,6 +204,13 @@ def _validate_response(
                 "JSON-RPC 2.0 specification.",
             )
 
+        # errors must include a message
+        error_message = error.get("message")
+        if not isinstance(error_message, str):
+            _raise_bad_response_format(
+                response, 'error["message"] is required and must be a string value.'
+            )
+
         # errors must include an integer code
         code = error.get("code")
         if not isinstance(code, int):
@@ -220,15 +227,7 @@ def _validate_response(
                     "currently enabled."
                 ),
             )
-
-        # errors must include a message
-        error_message = error.get("message")
-        if not isinstance(error_message, str):
-            _raise_bad_response_format(
-                response, 'error["message"] is required and must be a string value.'
-            )
-
-        if any(
+        elif any(
             # parse specific timeout messages
             timeout_str in error_message.lower()
             for timeout_str in KNOWN_REQUEST_TIMEOUT_MESSAGING


### PR DESCRIPTION
### What was wrong?

Some of our integration tests dealing with the way `geth --dev` mines within an interval window flaky and still not passing with a flaky decorator in some cases. I'm going to try to run this branch many times and try to address them here.

### How was it fixed?

- Add flaky geth dev mining decorator to receipt unmined tests (cadf7f8215e69f085cb20a3ee2d54a1cf8509559)
- Mark certain very flaky tests with `xfail` + `strict=False` (899a909b7b9a6b1aeea23c2bbbb795b66e410c37)
- Some tests were incorrectly checking that the `gasPrice` on dynamic fee transactions was equal to the `maxFeePerGas`. Really, it's the minimum between the `maxFeePerGas` and `maxPriorityFeePerGas` + `baseFeePerGas` (block), which is the "effective gas price". Use `<=` in that comparison.

Feature:

- Introduce a ``RequestTimedOut`` exception for when requests to the node time out.
- Use this exception in ``xfail`` tests that fail specifically with a client-side timeout to distinguish the fail case. It isn't possible to use `xfail` _and_ `flaky` on the same test out-of-the-box and have them work well enough. This PR adds a decorator that:

    - Accepts flaky arguments `max_runs` and `min_passes` and retries the test according to flaky rules.
    - Accepts an exception that if by the last `flaky` retry, if this particular exception is raised, it `xfails` the test with a given `reason` string argument, as is also accepted by `xfail`.

What this means is that we can retry a test up to `max_runs` times, but if by the end of it we have some flaky exception case that is sometimes expected, we `xfail` the test and it silently fails for that test run.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20240719_153530](https://github.com/user-attachments/assets/20b2577e-33f5-4c36-b04a-d03e014a0bb3)
