### PR TITLE
Allow ContractFunctions to be called via a combomethod style

### DIFF
--- a/docs/web3.contract.rst
+++ b/docs/web3.contract.rst
@@ -679,6 +679,16 @@ If you have the function name in a variable, you might prefer this alternative:
         contract_func = myContract.functions[func_to_call]
         twentyone = contract_func(3).call()
 
+You can also interact with contract functions without parentheses if the function doesn't
+take any arguments. For example:
+
+    .. code-block:: python
+
+        >>> myContract.functions.return13.call()
+        13
+        >>> myContract.functions.return13().call()
+        13
+
 :py:class:`ContractFunction` provides methods to interact with contract functions.
 Positional and keyword arguments supplied to the contract function subclass
 will be used to find the contract function by signature,

--- a/newsfragments/3444.feature.rst
+++ b/newsfragments/3444.feature.rst
@@ -1,0 +1,1 @@
+Allow user to call ContractFunctions without parentheses

--- a/tests/core/contracts/test_contract_build_transaction.py
+++ b/tests/core/contracts/test_contract_build_transaction.py
@@ -53,6 +53,20 @@ def test_build_transaction_with_contract_no_arguments(
     }
 
 
+def test_build_transaction_with_contract_no_arguments_no_parens(
+    w3, math_contract, build_transaction
+):
+    txn = math_contract.functions.incrementCounter.build_transaction()
+    assert dissoc(txn, "gas") == {
+        "to": math_contract.address,
+        "data": "0x5b34b966",
+        "value": 0,
+        "maxFeePerGas": 2750000000,
+        "maxPriorityFeePerGas": 10**9,
+        "chainId": 131277322940537,
+    }
+
+
 def test_build_transaction_with_contract_fallback_function(
     w3, fallback_function_contract
 ):
@@ -299,6 +313,21 @@ async def test_async_build_transaction_with_contract_no_arguments(
     txn = await async_build_transaction(
         contract=async_math_contract, contract_function="incrementCounter"
     )
+    assert dissoc(txn, "gas") == {
+        "to": async_math_contract.address,
+        "data": "0x5b34b966",
+        "value": 0,
+        "maxFeePerGas": 2750000000,
+        "maxPriorityFeePerGas": 10**9,
+        "chainId": 131277322940537,
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_build_transaction_with_contract_no_arguments_no_parens(
+    async_w3, async_math_contract, async_build_transaction
+):
+    txn = await async_math_contract.functions.incrementCounter.build_transaction()
     assert dissoc(txn, "gas") == {
         "to": async_math_contract.address,
         "data": "0x5b34b966",

--- a/tests/core/contracts/test_contract_call_interface.py
+++ b/tests/core/contracts/test_contract_call_interface.py
@@ -145,6 +145,10 @@ def test_call_with_no_arguments(math_contract, call):
     assert result == 13
 
 
+def test_call_no_arguments_no_parens(math_contract):
+    assert math_contract.functions.return13.call() == 13
+
+
 def test_call_with_one_argument(math_contract, call):
     result = call(contract=math_contract, contract_function="multiply7", func_args=[3])
     assert result == 21
@@ -2284,6 +2288,12 @@ async def test_async_call_revert_contract(async_revert_contract):
 @pytest.mark.asyncio
 async def test_async_call_with_no_arguments(async_math_contract, call):
     result = await async_math_contract.functions.return13().call()
+    assert result == 13
+
+
+@pytest.mark.asyncio
+async def test_async_call_with_no_arguments_no_parens(async_math_contract, call):
+    result = await async_math_contract.functions.return13.call()
     assert result == 13
 
 

--- a/tests/core/contracts/test_contract_estimate_gas.py
+++ b/tests/core/contracts/test_contract_estimate_gas.py
@@ -18,6 +18,19 @@ def test_contract_estimate_gas(w3, math_contract, estimate_gas, transact):
     assert abs(gas_estimate - gas_used) < 21000
 
 
+def test_estimate_gas_can_be_called_without_parens(
+    w3, math_contract, estimate_gas, transact
+):
+    gas_estimate = math_contract.functions.incrementCounter.estimate_gas()
+
+    txn_hash = transact(contract=math_contract, contract_function="incrementCounter")
+
+    txn_receipt = w3.eth.wait_for_transaction_receipt(txn_hash)
+    gas_used = txn_receipt.get("gasUsed")
+
+    assert abs(gas_estimate - gas_used) < 21000
+
+
 def test_contract_fallback_estimate_gas(w3, fallback_function_contract):
     gas_estimate = fallback_function_contract.fallback.estimate_gas()
 
@@ -184,6 +197,24 @@ async def test_async_estimate_gas_accepts_latest_block(
     async_w3, async_math_contract, async_transact
 ):
     gas_estimate = await async_math_contract.functions.counter().estimate_gas(
+        block_identifier="latest"
+    )
+
+    txn_hash = await async_transact(
+        contract=async_math_contract, contract_function="incrementCounter"
+    )
+
+    txn_receipt = await async_w3.eth.wait_for_transaction_receipt(txn_hash)
+    gas_used = txn_receipt.get("gasUsed")
+
+    assert abs(gas_estimate - gas_used) < 21000
+
+
+@pytest.mark.asyncio
+async def test_async_estimate_gas_can_be_called_without_parens(
+    async_w3, async_math_contract, async_transact
+):
+    gas_estimate = await async_math_contract.functions.counter.estimate_gas(
         block_identifier="latest"
     )
 

--- a/tests/core/contracts/test_contract_transact_interface.py
+++ b/tests/core/contracts/test_contract_transact_interface.py
@@ -285,6 +285,17 @@ def test_receive_contract_with_fallback_function(receive_function_contract, call
     assert final_value == "receive"
 
 
+def test_contract_can_transact_without_fn_parens(w3, math_contract, call):
+    initial_value = call(contract=math_contract, contract_function="counter")
+    txn_hash = math_contract.functions.incrementCounter.transact()
+    txn_receipt = w3.eth.wait_for_transaction_receipt(txn_hash)
+    assert txn_receipt is not None
+
+    final_value = call(contract=math_contract, contract_function="counter")
+
+    assert final_value - initial_value == 1
+
+
 @pytest.mark.asyncio
 async def test_async_transacting_with_contract_no_arguments(
     async_w3, async_math_contract, async_transact, async_call
@@ -296,6 +307,25 @@ async def test_async_transacting_with_contract_no_arguments(
     txn_hash = await async_transact(
         contract=async_math_contract, contract_function="incrementCounter"
     )
+    txn_receipt = await async_w3.eth.wait_for_transaction_receipt(txn_hash)
+    assert txn_receipt is not None
+
+    final_value = await async_call(
+        contract=async_math_contract, contract_function="counter"
+    )
+
+    assert final_value - initial_value == 1
+
+
+@pytest.mark.asyncio
+async def test_async_transacting_with_contract_no_arguments_no_parens(
+    async_w3, async_math_contract, async_transact, async_call
+):
+    initial_value = await async_call(
+        contract=async_math_contract, contract_function="counter"
+    )
+
+    txn_hash = await async_math_contract.functions.incrementCounter.transact()
     txn_receipt = await async_w3.eth.wait_for_transaction_receipt(txn_hash)
     assert txn_receipt is not None
 

--- a/web3/contract/async_contract.py
+++ b/web3/contract/async_contract.py
@@ -319,8 +319,8 @@ class AsyncContractFunction(BaseContractFunction):
             state_override,
             ccip_read_enabled,
             self.decode_tuples,
-            *self.args,
-            **self.kwargs,
+            *self.args or (),
+            **self.kwargs or {},
         )
 
     async def transact(self, transaction: Optional[TxParams] = None) -> HexBytes:
@@ -332,8 +332,8 @@ class AsyncContractFunction(BaseContractFunction):
             setup_transaction,
             self.contract_abi,
             self.abi,
-            *self.args,
-            **self.kwargs,
+            *self.args or (),
+            **self.kwargs or {},
         )
 
     async def estimate_gas(
@@ -352,8 +352,8 @@ class AsyncContractFunction(BaseContractFunction):
             self.abi,
             block_identifier,
             state_override,
-            *self.args,
-            **self.kwargs,
+            *self.args or (),
+            **self.kwargs or {},
         )
 
     async def build_transaction(
@@ -367,8 +367,8 @@ class AsyncContractFunction(BaseContractFunction):
             built_transaction,
             self.contract_abi,
             self.abi,
-            *self.args,
-            **self.kwargs,
+            *self.args or (),
+            **self.kwargs or {},
         )
 
     @staticmethod

--- a/web3/contract/contract.py
+++ b/web3/contract/contract.py
@@ -318,12 +318,13 @@ class ContractFunction(BaseContractFunction):
             state_override,
             ccip_read_enabled,
             self.decode_tuples,
-            *self.args,
-            **self.kwargs,
+            *self.args or (),
+            **self.kwargs or {},
         )
 
     def transact(self, transaction: Optional[TxParams] = None) -> HexBytes:
         setup_transaction = self._transact(transaction)
+
         return transact_with_contract_function(
             self.address,
             self.w3,
@@ -331,8 +332,8 @@ class ContractFunction(BaseContractFunction):
             setup_transaction,
             self.contract_abi,
             self.abi,
-            *self.args,
-            **self.kwargs,
+            *self.args or (),
+            **self.kwargs or {},
         )
 
     def estimate_gas(
@@ -351,12 +352,13 @@ class ContractFunction(BaseContractFunction):
             self.abi,
             block_identifier,
             state_override,
-            *self.args,
-            **self.kwargs,
+            *self.args or (),
+            **self.kwargs or {},
         )
 
     def build_transaction(self, transaction: Optional[TxParams] = None) -> TxParams:
         built_transaction = self._build_transaction(transaction)
+
         return build_transaction_for_function(
             self.address,
             self.w3,
@@ -364,8 +366,8 @@ class ContractFunction(BaseContractFunction):
             built_transaction,
             self.contract_abi,
             self.abi,
-            *self.args,
-            **self.kwargs,
+            *self.args or (),
+            **self.kwargs or {},
         )
 
     @staticmethod


### PR DESCRIPTION
### What was wrong?
We've agreed that it would be nice if ContractFunctions can be called both with and without parentheses if the function doesn't take arguments or keyword arguments. Both examples are okay below:
 
`myContract.functions.myFnName().call()`
`myContract.functions.myFnName.call()` 


Related to Issue #2545 
Closes #2541

### How was it fixed?

Added a tuple or a dict as fallback if either `**args` or `**kwargs` are `None`

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.rd.com/wp-content/uploads/2021/03/GettyImages-1199243328.jpg)
