### PR TITLE
Update filters.rst

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -724,7 +724,7 @@ The script can be run with: ``python ./eventscanner.py <your JSON-RPC API URL>``
                 self.state.start_chunk(current_block, chunk_size)
 
                 # Print some diagnostics to logs to try to fiddle with real world JSON-RPC API performance
-                estimated_end_block = current_block + chunk_size
+                estimated_end_block = min(current_block + chunk_size, end_block)
                 logger.debug(
                     f"Scanning token transfers for blocks: {current_block} - {estimated_end_block}, chunk size {chunk_size}, last chunk scan took {last_scan_duration}, last logs found {last_logs_found}"
                 )

--- a/newsfragments/3455.docs.rst
+++ b/newsfragments/3455.docs.rst
@@ -1,0 +1,1 @@
+Fix bug in filters example code


### PR DESCRIPTION

### What was wrong?
In the current implementation, estimated_end_block is calculated as current_block + chunk_size. This value could exceed end_block if the chunk size is large enough or if you’re near the end of the scan range. If estimated_end_block exceeds end_block, the scan might attempt to process blocks beyond the specified range, leading to issues.

### How was it fixed?
Capped estimated_end_block to end_block by updating the calculation to estimated_end_block = min(current_block + chunk_size, end_block).
