### PR TITLE
Upgrade eth-typing requirement

### DIFF
--- a/newsfragments/3445.bugfix.rst
+++ b/newsfragments/3445.bugfix.rst
@@ -1,0 +1,1 @@
+Upgrade the eth-typing dependency from 5.0.0-beta.1 -> 5.0.0-beta.3

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         "eth-abi>=5.0.1",
         "eth-account>=0.13.1",
         "eth-hash[pycryptodome]>=0.5.1",
-        "eth-typing>=5.0.0b1",
+        "eth-typing>=5.0.0b3",
         "eth-utils>=5.0.0b1",
         "hexbytes>=1.2.0",
         "pydantic>=2.4.0",


### PR DESCRIPTION
### What was wrong?
Need eth-typing 5.0.0-b.3. 


### How was it fixed?
Upgraded the dependency in setup.py

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/id/834732994/photo/animal-photos.jpg?s=612x612&w=0&k=20&c=ruaXIroAz3NG8VT5HpuS8SS7rulupZygjcbbmbZyrUQ=)
