### PR TITLE
Clean up session warnings

### DIFF
--- a/newsfragments/3468.internal.rst
+++ b/newsfragments/3468.internal.rst
@@ -1,0 +1,1 @@
+Test warning cleanup

--- a/tests/core/middleware/test_middleware.py
+++ b/tests/core/middleware/test_middleware.py
@@ -12,7 +12,7 @@ from web3.middleware import (
 )
 
 
-class TestMiddleware(Web3Middleware):
+class MockMiddleware(Web3Middleware):
     def response_processor(self, method, response):
         if method == "eth_blockNumber":
             response["result"] = 1234
@@ -20,7 +20,7 @@ class TestMiddleware(Web3Middleware):
         return response
 
 
-class TestMiddleware2(Web3Middleware):
+class MockMiddleware2(Web3Middleware):
     def response_processor(self, method, response):
         if method == "eth_blockNumber":
             response["result"] = 4321
@@ -32,15 +32,15 @@ def test_middleware_class_eq_magic_method():
     w3_a = Web3()
     w3_b = Web3()
 
-    mw1w3_a = TestMiddleware(w3_a)
+    mw1w3_a = MockMiddleware(w3_a)
     assert mw1w3_a is not None
     assert mw1w3_a != ""
 
-    mw1w3_a_equal = TestMiddleware(w3_a)
+    mw1w3_a_equal = MockMiddleware(w3_a)
     assert mw1w3_a == mw1w3_a_equal
 
-    mw2w3_a = TestMiddleware2(w3_a)
-    mw1w3_b = TestMiddleware(w3_b)
+    mw2w3_a = MockMiddleware2(w3_a)
+    mw1w3_b = MockMiddleware(w3_b)
     assert mw1w3_a != mw2w3_a
     assert mw1w3_a != mw1w3_b
 
@@ -72,10 +72,10 @@ def test_unnamed_middleware_are_given_unique_keys(w3):
 
 
 def test_unnamed_class_middleware_are_given_unique_keys(w3):
-    w3.middleware_onion.add(TestMiddleware)
-    w3.middleware_onion.add(TestMiddleware2)
+    w3.middleware_onion.add(MockMiddleware)
+    w3.middleware_onion.add(MockMiddleware2)
     assert isinstance(w3.eth.block_number, int)
 
     with pytest.raises(Web3ValueError):
         # adding the same middleware again should cause an error
-        w3.middleware_onion.add(TestMiddleware)
+        w3.middleware_onion.add(MockMiddleware)

--- a/tests/core/providers/test_async_http_provider.py
+++ b/tests/core/providers/test_async_http_provider.py
@@ -45,6 +45,9 @@ async def test_async_no_args() -> None:
     assert not await w3.is_connected()
     with pytest.raises(ProviderConnectionError):
         await w3.is_connected(show_traceback=True)
+    for cached_items in provider._request_session_manager.session_cache.items():
+        cache_key, session = cached_items
+        await session.close()
 
 
 def test_init_kwargs():
@@ -92,6 +95,7 @@ async def test_async_user_provided_session() -> None:
     cached_session = await provider.cache_async_session(session)
     assert len(provider._request_session_manager.session_cache) == 1
     assert cached_session == session
+    await session.close()
 
 
 @pytest.mark.parametrize("provider", (AsyncHTTPProvider(), AsyncHTTPProvider))

--- a/tests/core/providers/test_async_ipc_provider.py
+++ b/tests/core/providers/test_async_ipc_provider.py
@@ -234,6 +234,9 @@ async def test_async_iterator_pattern_exception_handling_for_requests(
             break
 
         pytest.fail("Expected `ConnectionClosed` exception.")
+        for cache_items in w3.provider._request_session_manager.session_cache.items():
+            cache_key, session = cache_items
+            await session.close()
 
     assert exception_caught
 
@@ -254,6 +257,9 @@ async def test_async_iterator_pattern_exception_handling_for_subscriptions(
         except ConnectionClosed:
             exception_caught = True
             break
+        for cache_items in w3.provider._request_session_manager.session_cache.items():
+            cache_key, session = cache_items
+            await session.close()
 
         pytest.fail("Expected `ConnectionClosed` exception.")
 

--- a/tests/core/providers/test_async_tester_provider.py
+++ b/tests/core/providers/test_async_tester_provider.py
@@ -17,6 +17,9 @@ async def test_async_tester_provider_is_connected() -> None:
     provider = AsyncEthereumTesterProvider()
     connected = await provider.is_connected()
     assert connected
+    for cache_items in provider._request_cache.items():
+        cache_key, session = cache_items
+        await session.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### What was wrong?
Just saw some warnings that would be quick to clean up in tests. 


### How was it fixed?
Mostly closed some sessions. Renamed a class called `TestMiddleware` to `MockMiddleware` so pytest didn't think it was special.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i.pinimg.com/236x/5a/7b/fa/5a7bfa290568e1f3bd2593cf7cb5e6a3.jpg)
