### PR TITLE
(bugfix) Use a defined __hash__() for unhashable middleware:

### DIFF
--- a/newsfragments/3463.bugfix.rst
+++ b/newsfragments/3463.bugfix.rst
@@ -1,0 +1,1 @@
+Specify a unique ``__hash__()`` for unhashable ``Web3Middleware`` types and use this hash as the middleware onion key when a name is not provided for the middleware. This fixes a bug where different middleware were given the same name and therefore raised errors.

--- a/tests/core/middleware/test_middleware.py
+++ b/tests/core/middleware/test_middleware.py
@@ -12,17 +12,25 @@ from web3.middleware import (
 )
 
 
+class TestMiddleware(Web3Middleware):
+    def response_processor(self, method, response):
+        if method == "eth_blockNumber":
+            response["result"] = 1234
+
+        return response
+
+
+class TestMiddleware2(Web3Middleware):
+    def response_processor(self, method, response):
+        if method == "eth_blockNumber":
+            response["result"] = 4321
+
+        return response
+
+
 def test_middleware_class_eq_magic_method():
     w3_a = Web3()
     w3_b = Web3()
-
-    class TestMiddleware(Web3Middleware):
-        def request_processor(self, method, params):
-            return 1234
-
-    class TestMiddleware2(Web3Middleware):
-        def request_processor(self, method, params):
-            return 4321
 
     mw1w3_a = TestMiddleware(w3_a)
     assert mw1w3_a is not None
@@ -61,3 +69,13 @@ def test_unnamed_middleware_are_given_unique_keys(w3):
     with pytest.raises(Web3ValueError):
         # adding the same middleware again should cause an error
         w3.middleware_onion.add(request_formatting_middleware)
+
+
+def test_unnamed_class_middleware_are_given_unique_keys(w3):
+    w3.middleware_onion.add(TestMiddleware)
+    w3.middleware_onion.add(TestMiddleware2)
+    assert isinstance(w3.eth.block_number, int)
+
+    with pytest.raises(Web3ValueError):
+        # adding the same middleware again should cause an error
+        w3.middleware_onion.add(TestMiddleware)

--- a/tests/core/middleware/test_middleware.py
+++ b/tests/core/middleware/test_middleware.py
@@ -1,0 +1,63 @@
+import pytest
+
+from web3 import (
+    Web3,
+)
+from web3.exceptions import (
+    Web3ValueError,
+)
+from web3.middleware import (
+    FormattingMiddlewareBuilder,
+    Web3Middleware,
+)
+
+
+def test_middleware_class_eq_magic_method():
+    w3_a = Web3()
+    w3_b = Web3()
+
+    class TestMiddleware(Web3Middleware):
+        def request_processor(self, method, params):
+            return 1234
+
+    class TestMiddleware2(Web3Middleware):
+        def request_processor(self, method, params):
+            return 4321
+
+    mw1w3_a = TestMiddleware(w3_a)
+    assert mw1w3_a is not None
+    assert mw1w3_a != ""
+
+    mw1w3_a_equal = TestMiddleware(w3_a)
+    assert mw1w3_a == mw1w3_a_equal
+
+    mw2w3_a = TestMiddleware2(w3_a)
+    mw1w3_b = TestMiddleware(w3_b)
+    assert mw1w3_a != mw2w3_a
+    assert mw1w3_a != mw1w3_b
+
+
+def test_unnamed_middleware_are_given_unique_keys(w3):
+    request_formatting_middleware = FormattingMiddlewareBuilder.build(
+        request_formatters={lambda x: x}
+    )
+    request_formatting_middleware2 = FormattingMiddlewareBuilder.build(
+        request_formatters={lambda x: x if x else None}
+    )
+    result_formatting_middleware = FormattingMiddlewareBuilder.build(
+        result_formatters={lambda x: x}
+    )
+    error_formatting_middleware = FormattingMiddlewareBuilder.build(
+        error_formatters={lambda x: x}
+    )
+
+    # adding different middleware should not cause an error
+    w3.middleware_onion.add(request_formatting_middleware)
+    w3.middleware_onion.add(request_formatting_middleware2)
+    w3.middleware_onion.add(result_formatting_middleware)
+    w3.middleware_onion.add(error_formatting_middleware)
+    assert isinstance(w3.eth.block_number, int)
+
+    with pytest.raises(Web3ValueError):
+        # adding the same middleware again should cause an error
+        w3.middleware_onion.add(request_formatting_middleware)

--- a/web3/datastructures.py
+++ b/web3/datastructures.py
@@ -182,7 +182,7 @@ class NamedElementOnion(Mapping[TKey, TValue]):
         if name is None:
             name = cast(TKey, element)
 
-        name = self._build_tkey(name)
+        name = self._build_name(name)
 
         if name in self._queue:
             if name is element:
@@ -219,7 +219,7 @@ class NamedElementOnion(Mapping[TKey, TValue]):
             if name is None:
                 name = cast(TKey, element)
 
-            name = self._build_tkey(name)
+            name = self._build_name(name)
 
             self._queue.move_to_end(name, last=False)
         elif layer == len(self._queue):
@@ -233,7 +233,7 @@ class NamedElementOnion(Mapping[TKey, TValue]):
         self._queue.clear()
 
     def replace(self, old: TKey, new: TKey) -> TValue:
-        old_name = self._build_tkey(old)
+        old_name = self._build_name(old)
 
         if old_name not in self._queue:
             raise Web3ValueError(
@@ -249,7 +249,7 @@ class NamedElementOnion(Mapping[TKey, TValue]):
         return to_be_replaced
 
     @staticmethod
-    def _build_tkey(value: TKey) -> TKey:
+    def _build_name(value: TKey) -> TKey:
         try:
             value.__hash__()
             return value
@@ -261,12 +261,12 @@ class NamedElementOnion(Mapping[TKey, TValue]):
                 )
             # This will either be ``Web3Middleware`` class or the ``build`` method of a
             # ``Web3MiddlewareBuilder``. Instantiate with empty ``Web3`` and use a
-            # unique identifier with the ``__hash__()`` as the TKey.
+            # unique identifier with the ``__hash__()`` as the name.
             v = value(None)
             return cast(TKey, f"{v.__class__}<{v.__hash__()}>")
 
     def remove(self, old: TKey) -> None:
-        old_name = self._build_tkey(old)
+        old_name = self._build_name(old)
         if old_name not in self._queue:
             raise Web3ValueError("You can only remove something that has been added")
         del self._queue[old_name]
@@ -280,8 +280,8 @@ class NamedElementOnion(Mapping[TKey, TValue]):
         return [(val, key) for key, val in reversed(self._queue.items())]
 
     def _replace_with_new_name(self, old: TKey, new: TKey) -> None:
-        old_name = self._build_tkey(old)
-        new_name = self._build_tkey(new)
+        old_name = self._build_name(old)
+        new_name = self._build_name(new)
 
         self._queue[new_name] = new
         found_old = False
@@ -303,11 +303,11 @@ class NamedElementOnion(Mapping[TKey, TValue]):
         return NamedElementOnion(cast(List[Any], combined.items()))
 
     def __contains__(self, element: Any) -> bool:
-        element_name = self._build_tkey(element)
+        element_name = self._build_name(element)
         return element_name in self._queue
 
     def __getitem__(self, element: TKey) -> TValue:
-        element_name = self._build_tkey(element)
+        element_name = self._build_name(element)
         return self._queue[element_name]
 
     def __len__(self) -> int:

--- a/web3/datastructures.py
+++ b/web3/datastructures.py
@@ -182,7 +182,7 @@ class NamedElementOnion(Mapping[TKey, TValue]):
         if name is None:
             name = cast(TKey, element)
 
-        name = self._repr_if_not_hashable(name)
+        name = self._build_tkey(name)
 
         if name in self._queue:
             if name is element:
@@ -219,7 +219,7 @@ class NamedElementOnion(Mapping[TKey, TValue]):
             if name is None:
                 name = cast(TKey, element)
 
-            name = self._repr_if_not_hashable(name)
+            name = self._build_tkey(name)
 
             self._queue.move_to_end(name, last=False)
         elif layer == len(self._queue):
@@ -233,7 +233,7 @@ class NamedElementOnion(Mapping[TKey, TValue]):
         self._queue.clear()
 
     def replace(self, old: TKey, new: TKey) -> TValue:
-        old_name = self._repr_if_not_hashable(old)
+        old_name = self._build_tkey(old)
 
         if old_name not in self._queue:
             raise Web3ValueError(
@@ -248,15 +248,25 @@ class NamedElementOnion(Mapping[TKey, TValue]):
             self._queue[old_name] = new
         return to_be_replaced
 
-    def _repr_if_not_hashable(self, value: TKey) -> TKey:
+    @staticmethod
+    def _build_tkey(value: TKey) -> TKey:
         try:
             value.__hash__()
+            return value
         except TypeError:
-            value = cast(TKey, repr(value))
-        return value
+            # unhashable, unnamed elements
+            if not callable(value):
+                raise Web3TypeError(
+                    f"Expected a callable or hashable type, got {type(value)}"
+                )
+            # This will either be ``Web3Middleware`` class or the ``build`` method of a
+            # ``Web3MiddlewareBuilder``. Instantiate with empty ``Web3`` and use a
+            # unique identifier with the ``__hash__()`` as the TKey.
+            v = value(None)
+            return cast(TKey, f"{v.__class__}<{v.__hash__()}>")
 
     def remove(self, old: TKey) -> None:
-        old_name = self._repr_if_not_hashable(old)
+        old_name = self._build_tkey(old)
         if old_name not in self._queue:
             raise Web3ValueError("You can only remove something that has been added")
         del self._queue[old_name]
@@ -270,8 +280,8 @@ class NamedElementOnion(Mapping[TKey, TValue]):
         return [(val, key) for key, val in reversed(self._queue.items())]
 
     def _replace_with_new_name(self, old: TKey, new: TKey) -> None:
-        old_name = self._repr_if_not_hashable(old)
-        new_name = self._repr_if_not_hashable(new)
+        old_name = self._build_tkey(old)
+        new_name = self._build_tkey(new)
 
         self._queue[new_name] = new
         found_old = False
@@ -293,11 +303,11 @@ class NamedElementOnion(Mapping[TKey, TValue]):
         return NamedElementOnion(cast(List[Any], combined.items()))
 
     def __contains__(self, element: Any) -> bool:
-        element_name = self._repr_if_not_hashable(element)
+        element_name = self._build_tkey(element)
         return element_name in self._queue
 
     def __getitem__(self, element: TKey) -> TValue:
-        element_name = self._repr_if_not_hashable(element)
+        element_name = self._build_tkey(element)
         return self._queue[element_name]
 
     def __len__(self) -> int:

--- a/web3/middleware/base.py
+++ b/web3/middleware/base.py
@@ -40,6 +40,14 @@ class Web3Middleware:
     def __init__(self, w3: Union["AsyncWeb3", "Web3"]) -> None:
         self._w3 = w3
 
+    def __hash__(self) -> int:
+        return hash(f"{self.__class__.__name__}({str(self.__dict__)})")
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Web3Middleware):
+            return False
+        return self.__hash__() == other.__hash__()
+
     # -- sync -- #
 
     def wrap_make_request(self, make_request: "MakeRequestFn") -> "MakeRequestFn":


### PR DESCRIPTION
### What was wrong?

- Closes #3461
- There is a bug where the middleware builders, which return curry-wrapped ``build`` functions, end up being given the same identifier when a name is not provided for the middleware in the onion.

### How was it fixed?

This fixes the issue by defining a unique hash for the base ``Web3Middleware`` class and using that hash in the case where the middleware is unhashable and therefore indistinguishable from another "built" middleware. This also uses the `__hash__()` by default for any of the class-based middleware if a name isn't provided, rather than using a `repr()` as before - which is not unique enough, leading to the complications.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![](https://www.arrowexterminators.com/assets/istock-1032959962_gvZN2oZ.jpg)
