### PR TITLE
``raw_tx.hex()`` -> ``raw_tx.to_0x_hex()``

### DIFF
--- a/newsfragments/3471.bugfix.rst
+++ b/newsfragments/3471.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug with newer ``hexbytes`` versions that yield non-0x-prefixed hex for ``HexBytes``: ``raw_transaction.hex()`` -> ``raw_transaction.to_0x_hex()``.

--- a/web3/middleware/signing.py
+++ b/web3/middleware/signing.py
@@ -189,7 +189,7 @@ class SignAndSendRawMiddlewareBuilder(Web3MiddlewareBuilder):
 
                 return (
                     RPCEndpoint("eth_sendRawTransaction"),
-                    [raw_tx.hex()],
+                    [raw_tx.to_0x_hex()],
                 )
 
     # -- async -- #
@@ -220,5 +220,5 @@ class SignAndSendRawMiddlewareBuilder(Web3MiddlewareBuilder):
 
                 return (
                     RPCEndpoint("eth_sendRawTransaction"),
-                    [raw_tx.hex()],
+                    [raw_tx.to_0x_hex()],
                 )


### PR DESCRIPTION
### What was wrong?

Closes #3470

### How was it fixed?

- ``raw_transaction.hex()`` -> ``raw_transaction.to_0x_hex()`` due to new ``hexbytes`` major version changes.
- Sync and async integration tests for ``SignAndSendRawMiddleware``.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![](https://img.freepik.com/premium-vector/colorful-cute-bug-hand-drawn-vector-illustration_835197-16325.jpg)
