### PR TITLE
[V6] pin eth-typing <5.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ parameters:
     type: string
   pygeth_version:
     # update default value when updating geth integration test fixture
-    default: "3.13.0"
+    default: ">=3.14.0,<4"
     type: string
   go_version:
     default: "1.20.2"
@@ -91,7 +91,7 @@ geth_steps: &geth_steps
         name: build geth if missing
         command: |
           mkdir -p $HOME/.ethash
-          pip install --user "py-geth>=<< pipeline.parameters.pygeth_version >>"
+          pip install --user "py-geth<< pipeline.parameters.pygeth_version >>"
           export GOROOT=/usr/local/go
           echo << pipeline.parameters.geth_version >>
           export GETH_BINARY="$HOME/.py-geth/geth-<< pipeline.parameters.geth_version >>/bin/geth"

--- a/newsfragments/3449.bugfix.rst
+++ b/newsfragments/3449.bugfix.rst
@@ -1,0 +1,1 @@
+Add upper pins to ``eth-typing``, ``eth-utils``, and ``py-geth`` to prevent latest breaking major versions from installing.

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         "eth-abi>=4.0.0",
         "eth-account>=0.8.0,<0.13",
         "eth-hash[pycryptodome]>=0.5.1",
-        "eth-typing>=3.0.0,!=4.2.0",
+        "eth-typing>=3.0.0,!=4.2.0,<5.0.0",
         "eth-utils>=2.1.0",
         "hexbytes>=0.1.0,<0.4.0",
         "jsonschema>=4.0.0",

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         "eth-account>=0.8.0,<0.13",
         "eth-hash[pycryptodome]>=0.5.1",
         "eth-typing>=3.0.0,!=4.2.0,<5.0.0",
-        "eth-utils>=2.1.0",
+        "eth-utils>=2.1.0,<5",
         "hexbytes>=0.1.0,<0.4.0",
         "jsonschema>=4.0.0",
         "lru-dict>=1.1.6,<1.3.0",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ extras_require = {
     "tester": [
         "eth-tester[py-evm]>=0.9.0b1,<0.10.0b1; python_version <= '3.7'",
         "eth-tester[py-evm]>=0.11.0b1,<0.12.0b1; python_version > '3.7'",
-        "py-geth>=3.14.0",
+        "py-geth>=3.14.0,<4",
     ],
     "docs": [
         "sphinx>=5.3.0",


### PR DESCRIPTION
### What was wrong?

Related to Issue #
Closes #

### How was it fixed?

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cdn.shopify.com/s/files/1/0536/9741/3293/products/Round-Chicken-Plush-2.jpg?v=1660155066)
