### PR TITLE
Pin ckzg <2

### DIFF
--- a/newsfragments/3459.bugfix.rst
+++ b/newsfragments/3459.bugfix.rst
@@ -1,0 +1,1 @@
+Pin ckzg dependency to <2 so that blob transactions work

--- a/setup.py
+++ b/setup.py
@@ -61,8 +61,9 @@ setup(
     include_package_data=True,
     install_requires=[
         "aiohttp>=3.7.4.post0",
+        "ckzg<2",
         "eth-abi>=4.0.0",
-        "eth-account>=0.11.3,<0.13",
+        "eth-account>=0.8.0,<0.13",
         "eth-hash[pycryptodome]>=0.5.1",
         "eth-typing>=3.0.0,!=4.2.0,<5.0.0",
         "eth-utils>=2.1.0,<5",

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     install_requires=[
         "aiohttp>=3.7.4.post0",
         "eth-abi>=4.0.0",
-        "eth-account>=0.8.0,<0.13",
+        "eth-account>=0.11.3,<0.13",
         "eth-hash[pycryptodome]>=0.5.1",
         "eth-typing>=3.0.0,!=4.2.0,<5.0.0",
         "eth-utils>=2.1.0,<5",


### PR DESCRIPTION
### What was wrong?
ckzg released a breaking change in v2 for our blob transactions. 


### How was it fixed?
First I tried to pin eth-account to the lowest version that had the ckzg pin, but the 0.11.x line of eth-account dropped support for python 3.7, and so all of our Python 3.7 tests started failing. I think it makes the most sense to just require ckzg<2 here after all. 

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.rspcasa.org.au/wp-content/uploads/2020/10/Baby-goat-in-tree.jpg)
