### PR TITLE
Bump py-geth out of beta, now that stable is released.

### DIFF
--- a/newsfragments/3458.internal.rst
+++ b/newsfragments/3458.internal.rst
@@ -1,0 +1,1 @@
+Bump `py-geth` to ``>=5.0.0`` from ``>=5.0.0b1`` now that stable has been released. This only matters for the ``test`` install extra (CI and dev purposes).

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ extras_require = {
     ],
     "test": [
         "eth-tester[py-evm]>=0.11.0b1,<0.13.0b1",
-        "py-geth>=5.0.0b1",
+        "py-geth>=5.0.0",
         "pytest-asyncio>=0.18.1,<0.23",
         "pytest-mock>=1.10",
         "pytest-xdist>=2.4.0",


### PR DESCRIPTION
### What was wrong?

- Bump py-geth to ``>=5.0.0`` from ``>=5.0.0b1`` now that the stable is out. This is only relevant for CI or developers, as it is installed via the ``test`` install extra.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![1000025652](https://github.com/user-attachments/assets/55ea27e0-98f3-4bb1-8609-1e4bcb7fec41)
