### PR TITLE
Updates to ci runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,5 @@
 version: 2.1
 
-# heavily inspired by https://raw.githubusercontent.com/pinax/pinax-wiki/6bd2a99ab6f702e300d708532a6d1d9aa638b9f8/.circleci/config.yml
-
 parameters:
   geth_version:
     # update default value when updating geth integration test fixture
@@ -64,24 +62,38 @@ geth_steps: &geth_steps
           python -m pip install --upgrade pip
           python -m pip install tox
     - run:
-        name: build geth if missing
+        name: setup geth binary
         command: |
-          mkdir -p $HOME/.ethash
-          pip install --user "py-geth>=<< pipeline.parameters.pygeth_version >>"
-          export GOROOT=/usr/local/go
-          echo << pipeline.parameters.geth_version >>
-          export GETH_BINARY="$HOME/.py-geth/geth-<< pipeline.parameters.geth_version >>/bin/geth"
-          if [ ! -e "$GETH_BINARY" ]; then
+          if [ "<< pipeline.parameters.geth_version >>" != "custom" ]; then
+            export GOROOT=/usr/local/go
+            export GETH_BINARY="$HOME/.py-geth/geth-<< pipeline.parameters.geth_version >>/bin/geth"
+            echo "configured geth version: << pipeline.parameters.geth_version >>"
+            if [ ! -e "$GETH_BINARY" ]; then
+              echo "GETH_BINARY not set, installing geth..."
+              curl -O https://storage.googleapis.com/golang/go<< pipeline.parameters.go_version >>.linux-amd64.tar.gz
+              tar xvf go<< pipeline.parameters.go_version >>.linux-amd64.tar.gz
+              sudo chown -R root:root ./go
+              sudo mv go /usr/local
+              sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
+              sudo apt-get update
+              sudo apt-get install -y build-essential
+              pip install --user "py-geth>=<< pipeline.parameters.pygeth_version >>"
+              python -m geth.install << pipeline.parameters.geth_version >>
+            fi
+            sudo ln -s /home/circleci/.py-geth/geth-<< pipeline.parameters.geth_version >>/bin/geth /usr/local/bin/geth
+          else
+            export GOROOT=/usr/local/go
+            export GETH_BINARY="./custom_geth"
+            echo 'export GETH_BINARY="./custom_geth"' >> $BASH_ENV
             curl -O https://storage.googleapis.com/golang/go<< pipeline.parameters.go_version >>.linux-amd64.tar.gz
             tar xvf go<< pipeline.parameters.go_version >>.linux-amd64.tar.gz
             sudo chown -R root:root ./go
             sudo mv go /usr/local
             sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
-            sudo apt-get update;
-            sudo apt-get install -y build-essential;
-            python -m geth.install << pipeline.parameters.geth_version >>;
+            sudo apt-get update
+            sudo apt-get install -y build-essential
           fi
-          sudo ln -s /home/circleci/.py-geth/geth-<< pipeline.parameters.geth_version >>/bin/geth /usr/local/bin/geth
+          echo -e "GETH_BINARY=$GETH_BINARY"
           geth version
     - run:
         name: run tox
@@ -91,96 +103,11 @@ geth_steps: &geth_steps
           - .tox
           - ~/.cache/pip
           - ~/.local
-          - ~/.ethash
           - ~/.py-geth
-        key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
-
-geth_custom_steps: &geth_custom_steps
-  working_directory: ~/repo
-  steps:
-    - checkout
-    - restore_cache:
-        keys:
-          - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
-    - run:
-        name: install dependencies
-        command: |
-          python -m pip install --upgrade pip
-          python -m pip install tox
-    - run:
-        name: use a pre-built geth binary
-        command: |
-          mkdir -p $HOME/.ethash
-          export GOROOT=/usr/local/go
-          export GETH_BINARY="./custom_geth"
-          echo 'export GETH_BINARY="./custom_geth"' >> $BASH_ENV
-          curl -O https://storage.googleapis.com/golang/go<< pipeline.parameters.go_version >>.linux-amd64.tar.gz
-          tar xvf go<< pipeline.parameters.go_version >>.linux-amd64.tar.gz
-          sudo chown -R root:root ./go
-          sudo mv go /usr/local
-          sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
-          sudo apt-get update;
-          sudo apt-get install -y build-essential;
-          ./custom_geth version
-    - run:
-        name: run tox
-        command: python -m tox run -r
-    - save_cache:
-        paths:
-          - .tox
-          - ~/.cache/pip
-          - ~/.local
-          - ~/.ethash
         key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 orbs:
   win: circleci/windows@5.0.0
-
-windows-wheel-steps:
-  windows-wheel-setup: &windows-wheel-setup
-    executor:
-      name: win/default
-      shell: bash.exe
-    working_directory: C:\Users\circleci\project\web3.py
-    environment:
-      TOXENV: windows-wheel
-  restore-cache-step: &restore-cache-step
-    restore_cache:
-      keys:
-        - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
-  install-pyenv-step: &install-pyenv-step
-    run:
-      name: install pyenv
-      command: |
-        pip install pyenv-win --target $HOME/.pyenv
-        echo 'export PYENV="$HOME/.pyenv/pyenv-win/"' >> $BASH_ENV
-        echo 'export PYENV_ROOT="$HOME/.pyenv/pyenv-win/"' >> $BASH_ENV
-        echo 'export PYENV_USERPROFILE="$HOME/.pyenv/pyenv-win/"' >> $BASH_ENV
-        echo 'export PATH="$PATH:$HOME/.pyenv/pyenv-win/bin"' >> $BASH_ENV
-        echo 'export PATH="$PATH:$HOME/.pyenv/pyenv-win/shims"' >> $BASH_ENV
-        source $BASH_ENV
-        pyenv update
-  install-latest-python-step: &install-latest-python-step
-    run:
-      name: install latest python version and tox
-      command: |
-        LATEST_VERSION=$(pyenv install --list | grep -E "${MINOR_VERSION}\.[0-9]+$" | tail -1)
-        echo "installing python version $LATEST_VERSION"
-        pyenv install $LATEST_VERSION
-        pyenv global $LATEST_VERSION
-        python3 -m pip install --upgrade pip
-        python3 -m pip install tox
-  run-tox-step: &run-tox-step
-    run:
-      name: run tox
-      command: |
-        echo 'running tox with' $(python3 --version)
-        python3 -m tox run -r
-  save-cache-step: &save-cache-step
-    save_cache:
-      paths:
-        - .tox
-      key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 docs: &docs
   working_directory: ~/repo
@@ -212,595 +139,128 @@ docs: &docs
   resource_class: xlarge
 
 jobs:
+  common:
+    parameters:
+      python_minor_version:
+        type: string
+      tox_env:
+        type: string
+    <<: *common
+    docker:
+      - image: cimg/python:3.<< parameters.python_minor_version >>
+    environment:
+      TOXENV: py3<< parameters.python_minor_version >>-<< parameters.tox_env >>
+
+  geth:
+    parameters:
+      python_minor_version:
+        type: string
+      tox_env:
+        type: string
+    <<: *geth_steps
+    docker:
+      - image: cimg/python:3.<< parameters.python_minor_version >>
+    environment:
+      TOXENV: py3<< parameters.python_minor_version >>-<< parameters.tox_env >>
+
   docs:
+    parameters:
+      python_minor_version:
+        type: string
     <<: *docs
     docker:
-      - image: cimg/python:3.9
-        environment:
-          TOXENV: docs
-
-  py38-lint:
-    <<: *common
-    docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.<< parameters.python_minor_version >>
     environment:
-      TOXENV: py38-lint
+      TOXENV: docs
 
-  py38-core:
-    <<: *common
-    docker:
-      - image: cimg/python:3.8
+  windows-wheel:
+    parameters:
+      python_minor_version:
+        type: string
+    executor:
+      name: win/default
+      shell: bash.exe
+    working_directory: C:\Users\circleci\project\web3.py
     environment:
-      TOXENV: py38-core
-
-  py38-core_async:
-    <<: *common
-    docker:
-      - image: cimg/python:3.8
-    environment:
-        TOXENV: py38-core_async
-
-  py38-ens:
-    <<: *common
-    docker:
-      - image: cimg/python:3.8
-    environment:
-      TOXENV: py38-ens
-
-  py38-ensip15:
-    <<: *common
-    docker:
-      - image: cimg/python:3.8
-    environment:
-      TOXENV: py38-ensip15
-
-  py38-integration-goethereum-ipc:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.8
-    environment:
-      TOXENV: py38-integration-goethereum-ipc
-
-  py38-integration-goethereum-ipc_async:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.8
-    environment:
-      TOXENV: py38-integration-goethereum-ipc_async
-
-  py38-integration-goethereum-http:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.8
-    environment:
-      TOXENV: py38-integration-goethereum-http
-
-  py38-integration-goethereum-http_async:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.8
-    environment:
-      TOXENV: py38-integration-goethereum-http_async
-
-  py38-integration-goethereum-legacy_ws:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.8
-    environment:
-      TOXENV: py38-integration-goethereum-legacy_ws
-
-  py38-integration-goethereum-ws:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.8
-    environment:
-      TOXENV: py38-integration-goethereum-ws
-
-  py38-integration-ethtester-pyevm:
-    <<: *common
-    docker:
-      - image: cimg/python:3.8
-    environment:
-      TOXENV: py38-integration-ethtester
-      ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
-
-  py38-wheel:
-    <<: *common
-    docker:
-      - image: cimg/python:3.8
-    environment:
-      TOXENV: py38-wheel
-
-  #
-  # Python 3.9
-  #
-  py39-lint:
-    <<: *common
-    docker:
-      - image: cimg/python:3.9
-    environment:
-      TOXENV: py39-lint
-
-  py39-core:
-    <<: *common
-    docker:
-      - image: cimg/python:3.9
-    environment:
-      TOXENV: py39-core
-
-  py39-core_async:
-    <<: *common
-    docker:
-      - image: cimg/python:3.9
-    environment:
-        TOXENV: py39-core_async
-
-  py39-ens:
-    <<: *common
-    docker:
-      - image: cimg/python:3.9
-    environment:
-      TOXENV: py39-ens
-
-  py39-ensip15:
-    <<: *common
-    docker:
-      - image: cimg/python:3.9
-    environment:
-      TOXENV: py39-ensip15
-
-  py39-integration-goethereum-ipc:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.9
-    environment:
-      TOXENV: py39-integration-goethereum-ipc
-
-  py39-integration-goethereum-ipc_async:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.9
-    environment:
-      TOXENV: py39-integration-goethereum-ipc_async
-
-  py39-integration-goethereum-http:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.9
-    environment:
-      TOXENV: py39-integration-goethereum-http
-
-  py39-integration-goethereum-http_async:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.9
-    environment:
-      TOXENV: py39-integration-goethereum-http_async
-
-  py39-integration-goethereum-ws:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.9
-    environment:
-      TOXENV: py39-integration-goethereum-ws
-
-  py39-integration-goethereum-legacy_ws:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.9
-    environment:
-      TOXENV: py39-integration-goethereum-ws
-
-  py39-integration-ethtester-pyevm:
-    <<: *common
-    docker:
-      - image: cimg/python:3.9
-    environment:
-      TOXENV: py39-integration-ethtester
-      ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
-
-  py39-wheel:
-    <<: *common
-    docker:
-      - image: cimg/python:3.9
-        environment:
-          TOXENV: py39-wheel
-
-  #
-  # Python 3.10
-  #
-  py310-lint:
-    <<: *common
-    docker:
-      - image: cimg/python:3.10
-    environment:
-      TOXENV: py310-lint
-
-  py310-core:
-    <<: *common
-    docker:
-      - image: cimg/python:3.10
-    environment:
-      TOXENV: py310-core
-
-  py310-core_async:
-    <<: *common
-    docker:
-      - image: cimg/python:3.10
-    environment:
-      TOXENV: py310-core_async
-
-  py310-ens:
-    <<: *common
-    docker:
-      - image: cimg/python:3.10
-    environment:
-      TOXENV: py310-ens
-
-  py310-ensip15:
-    <<: *common
-    docker:
-      - image: cimg/python:3.10
-    environment:
-      TOXENV: py310-ensip15
-
-  py310-integration-goethereum-ipc:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.10
-    environment:
-      TOXENV: py310-integration-goethereum-ipc
-
-  py310-integration-goethereum-ipc_async:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.10
-    environment:
-      TOXENV: py310-integration-goethereum-ipc_async
-
-  py310-integration-goethereum-http:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.10
-    environment:
-      TOXENV: py310-integration-goethereum-http
-
-  py310-integration-goethereum-http_async:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.10
-    environment:
-      TOXENV: py310-integration-goethereum-http_async
-
-  py310-integration-goethereum-legacy_ws:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.10
-    environment:
-      TOXENV: py310-integration-goethereum-legacy_ws
-
-  py310-integration-goethereum-ws:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.10
-    environment:
-      TOXENV: py310-integration-goethereum-ws
-
-  py310-integration-ethtester-pyevm:
-    <<: *common
-    docker:
-      - image: cimg/python:3.10
-    environment:
-      TOXENV: py310-integration-ethtester
-      ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
-
-  py310-wheel:
-    <<: *common
-    docker:
-      - image: cimg/python:3.10
-        environment:
-          TOXENV: py310-wheel
-
-  #
-  # Python 3.11
-  #
-  py311-lint:
-    <<: *common
-    docker:
-      - image: cimg/python:3.11
-    environment:
-      TOXENV: py311-lint
-
-  py311-core:
-    <<: *common
-    docker:
-      - image: cimg/python:3.11
-    environment:
-      TOXENV: py311-core
-
-  py311-core_async:
-    <<: *common
-    docker:
-      - image: cimg/python:3.11
-    environment:
-      TOXENV: py311-core_async
-
-  py311-ens:
-    <<: *common
-    docker:
-      - image: cimg/python:3.11
-    environment:
-      TOXENV: py311-ens
-
-  py311-ensip15:
-    <<: *common
-    docker:
-      - image: cimg/python:3.11
-    environment:
-      TOXENV: py311-ensip15
-
-  py311-integration-goethereum-ipc:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.11
-    environment:
-      TOXENV: py311-integration-goethereum-ipc
-
-  py311-integration-goethereum-ipc_async:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.11
-    environment:
-      TOXENV: py311-integration-goethereum-ipc_async
-
-  py311-integration-goethereum-http:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.11
-    environment:
-      TOXENV: py311-integration-goethereum-http
-
-  py311-integration-goethereum-http_async:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.11
-    environment:
-      TOXENV: py311-integration-goethereum-http_async
-
-  py311-integration-goethereum-legacy_ws:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.11
-    environment:
-      TOXENV: py311-integration-goethereum-legacy_ws
-
-  py311-integration-goethereum-ws:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.11
-    environment:
-      TOXENV: py311-integration-goethereum-ws
-
-  py311-integration-ethtester-pyevm:
-    <<: *common
-    docker:
-      - image: cimg/python:3.11
-    environment:
-      TOXENV: py311-integration-ethtester
-      ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
-
-  py311-wheel:
-    <<: *common
-    docker:
-      - image: cimg/python:3.11
-        environment:
-          TOXENV: py311-wheel
-
-  py311-windows-wheel:
-    <<: *windows-wheel-setup
+      TOXENV: windows-wheel
     steps:
       - checkout
-      - <<: *restore-cache-step
-      - <<: *install-pyenv-step
+      - restore_cache:
+          keys:
+            - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
       - run:
-          name: set minor version
-          command: echo "export MINOR_VERSION='3.11'" >> $BASH_ENV
-      - <<: *install-latest-python-step
-      - <<: *run-tox-step
-      - <<: *save-cache-step
-
-  #
-  # Python 3.12
-  #
-  py312-lint:
-    <<: *common
-    docker:
-      - image: cimg/python:3.12
-    environment:
-      TOXENV: py312-lint
-
-  py312-core:
-    <<: *common
-    docker:
-      - image: cimg/python:3.12
-    environment:
-      TOXENV: py312-core
-
-  py312-core_async:
-    <<: *common
-    docker:
-      - image: cimg/python:3.12
-    environment:
-      TOXENV: py312-core_async
-
-  py312-ens:
-    <<: *common
-    docker:
-      - image: cimg/python:3.12
-    environment:
-      TOXENV: py312-ens
-
-  py312-ensip15:
-    <<: *common
-    docker:
-      - image: cimg/python:3.12
-    environment:
-      TOXENV: py312-ensip15
-
-  py312-integration-goethereum-ipc:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.12
-    environment:
-      TOXENV: py312-integration-goethereum-ipc
-
-  py312-integration-goethereum-ipc_async:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.12
-    environment:
-      TOXENV: py312-integration-goethereum-ipc_async
-
-  py312-integration-goethereum-http:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.12
-    environment:
-      TOXENV: py312-integration-goethereum-http
-
-  py312-integration-goethereum-http_async:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.12
-    environment:
-      TOXENV: py312-integration-goethereum-http_async
-
-  py312-integration-goethereum-legacy_ws:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.12
-    environment:
-      TOXENV: py312-integration-goethereum-legacy_ws
-
-  py312-integration-goethereum-ws:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.12
-    environment:
-      TOXENV: py312-integration-goethereum-ws
-
-  py312-integration-ethtester-pyevm:
-    <<: *common
-    docker:
-      - image: cimg/python:3.12
-    environment:
-      TOXENV: py312-integration-ethtester
-      ETHEREUM_TESTER_CHAIN_BACKEND: eth_tester.backends.PyEVMBackend
-
-  py312-wheel:
-    <<: *common
-    docker:
-      - image: cimg/python:3.12
-        environment:
-          TOXENV: py312-wheel
-
-  py312-windows-wheel:
-    <<: *windows-wheel-setup
-    steps:
-      - checkout
-      - <<: *restore-cache-step
-      - <<: *install-pyenv-step
+          name: install pyenv
+          command: |
+            pip install pyenv-win --target $HOME/.pyenv
+            echo 'export PYENV="$HOME/.pyenv/pyenv-win/"' >> $BASH_ENV
+            echo 'export PYENV_ROOT="$HOME/.pyenv/pyenv-win/"' >> $BASH_ENV
+            echo 'export PYENV_USERPROFILE="$HOME/.pyenv/pyenv-win/"' >> $BASH_ENV
+            echo 'export PATH="$PATH:$HOME/.pyenv/pyenv-win/bin"' >> $BASH_ENV
+            echo 'export PATH="$PATH:$HOME/.pyenv/pyenv-win/shims"' >> $BASH_ENV
+            source $BASH_ENV
+            pyenv update
       - run:
-          name: set minor version
-          command: echo "export MINOR_VERSION='3.12'" >> $BASH_ENV
-      - <<: *install-latest-python-step
-      - <<: *run-tox-step
-      - <<: *save-cache-step
-
-  benchmark:
-    <<: *geth_steps
-    docker:
-      - image: cimg/python:3.10
-    environment:
-      TOXENV: benchmark
-
-
-define: &all_jobs
-  # These are the longest running tests, start them first
-  - py38-core
-  - py39-core
-  - py310-core
-  - py311-core
-  - py312-core
-  - py38-core_async
-  - py39-core_async
-  - py310-core_async
-  - py311-core_async
-  - py312-core_async
-  - docs
-  - benchmark
-  - py38-lint
-  - py38-ens
-  - py38-ensip15
-  - py38-integration-goethereum-ipc
-  - py38-integration-goethereum-ipc_async
-  - py38-integration-goethereum-http
-  - py38-integration-goethereum-http_async
-  - py38-integration-goethereum-legacy_ws
-  - py38-integration-goethereum-ws
-  - py38-integration-ethtester-pyevm
-  - py38-wheel
-  - py39-lint
-  - py39-ens
-  - py39-ensip15
-  - py39-integration-goethereum-ipc
-  - py39-integration-goethereum-ipc_async
-  - py39-integration-goethereum-http
-  - py39-integration-goethereum-http_async
-  - py39-integration-goethereum-legacy_ws
-  - py39-integration-goethereum-ws
-  - py39-integration-ethtester-pyevm
-  - py39-wheel
-  - py310-lint
-  - py310-ens
-  - py310-ensip15
-  - py310-integration-goethereum-ipc
-  - py310-integration-goethereum-ipc_async
-  - py310-integration-goethereum-http
-  - py310-integration-goethereum-http_async
-  - py310-integration-goethereum-legacy_ws
-  - py310-integration-goethereum-ws
-  - py310-integration-ethtester-pyevm
-  - py310-wheel
-  - py311-lint
-  - py311-ens
-  - py311-ensip15
-  - py311-integration-goethereum-ipc
-  - py311-integration-goethereum-ipc_async
-  - py311-integration-goethereum-http
-  - py311-integration-goethereum-http_async
-  - py311-integration-goethereum-legacy_ws
-  - py311-integration-goethereum-ws
-  - py311-integration-ethtester-pyevm
-  - py311-wheel
-  - py311-windows-wheel
-  - py312-lint
-  - py312-ens
-  - py312-ensip15
-  - py312-integration-goethereum-ipc
-  - py312-integration-goethereum-ipc_async
-  - py312-integration-goethereum-http
-  - py312-integration-goethereum-http_async
-  - py312-integration-goethereum-legacy_ws
-  - py312-integration-goethereum-ws
-  - py312-integration-ethtester-pyevm
-  - py312-wheel
-  - py312-windows-wheel
+          name: install latest python version and tox
+          command: |
+            LATEST_VERSION=$(pyenv install --list | grep -E "^\s*3\.<< parameters.python_minor_version >>\.[0-9]+$" | tail -1 | tr -d ' ')
+            echo "installing python version $LATEST_VERSION"
+            pyenv install $LATEST_VERSION
+            pyenv global $LATEST_VERSION
+            python3 -m pip install --upgrade pip
+            python3 -m pip install tox
+      - run:
+          name: run tox
+          command: |
+            echo 'running tox with' $(python3 --version)
+            python3 -m tox run -r
+      - save_cache:
+          paths:
+            - .tox
+          key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 workflows:
   version: 2
   test:
-    jobs: *all_jobs
+    jobs: &all_jobs
+      - common:
+          matrix:
+            parameters:
+              python_minor_version: ["8", "9", "10", "11", "12"]
+              tox_env: [
+                "lint",
+                "core",
+                "core_async",
+                "ens",
+                "ensip15",
+                "wheel"
+              ]
+          name: "py3<< matrix.python_minor_version >>-<< matrix.tox_env >>"
+      - geth:
+          matrix:
+            parameters:
+              python_minor_version: ["8", "9", "10", "11", "12"]
+              tox_env: [
+                "integration-goethereum-ipc",
+                "integration-goethereum-ipc_async",
+                "integration-goethereum-http",
+                "integration-goethereum-http_async",
+                "integration-goethereum-legacy_ws",
+                "integration-goethereum-ws",
+                "integration-ethtester"
+              ]
+          name: "py3<< matrix.python_minor_version >>-<< matrix.tox_env >>"
+      - docs:
+          matrix:
+            parameters:
+              python_minor_version: ["9"]
+          name: "py3<< matrix.python_minor_version >>-docs"
+      - windows-wheel:
+          matrix:
+            parameters:
+              python_minor_version: ["10", "11", "12"]
+          name: "py3<< matrix.python_minor_version >>-windows-wheel"
+
+
   nightly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,10 @@
 version: 2.1
 
 parameters:
+  # NOTE: Do not update the `geth_version` manually. It is updated during the
+  # integration test fixture generation.
   geth_version:
-    # update default value when updating geth integration test fixture
-    default: "v1.14.5"
-    type: string
-  pygeth_version:
-    # update default value when updating geth integration test fixture
-    default: "5.0.0b1"
+    default: "1.14.5"
     type: string
   go_version:
     default: "1.22.4"
@@ -66,8 +63,8 @@ geth_steps: &geth_steps
         command: |
           if [ "<< pipeline.parameters.geth_version >>" != "custom" ]; then
             export GOROOT=/usr/local/go
-            export GETH_BINARY="$HOME/.py-geth/geth-<< pipeline.parameters.geth_version >>/bin/geth"
-            echo "configured geth version: << pipeline.parameters.geth_version >>"
+            export GETH_BINARY="$HOME/.py-geth/geth-v<< pipeline.parameters.geth_version >>/bin/geth"
+            echo "configured geth version: v<< pipeline.parameters.geth_version >>"
             if [ ! -e "$GETH_BINARY" ]; then
               echo "GETH_BINARY not set, installing geth..."
               curl -O https://storage.googleapis.com/golang/go<< pipeline.parameters.go_version >>.linux-amd64.tar.gz
@@ -77,10 +74,12 @@ geth_steps: &geth_steps
               sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
               sudo apt-get update
               sudo apt-get install -y build-essential
-              pip install --user "py-geth>=<< pipeline.parameters.pygeth_version >>"
-              python -m geth.install << pipeline.parameters.geth_version >>
+              pygeth_version=$(python web3/scripts/parse_pygeth_version.py)
+              echo "installing py-geth$pygeth_version"
+              pip install --user "py-geth$pygeth_version"
+              python -m geth.install v<< pipeline.parameters.geth_version >>
             fi
-            sudo ln -s /home/circleci/.py-geth/geth-<< pipeline.parameters.geth_version >>/bin/geth /usr/local/bin/geth
+            sudo ln -s /home/circleci/.py-geth/geth-v<< pipeline.parameters.geth_version >>/bin/geth /usr/local/bin/geth
           else
             export GOROOT=/usr/local/go
             export GETH_BINARY="./custom_geth"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ common: &common
         command: |
           python -m pip install --upgrade pip
           python -m pip install tox
+          python web3/scripts/install_pre_releases.py
     - run:
         name: run tox
         command: python -m tox run -r

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -379,7 +379,7 @@ Geth Fixtures
 
    .. code:: sh
 
-       $ GETH_BINARY=~/.py-geth/geth-v1.14.5/bin/geth python ./tests/integration/generate_fixtures/go_ethereum.py ./tests/integration/geth-1.14.5-fixture
+       $ GETH_BINARY=~/.py-geth/geth-v1.14.5/bin/geth python ./tests/integration/generate_fixtures/go_ethereum.py
 
 3. The output of this script is your fixture, a zip file, which is now stored in ``/tests/integration/``.
    Update the ``/tests/integration/go_ethereum/conftest.py`` and

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -397,11 +397,10 @@ Geth Fixtures
 CI Testing With a Nightly Geth Build
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Occasionally you'll want to have CI run the test suite against an unreleased version of Geth,
-for example, to test upcoming hard fork changes. The workflow described below is for testing only,
-i.e., open a PR, let CI run the tests, but the changes should only be merged into main once the
-Geth release is published or you have some workaround that doesn't require test fixtures built from
-an unstable client.
+Occasionally you'll want to have CI run the test suite against an unreleased version of
+Geth - e.g. to test upcoming hard fork changes. The workflow described below is for
+testing only, as updates will only be merged into main once the Geth release is
+published and the test runs are updated to use the new stable version.
 
 1. Configure ``tests/integration/generate_fixtures/go_ethereum/common.py`` as needed.
 
@@ -415,7 +414,8 @@ an unstable client.
    `develop build <https://geth.ethereum.org/downloads/>`_, then
    add it to the root of your web3.py directory. Rename the binary ``custom_geth``.
 
-5. In ``.circleci/config.yml``, update jobs relying on ``geth_steps``, to instead use ``custom_geth_steps``.
+5. In ``.circleci/config.yml``, update the ``geth_version`` pipeline parameter to
+   "custom". This will trigger the custom Geth build to be used in the CI test suite.
 
 6. Create a PR and let CI do its thing.
 

--- a/newsfragments/3452.internal.rst
+++ b/newsfragments/3452.internal.rst
@@ -1,0 +1,1 @@
+Refactor and DRY up CI run setup and reduce surface area for errors. Include pre-releases in CI runs for internally maintained libraries to try and catch any conflicts.

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ extras_require = {
         "towncrier>=21,<22",
     ],
     "test": [
+        # Note: ethereum-maintained libraries in this list should be added to the
+        # `install_pre_releases.py` script.
         "eth-tester[py-evm]>=0.11.0b1,<0.13.0b1",
         "py-geth>=5.0.0",
         "pytest-asyncio>=0.18.1,<0.23",
@@ -58,13 +60,15 @@ setup(
     url="https://github.com/ethereum/web3.py",
     include_package_data=True,
     install_requires=[
-        "aiohttp>=3.7.4.post0",
+        # Note: ethereum-maintained libraries in this list should be added to the
+        # `install_pre_releases.py` script.
         "eth-abi>=5.0.1",
         "eth-account>=0.13.1",
         "eth-hash[pycryptodome]>=0.5.1",
         "eth-typing>=5.0.0",
         "eth-utils>=5.0.0",
         "hexbytes>=1.2.0",
+        "aiohttp>=3.7.4.post0",
         "pydantic>=2.4.0",
         "pywin32>=223;platform_system=='Windows'",
         "requests>=2.23.0",

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,6 @@ extras_require = {
         "sphinx-autobuild>=2021.3.14",
         "sphinx_rtd_theme>=1.0.0",
         "towncrier>=21,<22",
-        # web3 will work but emit warnings with eth-account>=0.12.2,
-        # but doctests fail between 0.12.2 and 0.13.0
-        "eth-account>=0.13.0",
     ],
     "test": [
         "eth-tester[py-evm]>=0.11.0b1,<0.13.0b1",

--- a/tests/core/test_library_files.py
+++ b/tests/core/test_library_files.py
@@ -11,9 +11,7 @@ DEFAULT_EXCEPTIONS = (
 
 def test_no_default_exceptions_are_raised_within_web3py():
     for root, dirs, files in os.walk(WEB3_PATH):
-        if "module_testing" in dirs:
-            dirs.remove("module_testing")
-            continue
+        [dirs.remove(dir_) for dir_ in dirs if dir_ in ("scripts", "module_testing")]
         for file in files:
             if file.endswith(".py"):
                 file_path = os.path.join(root, file)

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,7 @@
 [tox]
 envlist=
-    py{38,39,310,311,312}-ens
-    py{38,39,310,311,312}-core
+    py{38,39,310,311,312}-{ens,core,lint,wheel}
     py{38,39,310,311,312}-integration-{goethereum,ethtester}
-    py{38,39,310,311,312}-lint
-    py{38,39,310,311,312}-wheel
     docs
     benchmark
     windows-wheel

--- a/web3/scripts/install_pre_releases.py
+++ b/web3/scripts/install_pre_releases.py
@@ -1,0 +1,33 @@
+"""
+The goal of this script is to install the latest versions, including pre-releases, for
+libraries that we maintain (and therefore control the release process) during our CI
+runs. This helps us test pre-releases before they cause any issues once stable versions
+are released.
+"""
+
+import subprocess
+import sys
+
+ETHEREUM_LIBRARIES = [
+    "eth-account",
+    "eth-abi",
+    "eth-account",
+    "eth-hash[pycryptodome]",
+    "eth-typing",
+    "eth-utils",
+    "hexbytes",
+    "eth-tester[py-evm]",
+    "py-geth",
+]
+
+
+def install_eth_pre_releases() -> None:
+    for lib in ETHEREUM_LIBRARIES:
+        print(f"Installing {lib} with `--pre` and `-U`")
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "--pre", "-U", lib]
+        )
+
+
+if __name__ == "__main__":
+    install_eth_pre_releases()

--- a/web3/scripts/parse_pygeth_version.py
+++ b/web3/scripts/parse_pygeth_version.py
@@ -1,0 +1,16 @@
+import re
+
+
+def get_pygeth_version() -> str:
+    with open("setup.py") as f:
+        setup_contents = f.read()
+    version_match = re.search(r"py-geth\s*([><=~!]+)\s*([\d.]+)", setup_contents)
+    if version_match:
+        return "".join(version_match.group(1, 2))
+    else:
+        raise ValueError("py-geth not found in setup.py")
+
+
+if __name__ == "__main__":
+    version = get_pygeth_version()
+    print(version)


### PR DESCRIPTION
### What was wrong?

- We have a few places to update `py-geth` versions that can be out of sync if we aren't careful. Update the version in all relevant places when we generate the fixture and take the version directly from the `GETH_BINARY` that needs to be set when the test fixture is generated. 

- Along the way, parametrize and DRY up the circleci config.

- We should also figure out a good way to `pip install --pre` (include pre-releases) for all of the ethereum libraries we maintain so we can get pre-releases building in the nightly runs and catch issues sooner (before they get to "stable").

^ I implemented the best approach I saw for installing pre-releases of our libs. The shortcoming is that the libs need to be added to the script but if we document it well enough in the internal handbook it seemed the least intrusive way into other parts of the codebase that I saw.

### Todo:

- [x] Add or update documentation related to these changes
- [x] pip install pre-release versions of only our deps.
- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fwallpapercrafter.com%2Fdesktop1%2F652948-bear-baby-bear-cute-grass-wildlife-wild-animals.jpg&f=1&nofb=1&ipt=9643f4bc35dfe69736a8ea6071de1689189aa76c1efb2bc17bb4e8100f90b650&ipo=images)
