### PR TITLE
Pin ckzg library

### DIFF
--- a/newsfragments/3456.bugfix.rst
+++ b/newsfragments/3456.bugfix.rst
@@ -1,0 +1,1 @@
+Pin ckzg library to <2.0 so core tests pass

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "aiohttp>=3.7.4.post0",
+        "ckzg<2.0",
         "eth-abi>=5.0.1",
         "eth-account>=0.13.1",
         "eth-hash[pycryptodome]>=0.5.1",


### PR DESCRIPTION
### What was wrong?
ckzg updated something in v2.0, and our builds started failing. I haven't checked to see what it is yet, but figured I'd get this up so we're passing again.

### How was it fixed?
Added an upper pin here. It probably makes more sense to actually pin this in eth-account, though long term. Once we're pinned in eth-account and that change is released, we can remove the requirement here. 

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://t3.ftcdn.net/jpg/00/31/29/58/360_F_31295810_BHXDNJBckJEcwXBYmYIDRv0qlQviEERF.jpg)
