### PR TITLE
Contract Events APIs

### DIFF
--- a/docs/web3.contract.rst
+++ b/docs/web3.contract.rst
@@ -210,7 +210,23 @@ Each Contract Factory exposes the following properties.
 Methods
 -------
 
+Method doctests use the following ABI and bytecode.
+
+.. code-block:: python
+
+    >>> bytecode = '6060604052341561000c57fe5b604051602080610acb833981016040528080519060200190919050505b620f42408114151561003b5760006000fd5b670de0b6b3a76400008102600281905550600254600060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020819055505b505b610a27806100a46000396000f30060606040523615610097576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806306fdde0314610099578063095ea7b31461013257806318160ddd1461018957806323b872dd146101af578063313ce5671461022557806370a082311461025157806395d89b411461029b578063a9059cbb14610334578063dd62ed3e1461038b575bfe5b34156100a157fe5b6100a96103f4565b60405180806020018281038252838181518152602001915080519060200190808383600083146100f8575b8051825260208311156100f8576020820191506020810190506020830392506100d4565b505050905090810190601f1680156101245780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561013a57fe5b61016f600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190505061042e565b604051808215151515815260200191505060405180910390f35b341561019157fe5b610199610521565b6040518082815260200191505060405180910390f35b34156101b757fe5b61020b600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091908035906020019091905050610527565b604051808215151515815260200191505060405180910390f35b341561022d57fe5b610235610791565b604051808260ff1660ff16815260200191505060405180910390f35b341561025957fe5b610285600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610796565b6040518082815260200191505060405180910390f35b34156102a357fe5b6102ab6107e0565b60405180806020018281038252838181518152602001915080519060200190808383600083146102fa575b8051825260208311156102fa576020820191506020810190506020830392506102d6565b505050905090810190601f1680156103265780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561033c57fe5b610371600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190505061081a565b604051808215151515815260200191505060405180910390f35b341561039357fe5b6103de600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610973565b6040518082815260200191505060405180910390f35b604060405190810160405280600981526020017f54657374546f6b656e000000000000000000000000000000000000000000000081525081565b600081600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020819055508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925846040518082815260200191505060405180910390a3600190505b92915050565b60025481565b600081600060008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205410806105f1575081600160008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054105b156105fc5760006000fd5b81600060008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254019250508190555081600060008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254039250508190555081600160008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600082825403925050819055508273ffffffffffffffffffffffffffffffffffffffff168473ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef846040518082815260200191505060405180910390a3600190505b9392505050565b601281565b6000600060008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205490505b919050565b604060405190810160405280600481526020017f544553540000000000000000000000000000000000000000000000000000000081525081565b600081600060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205410156108695760006000fd5b81600060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254039250508190555081600060008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600082825401925050819055508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef846040518082815260200191505060405180910390a3600190505b92915050565b6000600160008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205490505b929150505600a165627a7a723058205071371ee2a4a1be3c96e77d939cdc26161a256fdd638efc08bd33dfc65d3b850029'
+    >>> abi = '[{"constant":true,"inputs":[],"name":"name","outputs":[{"name":"","type":"string"}],"payable":false,"type":"function","stateMutability":"view"},{"constant":false,"inputs":[{"name":"_spender","type":"address"},{"name":"_value","type":"uint256"}],"name":"approve","outputs":[{"name":"","type":"bool"}],"payable":false,"type":"function","stateMutability":"nonpayable"},{"constant":true,"inputs":[],"name":"totalSupply","outputs":[{"name":"","type":"uint256"}],"payable":false,"type":"function","stateMutability":"view"},{"constant":false,"inputs":[{"name":"_from","type":"address"},{"name":"_to","type":"address"},{"name":"_value","type":"uint256"}],"name":"transferFrom","outputs":[{"name":"","type":"bool"}],"payable":false,"type":"function","stateMutability":"nonpayable"},{"constant":true,"inputs":[],"name":"decimals","outputs":[{"name":"","type":"uint8"}],"payable":false,"type":"function","stateMutability":"view"},{"constant":true,"inputs":[{"name":"_owner","type":"address"}],"name":"balanceOf","outputs":[{"name":"","type":"uint256"}],"payable":false,"type":"function","stateMutability":"view"},{"constant":true,"inputs":[],"name":"symbol","outputs":[{"name":"","type":"string"}],"payable":false,"type":"function","stateMutability":"view"},{"constant":false,"inputs":[{"name":"_to","type":"address"},{"name":"_value","type":"uint256"}],"name":"transfer","outputs":[{"name":"","type":"bool"}],"payable":false,"type":"function","stateMutability":"nonpayable"},{"constant":true,"inputs":[{"name":"_owner","type":"address"},{"name":"_spender","type":"address"}],"name":"allowance","outputs":[{"name":"","type":"uint256"}],"payable":false,"type":"function","stateMutability":"view"},{"inputs":[{"name":"_totalSupply","type":"uint256"}],"payable":false,"type":"constructor","stateMutability":"nonpayable"},{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"owner","type":"address"},{"indexed":true,"name":"spender","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Approval","type":"event"}]'
+    >>> contract = w3.eth.contract(abi=abi, bytecode=bytecode)
+
 Each Contract Factory exposes the following methods.
+
+.. testsetup:: contractmethods
+
+    from web3 import Web3
+    w3 = Web3(Web3.EthereumTesterProvider())
+    bytecode = '6060604052341561000c57fe5b604051602080610acb833981016040528080519060200190919050505b620f42408114151561003b5760006000fd5b670de0b6b3a76400008102600281905550600254600060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020819055505b505b610a27806100a46000396000f30060606040523615610097576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806306fdde0314610099578063095ea7b31461013257806318160ddd1461018957806323b872dd146101af578063313ce5671461022557806370a082311461025157806395d89b411461029b578063a9059cbb14610334578063dd62ed3e1461038b575bfe5b34156100a157fe5b6100a96103f4565b60405180806020018281038252838181518152602001915080519060200190808383600083146100f8575b8051825260208311156100f8576020820191506020810190506020830392506100d4565b505050905090810190601f1680156101245780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561013a57fe5b61016f600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190505061042e565b604051808215151515815260200191505060405180910390f35b341561019157fe5b610199610521565b6040518082815260200191505060405180910390f35b34156101b757fe5b61020b600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091908035906020019091905050610527565b604051808215151515815260200191505060405180910390f35b341561022d57fe5b610235610791565b604051808260ff1660ff16815260200191505060405180910390f35b341561025957fe5b610285600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610796565b6040518082815260200191505060405180910390f35b34156102a357fe5b6102ab6107e0565b60405180806020018281038252838181518152602001915080519060200190808383600083146102fa575b8051825260208311156102fa576020820191506020810190506020830392506102d6565b505050905090810190601f1680156103265780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b341561033c57fe5b610371600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803590602001909190505061081a565b604051808215151515815260200191505060405180910390f35b341561039357fe5b6103de600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610973565b6040518082815260200191505060405180910390f35b604060405190810160405280600981526020017f54657374546f6b656e000000000000000000000000000000000000000000000081525081565b600081600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020819055508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925846040518082815260200191505060405180910390a3600190505b92915050565b60025481565b600081600060008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205410806105f1575081600160008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054105b156105fc5760006000fd5b81600060008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254019250508190555081600060008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254039250508190555081600160008673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600082825403925050819055508273ffffffffffffffffffffffffffffffffffffffff168473ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef846040518082815260200191505060405180910390a3600190505b9392505050565b601281565b6000600060008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205490505b919050565b604060405190810160405280600481526020017f544553540000000000000000000000000000000000000000000000000000000081525081565b600081600060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205410156108695760006000fd5b81600060003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254039250508190555081600060008573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600082825401925050819055508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef846040518082815260200191505060405180910390a3600190505b92915050565b6000600160008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000205490505b929150505600a165627a7a723058205071371ee2a4a1be3c96e77d939cdc26161a256fdd638efc08bd33dfc65d3b850029'
+    abi = '[{"constant":true,"inputs":[],"name":"name","outputs":[{"name":"","type":"string"}],"payable":false,"type":"function","stateMutability":"view"},{"constant":false,"inputs":[{"name":"_spender","type":"address"},{"name":"_value","type":"uint256"}],"name":"approve","outputs":[{"name":"","type":"bool"}],"payable":false,"type":"function","stateMutability":"nonpayable"},{"constant":true,"inputs":[],"name":"totalSupply","outputs":[{"name":"","type":"uint256"}],"payable":false,"type":"function","stateMutability":"view"},{"constant":false,"inputs":[{"name":"_from","type":"address"},{"name":"_to","type":"address"},{"name":"_value","type":"uint256"}],"name":"transferFrom","outputs":[{"name":"","type":"bool"}],"payable":false,"type":"function","stateMutability":"nonpayable"},{"constant":true,"inputs":[],"name":"decimals","outputs":[{"name":"","type":"uint8"}],"payable":false,"type":"function","stateMutability":"view"},{"constant":true,"inputs":[{"name":"_owner","type":"address"}],"name":"balanceOf","outputs":[{"name":"","type":"uint256"}],"payable":false,"type":"function","stateMutability":"view"},{"constant":true,"inputs":[],"name":"symbol","outputs":[{"name":"","type":"string"}],"payable":false,"type":"function","stateMutability":"view"},{"constant":false,"inputs":[{"name":"_to","type":"address"},{"name":"_value","type":"uint256"}],"name":"transfer","outputs":[{"name":"","type":"bool"}],"payable":false,"type":"function","stateMutability":"nonpayable"},{"constant":true,"inputs":[{"name":"_owner","type":"address"},{"name":"_spender","type":"address"}],"name":"allowance","outputs":[{"name":"","type":"uint256"}],"payable":false,"type":"function","stateMutability":"view"},{"inputs":[{"name":"_totalSupply","type":"uint256"}],"payable":false,"type":"constructor","stateMutability":"nonpayable"},{"anonymous":false,"inputs":[{"indexed":true,"name":"from","type":"address"},{"indexed":true,"name":"to","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"name":"owner","type":"address"},{"indexed":true,"name":"spender","type":"address"},{"indexed":false,"name":"value","type":"uint256"}],"name":"Approval","type":"event"}]'
+    contract = w3.eth.contract(abi=abi, bytecode=bytecode)
 
 .. py:classmethod:: Contract.constructor(*args, **kwargs).transact(transaction=None)
 
@@ -232,12 +248,13 @@ Each Contract Factory exposes the following methods.
 
     Returns the transaction hash for the deploy transaction.
 
-    .. code-block:: python
+    .. doctest:: contractmethods
 
-        >>> deploy_txn = token_contract.constructor(web3.eth.accounts[0], 12345).transact()
-        >>> txn_receipt = web3.eth.get_transaction_receipt(deploy_txn)
+        >>> deploy_txn = contract.constructor(1000000).transact({'from': w3.eth.accounts[0], 'gas': 899000, 'gasPrice': Web3.to_wei(1, 'gwei')})
+        >>> txn_receipt = w3.eth.get_transaction_receipt(deploy_txn)
         >>> txn_receipt['contractAddress']
-        '0x4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318'
+        '0xF2E246BB76DF876Cef8b38ae84130F4F55De395b'
+
 
 .. py:classmethod:: Contract.constructor(*args, **kwargs).estimate_gas(transaction=None, block_identifier=None)
     :noindex:
@@ -257,10 +274,10 @@ Each Contract Factory exposes the following methods.
 
     Returns the gas needed to deploy the contract.
 
-    .. code-block:: python
+    .. doctest:: contractmethods
 
-        >>> token_contract.constructor(web3.eth.accounts[0], 12345).estimate_gas()
-        12563
+        >>> contract.constructor(1000000).estimate_gas()
+        664971
 
 .. py:classmethod:: Contract.constructor(*args, **kwargs).build_transaction(transaction=None)
     :noindex:
@@ -275,14 +292,15 @@ Each Contract Factory exposes the following methods.
 
     Returns the transaction dictionary that you can pass to send_transaction method.
 
-    .. code-block:: python
+    .. doctest:: contractmethods
 
         >>> transaction = {
-        'gasPrice': w3.eth.gas_price,
-        'chainId': None
-        }
-        >>> contract_data = token_contract.constructor(web3.eth.accounts[0], 12345).build_transaction(transaction)
-        >>> web3.eth.send_transaction(contract_data)
+        ...   'gas': 664971,
+        ...   'chainId': 131277322940537
+        ... }
+        >>> contract_data = contract.constructor(1000000).build_transaction(transaction)
+        >>> w3.eth.send_transaction(contract_data)
+        HexBytes('0x40c51804800dee88e14e69826cfe51bc5f25f61935331e8aa6d8d7771fb36350')
 
 .. _contract_create_filter:
 
@@ -296,32 +314,39 @@ Each Contract Factory exposes the following methods.
     - ``argument_filters``, optional. Expects a dictionary of argument names and values. When provided event logs are filtered for the event argument values. Event arguments can be both indexed or unindexed. Indexed values will be translated to their corresponding topic arguments. Unindexed arguments will be filtered using a regular expression.
     - ``topics`` optional, accepts the standard JSON-RPC topics argument.  See the JSON-RPC documentation for `eth_newFilter <https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_newfilter>`_ more information on the ``topics`` parameters.
 
+    .. doctest:: contractmethods
+
+        >>> filter = contract.events.Transfer.create_filter(from_block='latest')
+
 .. py:classmethod:: Contract.events.your_event_name.build_filter()
 
     Creates a EventFilterBuilder instance with the event abi, and the contract address if called from a deployed contract instance.  The EventFilterBuilder provides a convenient way to construct the filter parameters with value checking against the event abi. It allows for defining multiple match values or of single values through the match_any and match_single methods.
 
-    .. code-block:: python
+    .. doctest:: contractmethods
 
-        filter_builder = myContract.events.myEvent.build_filter()
-        filter_builder.from_block = "latest"
-        filter_builder.args.clientID.match_any(1, 2, 3, 4)
-        filter_builder.args.region.match_single("UK")
-        filter_instance = filter_builder.deploy()
+        >>> filter_builder = contract.events.Transfer.build_filter()
+        >>> filter_builder.from_block = "latest"
+        >>> filter_builder.args['from'].match_any(w3.eth.accounts[0])
+        >>> filter_builder.args['to'].match_single(w3.eth.accounts[1])
+        >>> filter_builder.args['value'].match_single(10000)
+        >>> filter_instance = filter_builder.deploy(w3)
 
     The ``deploy`` method returns a :py:class:`web3.utils.filters.LogFilter` instance from the filter parameters generated by the filter builder. Defining multiple match values for array arguments can be accomplished easily with the filter builder:
 
-    .. code-block:: python
+    .. doctest:: contractmethods
 
-        filter_builder = myContract.events.myEvent.build_filter()
-        filter_builder.args.clientGroups.match_any((1, 3, 5,), (2, 3, 5), (1, 2, 3))
+        >>> filter_builder = contract.events.Transfer.build_filter()
+        >>> filter_builder.args['to'].match_any(w3.eth.accounts[0], w3.eth.accounts[1])
 
     The filter builder blocks already defined filter parameters from being changed.
 
-    .. code-block:: python
+    .. doctest:: contractmethods
 
-        filter_builder = my_contract.events.myEvent.build_filter()
-        filter_builder.from_block = "latest"
-        filter_builder.from_block = 0  # raises a ValueError
+        >>> filter_builder = contract.events.Transfer.build_filter()
+        >>> filter_builder.from_block = "latest"
+        >>> filter_builder.from_block = 0
+        Traceback (most recent call last):
+        web3.exceptions.Web3ValueError: from_block is already set to 'latest'. Resetting filter parameters is not permitted
 
 .. py:classmethod:: Contract.encode_abi(abi_element_identifier, args=None, kwargs=None, data=None)
 
@@ -329,21 +354,116 @@ Each Contract Factory exposes the following methods.
     matches the given ``abi_element_identifier`` and arguments ``args``. The ``data`` parameter
     defaults to the function selector.
 
-    .. code-block:: python
+    .. doctest:: contractmethods
 
-      >>> contract.encode_abi("register", args=["rainbows", 10])
-      "0xea87152b0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000087261696e626f7773000000000000000000000000000000000000000000000000"
+      >>> contract.encode_abi("approve", args=[w3.eth.accounts[0], 10])
+      '0x095ea7b30000000000000000000000007e5f4552091a69125d5dfcb7b8c2659029395bdf000000000000000000000000000000000000000000000000000000000000000a'
 
+.. py:classmethod:: Contract.all_events()
+
+    Returns a list of all the events present in a Contract where every event is
+    an instance of :py:class:`ContractEvent`.
+
+    .. doctest:: contractmethods
+
+        >>> contract.all_events()
+        [<Event Transfer(address,address,uint256)>, <Event Approval(address,address,uint256)>]
+
+
+.. py:classmethod:: Contract.get_event_by_signature(signature)
+
+    Searches for a distinct event with matching signature. Returns an instance of
+    :py:class:`ContractEvent` upon finding a match. Raises ``Web3ValueError`` if no
+    match is found.
+
+    .. doctest:: contractmethods
+
+        >>> contract.get_event_by_signature('Transfer(address,address,uint256)')
+        <Event Transfer(address,address,uint256)>
+
+
+.. py:classmethod:: Contract.find_events_by_name(name)
+
+    Searches for all events matching the provided name. Returns a list of matching
+    events where every event is an instance of :py:class:`ContractEvent`. Returns an
+    empty list when no match is found.
+
+    .. doctest:: contractmethods
+
+        >>> contract.find_events_by_name('Transfer')
+        [<Event Transfer(address,address,uint256)>]
+
+
+.. py:classmethod:: Contract.get_event_by_name(name)
+
+    Searches for a distinct event matching the name. Returns an instance of
+    :py:class:`ContractEvent` upon finding a match. Raises ``Web3ValueError`` if no
+    match is found or if multiple matches are found.
+
+    .. doctest:: contractmethods
+
+        >>> contract.get_event_by_name('Approval')
+        <Event Approval(address,address,uint256)>
+
+.. py:classmethod:: Contract.find_events_by_selector(selector)
+
+    Searches for all events matching the provided selector. Returns a list of matching
+    events where every event is an instance of :py:class:`ContractEvent`. Returns an
+    empty list when no match is found.
+
+    .. doctest:: contractmethods
+
+        >>> contract.find_events_by_selector('0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925')
+        [<Event Approval(address,address,uint256)>]
+
+.. py:classmethod:: Contract.get_event_by_selector(selector)
+
+    Searches for a distinct event with matching selector.
+    The selector can be a hexadecimal string, bytes or int.
+    Returns an instance of :py:class:`ContractEvent` upon finding a match.
+    Raises ``Web3ValueError`` if no match is found.
+
+    .. doctest:: contractmethods
+
+        >>> contract.get_event_by_selector('0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925')
+        <Event Approval(address,address,uint256)>
+        >>> contract.get_event_by_selector(b'\x8c[\xe1\xe5\xeb\xec}[\xd1OqB}\x1e\x84\xf3\xdd\x03\x14\xc0\xf7\xb2)\x1e[ \n\xc8\xc7\xc3\xb9%')
+        <Event Approval(address,address,uint256)>
+        >>> contract.get_event_by_selector(0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925)
+        <Event Approval(address,address,uint256)>
+
+.. py:classmethod:: Contract.find_events_by_topic(topic)
+
+    Searches for all events matching the provided topic. Returns a list of matching
+    events where every event is an instance of :py:class:`ContractEvent`. Returns an
+    empty list when no match is found.
+
+    .. doctest:: contractmethods
+
+        >>> contract.find_events_by_topic('0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925')
+        [<Event Approval(address,address,uint256)>]
+
+.. py:classmethod:: Contract.get_event_by_topic(topic)
+
+    Searches for a distinct event with matching topic.
+    The topic is a hexadecimal string.
+    Returns an instance of :py:class:`ContractEvent` upon finding a match.
+    Raises ``Web3ValueError`` if no match is found.
+
+    .. doctest:: contractmethods
+
+        >>> contract.get_event_by_topic('0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925')
+        <Event Approval(address,address,uint256)>
 
 .. py:classmethod:: Contract.all_functions()
 
     Returns a list of all the functions present in a Contract where every function is
     an instance of :py:class:`ContractFunction`.
 
-    .. code-block:: python
+    .. doctest:: contractmethods
 
         >>> contract.all_functions()
-        [<Function identity(uint256,bool)>, <Function identity(int256,bool)>]
+        [<Function name()>, <Function approve(address,uint256)>, <Function totalSupply()>, <Function transferFrom(address,address,uint256)>, <Function decimals()>, <Function balanceOf(address)>, <Function symbol()>, <Function transfer(address,uint256)>, <Function allowance(address,address)>]
 
 
 .. py:classmethod:: Contract.get_function_by_signature(signature)
@@ -352,22 +472,22 @@ Each Contract Factory exposes the following methods.
     :py:class:`ContractFunction` upon finding a match. Raises ``Web3ValueError`` if no
     match is found.
 
-    .. code-block:: python
+    .. doctest:: contractmethods
 
-        >>> contract.get_function_by_signature('identity(uint256,bool)')
-        <Function identity(uint256,bool)>
+        >>> contract.get_function_by_signature('approve(address,uint256)')
+        <Function approve(address,uint256)>
 
 
 .. py:classmethod:: Contract.find_functions_by_name(name)
 
-    Searches for all function with matching name. Returns a list of matching functions
+    Searches for all functions matching the name. Returns a list of matching functions
     where every function is an instance of :py:class:`ContractFunction`. Returns an empty
     list when no match is found.
 
-    .. code-block:: python
+    .. doctest:: contractmethods
 
-        >>> contract.find_functions_by_name('identity')
-        [<Function identity(uint256,bool)>, <Function identity(int256,bool)>]
+        >>> contract.find_functions_by_name('transferFrom')
+        [<Function transferFrom(address,address,uint256)>]
 
 
 .. py:classmethod:: Contract.get_function_by_name(name)
@@ -376,10 +496,10 @@ Each Contract Factory exposes the following methods.
     :py:class:`ContractFunction` upon finding a match. Raises ``Web3ValueError`` if no
     match is found or if multiple matches are found.
 
-    .. code-block:: python
+    .. doctest:: contractmethods
 
-        >>> contract.get_function_by_name('unique_name')
-        <Function unique_name(uint256)>
+        >>> contract.get_function_by_name('decimals')
+        <Function decimals()>
 
 
 .. py:classmethod:: Contract.get_function_by_selector(selector)
@@ -389,14 +509,14 @@ Each Contract Factory exposes the following methods.
     Returns an instance of :py:class:`ContractFunction` upon finding a match.
     Raises ``Web3ValueError`` if no match is found.
 
-    .. code-block:: python
+    .. doctest:: contractmethods
 
-        >>> contract.get_function_by_selector('0xac37eebb')
-        <Function identity(uint256)'>
-        >>> contract.get_function_by_selector(b'\xac7\xee\xbb')
-        <Function identity(uint256)'>
-        >>> contract.get_function_by_selector(0xac37eebb)
-        <Function identity(uint256)'>
+        >>> contract.get_function_by_selector('0xdd62ed3e')
+        <Function allowance(address,address)>
+        >>> contract.get_function_by_selector(b'\xddb\xed>')
+        <Function allowance(address,address)>
+        >>> contract.get_function_by_selector(0xdd62ed3e)
+        <Function allowance(address,address)>
 
 
 .. py:classmethod:: Contract.find_functions_by_args(*args)
@@ -405,10 +525,10 @@ Each Contract Factory exposes the following methods.
     where every function is an instance of :py:class:`ContractFunction`. Returns an empty
     list when no match is found.
 
-    .. code-block:: python
+    .. doctest:: contractmethods
 
-        >>> contract.find_functions_by_args(1, True)
-        [<Function identity(uint256,bool)>, <Function identity(int256,bool)>]
+        >>> contract.find_functions_by_args(w3.eth.accounts[0], 10000)
+        [<Function approve(address,uint256)>, <Function transfer(address,uint256)>]
 
 
 .. py:classmethod:: Contract.get_function_by_args(*args)
@@ -417,10 +537,10 @@ Each Contract Factory exposes the following methods.
     :py:class:`ContractFunction` upon finding a match. Raises ``ValueError`` if no
     match is found or if multiple matches are found.
 
-    .. code-block:: python
+    .. doctest:: contractmethods
 
-        >>> contract.get_function_by_args(1)
-        <Function unique_func_with_args(uint256)>
+        >>> contract.get_function_by_args(w3.eth.accounts[0], w3.eth.accounts[1], 10000)
+        <Function transferFrom(address,address,uint256)>
 
 
 .. note::

--- a/newsfragments/3472.feature.rst
+++ b/newsfragments/3472.feature.rst
@@ -1,0 +1,1 @@
+New contract methods to obtain event elements from a contract ABI using a name, signature, selector, or topic.

--- a/tests/core/contracts/test_contract_ambiguous_functions.py
+++ b/tests/core/contracts/test_contract_ambiguous_functions.py
@@ -133,6 +133,53 @@ def test_find_or_get_functions_by_type(w3, method, args, repr_func, expected):
     assert repr_func(function) == expected
 
 
+def test_get_function_by_name(w3):
+    FUNCTION_NAME_OVERLAP_ABI = [
+        {
+            "anonymous": False,
+            "inputs": [],
+            "name": "increment",
+            "type": "function",
+        },
+        {
+            "anonymous": False,
+            "inputs": [],
+            "name": "incrementCount",
+            "type": "function",
+        },
+    ]
+    contract = w3.eth.contract(abi=FUNCTION_NAME_OVERLAP_ABI)
+
+    increment_func = contract.get_function_by_name("increment")
+    increment_count_func = contract.get_function_by_name("incrementCount")
+    assert repr(increment_func) == "<Function increment()>"
+    assert repr(increment_count_func) == "<Function incrementCount()>"
+
+
+def test_get_event_by_name(w3):
+    EVENT_NAME_OVERLAP_ABI = [
+        {
+            "anonymous": False,
+            "inputs": [],
+            "name": "Deposit",
+            "type": "event",
+        },
+        {
+            "anonymous": False,
+            "inputs": [],
+            "name": "Deposited",
+            "type": "event",
+        },
+    ]
+    contract = w3.eth.contract(abi=EVENT_NAME_OVERLAP_ABI)
+
+    deposit_event = contract.get_event_by_name("Deposit")
+    deposited_event = contract.get_event_by_name("Deposited")
+
+    assert repr(deposit_event) == "<Event Deposit()>"
+    assert repr(deposited_event) == "<Event Deposited()>"
+
+
 @pytest.mark.parametrize(
     "method,args,expected_message,expected_error",
     (

--- a/tests/core/contracts/test_contract_events.py
+++ b/tests/core/contracts/test_contract_events.py
@@ -1,0 +1,145 @@
+import pytest
+from typing import (
+    Any,
+    Callable,
+    Sequence,
+)
+
+from eth_typing import (
+    ABIEvent,
+)
+from eth_utils.toolz import (
+    compose,
+    curry,
+)
+
+from web3 import (
+    Web3,
+)
+from web3.contract.async_contract import (
+    AsyncContractEvent,
+)
+from web3.contract.contract import (
+    Contract,
+    ContractEvent,
+)
+
+map_repr = compose(list, curry(map, repr))
+
+
+@pytest.mark.parametrize(
+    "method,args,repr_func,expected",
+    (
+        (
+            "all_events",
+            (),
+            map_repr,
+            [
+                "<Event LogSingleArg(uint256)>",
+                "<Event LogSingleWithIndex(uint256)>",
+            ],
+        ),
+        (
+            "get_event_by_signature",
+            ("LogSingleArg(uint256)",),
+            repr,
+            "<Event LogSingleArg(uint256)>",
+        ),
+        (
+            "find_events_by_name",
+            ("LogSingleArg",),
+            map_repr,
+            [
+                "<Event LogSingleArg(uint256)>",
+            ],
+        ),
+        (
+            "get_event_by_name",
+            ("LogSingleArg",),
+            repr,
+            "<Event LogSingleArg(uint256)>",
+        ),
+        (
+            "find_events_by_selector",
+            (
+                b"\xf7\x0f\xe6\x89\xe2\x90\xd8\xce+*8\x8a\xc2\x8d\xb3o\xbb\x0e\x16\xa6\xd8\x9ch\x04\xc4a\xf6Z\x1b@\xbb\x15",  # noqa: E501
+            ),
+            map_repr,
+            [
+                "<Event LogSingleWithIndex(uint256)>",
+            ],
+        ),
+        (
+            "get_event_by_selector",
+            (
+                b"\xf7\x0f\xe6\x89\xe2\x90\xd8\xce+*8\x8a\xc2\x8d\xb3o\xbb\x0e\x16\xa6\xd8\x9ch\x04\xc4a\xf6Z\x1b@\xbb\x15",  # noqa: E501
+            ),
+            repr,
+            "<Event LogSingleWithIndex(uint256)>",
+        ),
+        (
+            "get_event_by_selector",
+            (0xF70FE689E290D8CE2B2A388AC28DB36FBB0E16A6D89C6804C461F65A1B40BB15,),
+            repr,
+            "<Event LogSingleWithIndex(uint256)>",
+        ),
+        (
+            "get_event_by_selector",
+            ("0xf70fe689e290d8ce2b2a388ac28db36fbb0e16a6d89c6804c461f65a1b40bb15",),
+            repr,
+            "<Event LogSingleWithIndex(uint256)>",
+        ),
+        (
+            "get_event_by_topic",
+            ("0x56d2ef3c5228bf5d88573621e325a4672ab50e033749a601e4f4a5e1dce905d4",),
+            repr,
+            "<Event LogSingleArg(uint256)>",
+        ),
+    ),
+)
+def test_find_or_get_events_by_type(
+    w3: "Web3",
+    method: str,
+    args: Sequence[str],
+    repr_func: Callable[[Any], str],
+    expected: str,
+    event_contract: "Contract",
+) -> None:
+    contract = w3.eth.contract(abi=event_contract.abi)
+    contract_event = getattr(contract, method)(*args)
+    assert repr_func(contract_event) == expected
+
+
+def test_find_events_by_identifier(w3: "Web3", event_contract: "Contract") -> None:
+    def callable_check(event_abi: ABIEvent) -> bool:
+        return event_abi["name"] == "LogSingleArg"
+
+    contract_events = event_contract.find_events_by_identifier(
+        event_contract.abi, w3, event_contract.address, callable_check
+    )
+    assert [repr(evt) for evt in contract_events] == ["<Event LogSingleArg(uint256)>"]
+
+
+def test_get_event_by_identifier(w3: "Web3", event_contract: "Contract") -> None:
+    contract_event = event_contract.get_event_by_identifier(
+        [event_contract.events.LogSingleArg], "LogSingleArg"
+    )
+    assert repr(contract_event) == "<Event LogSingleArg(uint256)>"
+
+
+def test_events_iterator(math_contract):
+    all_events = math_contract.all_events()
+    events_iter = math_contract.events
+
+    for event, expected_event in zip(iter(events_iter), all_events):
+        assert isinstance(event, ContractEvent)
+        assert event.name == expected_event.name
+
+
+def test_async_events_iterator(async_math_contract):
+    all_events = async_math_contract.all_events()
+    events_iter = async_math_contract.events
+
+    for event, expected_event in zip(iter(events_iter), all_events):
+        assert isinstance(event, AsyncContractEvent)
+        assert event.name == expected_event.name

--- a/tests/core/contracts/test_extracting_event_data.py
+++ b/tests/core/contracts/test_extracting_event_data.py
@@ -773,6 +773,7 @@ def test_contract_event_get_logs_sorted_by_log_index(w3, emitter, request_mocker
         ),
     ),
 )
+@pytest.mark.parametrize("event_is_instance", (True, False))
 def test_event_rich_log(
     w3,
     emitter,
@@ -784,6 +785,7 @@ def test_event_rich_log(
     call_args,
     process_receipt,
     expected_args,
+    event_is_instance,
 ):
     emitter_fn = emitter.functions[contract_fn]
     if hasattr(emitter_contract_event_ids, event_name):
@@ -796,14 +798,19 @@ def test_event_rich_log(
         txn_hash = emitter_fn(*call_args).transact()
     txn_receipt = wait_for_transaction(w3, txn_hash)
 
-    event_instance = emitter.events[event_name]
+    if event_is_instance:
+        event_object = emitter.events[event_name]()
+    elif not event_is_instance:
+        event_object = emitter.events[event_name]
+    else:
+        raise Exception("Unreachable!")
 
     if process_receipt:
-        processed_logs = event_instance.process_receipt(txn_receipt)
+        processed_logs = event_object.process_receipt(txn_receipt)
         assert len(processed_logs) == 1
         rich_log = processed_logs[0]
     elif not process_receipt:
-        rich_log = event_instance.process_log(txn_receipt["logs"][0])
+        rich_log = event_object.process_log(txn_receipt["logs"][0])
     else:
         raise Exception("Unreachable!")
 
@@ -1036,6 +1043,7 @@ def test_event_rich_log(
         ),
     ),
 )
+@pytest.mark.parametrize("event_is_instance", (True, False))
 def test_event_rich_log_non_strict(
     w3_non_strict_abi,
     non_strict_emitter,
@@ -1047,6 +1055,7 @@ def test_event_rich_log_non_strict(
     call_args,
     process_receipt,
     expected_args,
+    event_is_instance,
 ):
     emitter_fn = non_strict_emitter.functions[contract_fn]
     if hasattr(emitter_contract_event_ids, event_name):
@@ -1059,14 +1068,19 @@ def test_event_rich_log_non_strict(
         txn_hash = emitter_fn(*call_args).transact()
     txn_receipt = wait_for_transaction(w3_non_strict_abi, txn_hash)
 
-    event_instance = non_strict_emitter.events[event_name]
+    if event_is_instance:
+        event_object = non_strict_emitter.events[event_name]()
+    elif not event_is_instance:
+        event_object = non_strict_emitter.events[event_name]
+    else:
+        raise Exception("Unreachable!")
 
     if process_receipt:
-        processed_logs = event_instance.process_receipt(txn_receipt)
+        processed_logs = event_object.process_receipt(txn_receipt)
         assert len(processed_logs) == 1
         rich_log = processed_logs[0]
     elif not process_receipt:
-        rich_log = event_instance.process_log(txn_receipt["logs"][0])
+        rich_log = event_object.process_log(txn_receipt["logs"][0])
     else:
         raise Exception("Unreachable!")
 

--- a/tests/core/contracts/test_extracting_event_data.py
+++ b/tests/core/contracts/test_extracting_event_data.py
@@ -128,7 +128,7 @@ def test_event_data_extraction(
     assert len(txn_receipt["logs"]) == 1
     log_entry = txn_receipt["logs"][0]
 
-    event_abi = emitter._get_event_abi(event_name)
+    event_abi = emitter.get_event_by_name(event_name).abi
 
     event_topic = getattr(emitter_contract_log_topics, event_name)
     is_anonymous = event_abi["anonymous"]
@@ -335,7 +335,7 @@ def test_event_data_extraction_bytes(
     log_entry = txn_receipt["logs"][0]
 
     event_name = "LogListArgs"
-    event_abi = emitter._get_event_abi(event_name)
+    event_abi = emitter.get_event_by_name(event_name).abi
 
     event_topic = getattr(emitter_contract_log_topics, event_name)
 
@@ -386,7 +386,7 @@ def test_event_data_extraction_bytes_non_strict(
     log_entry = txn_receipt["logs"][0]
 
     event_name = "LogListArgs"
-    event_abi = non_strict_emitter._get_event_abi(event_name)
+    event_abi = non_strict_emitter.get_event_by_name(event_name).abi
 
     event_topic = getattr(emitter_contract_log_topics, event_name)
 
@@ -431,7 +431,7 @@ def test_dynamic_length_argument_extraction(
     assert len(txn_receipt["logs"]) == 1
     log_entry = txn_receipt["logs"][0]
 
-    event_abi = emitter._get_event_abi("LogDynamicArgs")
+    event_abi = emitter.get_event_by_name("LogDynamicArgs").abi
 
     event_topic = emitter_contract_log_topics.LogDynamicArgs
     assert event_topic in log_entry["topics"]
@@ -466,7 +466,7 @@ def test_argument_extraction_strict_bytes_types(
     log_entry = txn_receipt["logs"][0]
     assert len(log_entry["topics"]) == 2
 
-    event_abi = emitter._get_event_abi("LogListArgs")
+    event_abi = emitter.get_event_by_name("LogListArgs").abi
 
     event_topic = emitter_contract_log_topics.LogListArgs
     assert event_topic in log_entry["topics"]
@@ -545,14 +545,14 @@ def test_contract_event_get_logs_sorted_by_log_index(w3, emitter, request_mocker
     ]
 
     with request_mocker(w3, mock_results={"eth_getLogs": get_logs_response}):
-        logs = emitter.events.LogNoArguments().get_logs()
+        logs = emitter.events.LogNoArguments.get_logs()
 
         sorted_logs = sorted(
-            emitter.events.LogNoArguments().get_logs(),
+            emitter.events.LogNoArguments.get_logs(),
             key=lambda log: log["logIndex"],
         )
         sorted_logs = sorted(
-            emitter.events.LogNoArguments().get_logs(),
+            emitter.events.LogNoArguments.get_logs(),
             key=lambda log: log["blockNumber"],
         )
 
@@ -796,7 +796,7 @@ def test_event_rich_log(
         txn_hash = emitter_fn(*call_args).transact()
     txn_receipt = wait_for_transaction(w3, txn_hash)
 
-    event_instance = emitter.events[event_name]()
+    event_instance = emitter.events[event_name]
 
     if process_receipt:
         processed_logs = event_instance.process_receipt(txn_receipt)
@@ -819,7 +819,7 @@ def test_event_rich_log(
 
     quiet_event = emitter.events["LogBytes"]
     with pytest.warns(UserWarning, match=warning_msg):
-        empty_rich_log = quiet_event().process_receipt(txn_receipt)
+        empty_rich_log = quiet_event.process_receipt(txn_receipt)
         assert empty_rich_log == tuple()
 
 
@@ -1059,7 +1059,7 @@ def test_event_rich_log_non_strict(
         txn_hash = emitter_fn(*call_args).transact()
     txn_receipt = wait_for_transaction(w3_non_strict_abi, txn_hash)
 
-    event_instance = non_strict_emitter.events[event_name]()
+    event_instance = non_strict_emitter.events[event_name]
 
     if process_receipt:
         processed_logs = event_instance.process_receipt(txn_receipt)
@@ -1082,7 +1082,7 @@ def test_event_rich_log_non_strict(
 
     quiet_event = non_strict_emitter.events["LogBytes"]
     with pytest.warns(UserWarning, match=warning_msg):
-        empty_rich_log = quiet_event().process_receipt(txn_receipt)
+        empty_rich_log = quiet_event.process_receipt(txn_receipt)
         assert empty_rich_log == tuple()
 
 
@@ -1093,7 +1093,7 @@ def test_event_rich_log_with_byte_args(
     txn_hash = emitter.functions.logListArgs([b"13"], [b"54"]).transact()
     txn_receipt = wait_for_transaction(w3, txn_hash)
 
-    event_instance = emitter.events.LogListArgs()
+    event_instance = emitter.events.LogListArgs
 
     if process_receipt:
         processed_logs = event_instance.process_receipt(txn_receipt)
@@ -1122,7 +1122,7 @@ def test_event_rich_log_with_byte_args(
 def test_receipt_processing_with_discard_flag(
     event_contract, indexed_event_contract, dup_txn_receipt, wait_for_transaction
 ):
-    event_instance = indexed_event_contract.events.LogSingleWithIndex()
+    event_instance = indexed_event_contract.events.LogSingleWithIndex
 
     returned_logs = event_instance.process_receipt(dup_txn_receipt, errors=DISCARD)
     assert returned_logs == ()
@@ -1131,7 +1131,7 @@ def test_receipt_processing_with_discard_flag(
 def test_receipt_processing_with_ignore_flag(
     event_contract, indexed_event_contract, dup_txn_receipt, wait_for_transaction
 ):
-    event_instance = indexed_event_contract.events.LogSingleWithIndex()
+    event_instance = indexed_event_contract.events.LogSingleWithIndex
 
     returned_logs = event_instance.process_receipt(dup_txn_receipt, errors=IGNORE)
     assert len(returned_logs) == 2
@@ -1155,7 +1155,7 @@ def test_receipt_processing_with_ignore_flag(
 
 
 def test_receipt_processing_with_warn_flag(indexed_event_contract, dup_txn_receipt):
-    event_instance = indexed_event_contract.events.LogSingleWithIndex()
+    event_instance = indexed_event_contract.events.LogSingleWithIndex
 
     with pytest.warns(UserWarning, match="Expected 1 log topics.  Got 0"):
         returned_logs = event_instance.process_receipt(dup_txn_receipt, errors=WARN)
@@ -1163,21 +1163,21 @@ def test_receipt_processing_with_warn_flag(indexed_event_contract, dup_txn_recei
 
 
 def test_receipt_processing_with_strict_flag(indexed_event_contract, dup_txn_receipt):
-    event_instance = indexed_event_contract.events.LogSingleWithIndex()
+    event_instance = indexed_event_contract.events.LogSingleWithIndex
 
     with pytest.raises(LogTopicError, match="Expected 1 log topics.  Got 0"):
         event_instance.process_receipt(dup_txn_receipt, errors=STRICT)
 
 
 def test_receipt_processing_with_invalid_flag(indexed_event_contract, dup_txn_receipt):
-    event_instance = indexed_event_contract.events.LogSingleWithIndex()
+    event_instance = indexed_event_contract.events.LogSingleWithIndex
 
     with pytest.raises(Web3AttributeError, match="Error flag must be one of: "):
         event_instance.process_receipt(dup_txn_receipt, errors="not-a-flag")
 
 
 def test_receipt_processing_with_no_flag(indexed_event_contract, dup_txn_receipt):
-    event_instance = indexed_event_contract.events.LogSingleWithIndex()
+    event_instance = indexed_event_contract.events.LogSingleWithIndex
 
     with pytest.warns(UserWarning, match="Expected 1 log topics.  Got 0"):
         returned_log = event_instance.process_receipt(dup_txn_receipt)
@@ -1185,7 +1185,7 @@ def test_receipt_processing_with_no_flag(indexed_event_contract, dup_txn_receipt
 
 
 def test_single_log_processing_with_errors(indexed_event_contract, dup_txn_receipt):
-    event_instance = indexed_event_contract.events.LogSingleWithIndex()
+    event_instance = indexed_event_contract.events.LogSingleWithIndex
 
     with pytest.raises(LogTopicError, match="Expected 1 log topics.  Got 0"):
         event_instance.process_log(dup_txn_receipt["logs"][0])
@@ -1244,7 +1244,7 @@ def test_receipt_processing_catches_insufficientdatabytes_error_by_default(
 ):
     txn_hash = emitter.functions.logListArgs([b"13"], [b"54"]).transact()
     txn_receipt = wait_for_transaction(w3, txn_hash)
-    event_instance = emitter.events.LogListArgs()
+    event_instance = emitter.events.LogListArgs
 
     # web3 doesn't generate logs with non-standard lengths, so we have to do it manually
     txn_receipt_dict = copy.deepcopy(txn_receipt)

--- a/tests/core/contracts/test_extracting_event_data_old.py
+++ b/tests/core/contracts/test_extracting_event_data_old.py
@@ -97,7 +97,7 @@ def test_event_data_extraction(
     assert len(txn_receipt["logs"]) == 1
     log_entry = txn_receipt["logs"][0]
 
-    event_abi = emitter._get_event_abi(event_name)
+    event_abi = emitter.get_event_by_name(event_name).abi
 
     event_topic = getattr(emitter_contract_log_topics, event_name)
     is_anonymous = event_abi["anonymous"]
@@ -132,7 +132,7 @@ def test_dynamic_length_argument_extraction(
     assert len(txn_receipt["logs"]) == 1
     log_entry = txn_receipt["logs"][0]
 
-    event_abi = emitter._get_event_abi("LogDynamicArgs")
+    event_abi = emitter.get_event_by_name("LogDynamicArgs").abi
 
     event_topic = emitter_contract_log_topics.LogDynamicArgs
     assert event_topic in log_entry["topics"]

--- a/tests/core/contracts/test_extracting_event_data_old.py
+++ b/tests/core/contracts/test_extracting_event_data_old.py
@@ -9,28 +9,6 @@ from web3._utils.events import (
 )
 
 
-@pytest.fixture()
-def emitter(
-    w3,
-    emitter_contract_data,
-    wait_for_transaction,
-    wait_for_block,
-    address_conversion_func,
-):
-    emitter_contract_factory = w3.eth.contract(**emitter_contract_data)
-
-    wait_for_block(w3)
-    deploy_txn_hash = emitter_contract_factory.constructor().transact({"gas": 10000000})
-    deploy_receipt = wait_for_transaction(w3, deploy_txn_hash)
-    contract_address = address_conversion_func(deploy_receipt["contractAddress"])
-
-    bytecode = w3.eth.get_code(contract_address)
-    assert bytecode == emitter_contract_factory.bytecode_runtime
-    _emitter = emitter_contract_factory(address=contract_address)
-    assert _emitter.address == contract_address
-    return _emitter
-
-
 @pytest.mark.parametrize(
     "contract_fn,event_name,call_args,expected_args",
     (

--- a/tests/core/filtering/test_filters_against_many_blocks.py
+++ b/tests/core/filtering/test_filters_against_many_blocks.py
@@ -50,9 +50,7 @@ def test_event_filter_new_events(
         builder.from_block = "latest"
         event_filter = builder.deploy(w3)
     else:
-        event_filter = emitter.events.LogNoArguments().create_filter(
-            from_block="latest"
-        )
+        event_filter = emitter.events.LogNoArguments.create_filter(from_block="latest")
 
     expected_match_counter = 0
 
@@ -109,9 +107,7 @@ def test_event_filter_new_events_many_deployed_contracts(
         builder.from_block = "latest"
         event_filter = builder.deploy(w3)
     else:
-        event_filter = emitter.events.LogNoArguments().create_filter(
-            from_block="latest"
-        )
+        event_filter = emitter.events.LogNoArguments.create_filter(from_block="latest")
 
     expected_match_counter = 0
 
@@ -179,7 +175,7 @@ async def test_async_event_filter_new_events(
         builder.from_block = "latest"
         event_filter = await builder.deploy(async_w3)
     else:
-        event_filter = await async_emitter.events.LogNoArguments().create_filter(
+        event_filter = await async_emitter.events.LogNoArguments.create_filter(
             from_block="latest"
         )
 
@@ -247,7 +243,7 @@ async def test_async_event_filter_new_events_many_deployed_contracts(
         builder.from_block = "latest"
         event_filter = await builder.deploy(async_w3)
     else:
-        event_filter = await async_emitter.events.LogNoArguments().create_filter(
+        event_filter = await async_emitter.events.LogNoArguments.create_filter(
             from_block="latest"
         )
 

--- a/web3/contract/async_contract.py
+++ b/web3/contract/async_contract.py
@@ -137,7 +137,7 @@ class AsyncContractEvent(BaseContractEvent):
             from = max(mycontract.web3.eth.block_number - 10, 1)
             to = mycontract.web3.eth.block_number
 
-            events = mycontract.events.Transfer.getLogs(from_block=from, to_block=to)
+            events = mycontract.events.Transfer.get_logs(from_block=from, to_block=to)
 
             for e in events:
                 print(e["args"]["from"],

--- a/web3/contract/async_contract.py
+++ b/web3/contract/async_contract.py
@@ -79,7 +79,9 @@ from web3.contract.utils import (
     async_call_contract_function,
     async_estimate_gas_for_function,
     async_transact_with_contract_function,
+    find_events_by_identifier,
     find_functions_by_identifier,
+    get_event_by_identifier,
     get_function_by_identifier,
 )
 from web3.exceptions import (
@@ -238,6 +240,12 @@ class AsyncContractEvent(BaseContractEvent):
         )
         builder.address = self.address
         return builder
+
+    @classmethod
+    def factory(cls, class_name: str, **kwargs: Any) -> Self:
+        return PropertyCheckingFactory(class_name, (cls,), kwargs)(
+            abi=kwargs.get("abi")
+        )
 
 
 class AsyncContractEvents(BaseContractEvents):
@@ -555,6 +563,27 @@ class AsyncContract(BaseContract):
         cls, fns: Sequence["AsyncContractFunction"], identifier: str
     ) -> "AsyncContractFunction":
         return get_function_by_identifier(fns, identifier)
+
+    @combomethod
+    def find_events_by_identifier(
+        cls,
+        contract_abi: ABI,
+        w3: "AsyncWeb3",
+        address: ChecksumAddress,
+        callable_check: Callable[..., Any],
+    ) -> List["AsyncContractEvent"]:
+        return cast(
+            List["AsyncContractEvent"],
+            find_events_by_identifier(
+                contract_abi, w3, address, callable_check, AsyncContractEvent
+            ),
+        )
+
+    @combomethod
+    def get_event_by_identifier(
+        cls, events: Sequence["AsyncContractEvent"], identifier: str
+    ) -> "AsyncContractEvent":
+        return get_event_by_identifier(events, identifier)
 
 
 class AsyncContractCaller(BaseContractCaller):

--- a/web3/contract/async_contract.py
+++ b/web3/contract/async_contract.py
@@ -589,11 +589,8 @@ class AsyncContract(BaseContract):
         address: ChecksumAddress,
         callable_check: Callable[..., Any],
     ) -> List["AsyncContractEvent"]:
-        return cast(
-            List["AsyncContractEvent"],
-            find_events_by_identifier(
-                contract_abi, w3, address, callable_check, AsyncContractEvent
-            ),
+        return find_events_by_identifier(
+            contract_abi, w3, address, callable_check, AsyncContractEvent
         )
 
     @combomethod

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -178,8 +178,9 @@ class BaseContractEvent:
     def process_receipt(
         self, txn_receipt: TxReceipt, errors: EventLogErrorFlags = WARN
     ) -> Iterable[EventData]:
-        return self._parse_logs(txn_receipt, errors)
+        return self._parse_logs(txn_receipt=txn_receipt, errors=errors)
 
+    @combomethod
     @to_tuple
     def _parse_logs(
         self, txn_receipt: TxReceipt, errors: EventLogErrorFlags
@@ -944,14 +945,9 @@ class BaseContract:
         Raises a Web3ValueError if the signature is invalid or if there is no match or
         more than one is found.
         """
-        if " " in signature:
-            raise Web3ValueError(
-                "Event signature should not contain any spaces. "
-                f"Found spaces in input: {signature}"
-            )
 
         def callable_check(event_abi: ABIEvent) -> bool:
-            return abi_to_signature(event_abi) == signature
+            return abi_to_signature(event_abi) == signature.replace(" ", "")
 
         events = self.find_events_by_identifier(
             self.abi, self.w3, self.address, callable_check

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -1032,75 +1032,6 @@ class BaseContract:
         events = self.find_events_by_topic(topic)
         return self.get_event_by_identifier(events, "topic")
 
-    #
-    # Private Helpers
-    #
-    _return_data_normalizers: Tuple[Callable[..., Any], ...] = tuple()
-
-    @classmethod
-    def _prepare_transaction(
-        cls,
-        abi_element_identifier: ABIElementIdentifier,
-        fn_args: Optional[Any] = None,
-        fn_kwargs: Optional[Any] = None,
-        transaction: Optional[TxParams] = None,
-    ) -> TxParams:
-        return prepare_transaction(
-            cls.address,
-            cls.w3,
-            abi_element_identifier=abi_element_identifier,
-            contract_abi=cls.abi,
-            transaction=transaction,
-            fn_args=fn_args,
-            fn_kwargs=fn_kwargs,
-        )
-
-    @classmethod
-    def _find_matching_fn_abi(
-        cls,
-        fn_identifier: Optional[ABIElementIdentifier] = None,
-        *args: Sequence[Any],
-        **kwargs: Dict[str, Any],
-    ) -> ABIElement:
-        return get_abi_element(
-            cls.abi,
-            fn_identifier,
-            *args,
-            abi_codec=cls.w3.codec,
-            **kwargs,
-        )
-
-    @classmethod
-    def _get_event_abi(
-        cls,
-        event_name: Optional[str] = None,
-        argument_names: Optional[Sequence[str]] = None,
-    ) -> ABIEvent:
-        return get_event_abi(
-            abi=cls.abi, event_name=event_name, argument_names=argument_names
-        )
-
-    @combomethod
-    def _encode_constructor_data(
-        cls, *args: Sequence[Any], **kwargs: Dict[str, Any]
-    ) -> HexStr:
-        constructor_abi = find_constructor_abi_element_by_type(cls.abi)
-
-        if constructor_abi:
-            arguments = get_normalized_abi_inputs(constructor_abi, *args, **kwargs)
-
-            deploy_data = add_0x_prefix(
-                encode_abi(cls.w3, constructor_abi, arguments, data=cls.bytecode)
-            )
-        else:
-            if args or kwargs:
-                msg = "Constructor args were provided, but no constructor function was provided."  # noqa: E501
-                raise Web3TypeError(msg)
-
-            deploy_data = to_hex(cls.bytecode)
-
-        return deploy_data
-
     @combomethod
     def find_functions_by_identifier(
         cls,
@@ -1176,6 +1107,75 @@ class BaseContract:
             )()
 
         return cast(function_type, NonExistentReceiveFunction())  # type: ignore
+
+    #
+    # Private Helpers
+    #
+    _return_data_normalizers: Tuple[Callable[..., Any], ...] = tuple()
+
+    @classmethod
+    def _prepare_transaction(
+        cls,
+        abi_element_identifier: ABIElementIdentifier,
+        fn_args: Optional[Any] = None,
+        fn_kwargs: Optional[Any] = None,
+        transaction: Optional[TxParams] = None,
+    ) -> TxParams:
+        return prepare_transaction(
+            cls.address,
+            cls.w3,
+            abi_element_identifier=abi_element_identifier,
+            contract_abi=cls.abi,
+            transaction=transaction,
+            fn_args=fn_args,
+            fn_kwargs=fn_kwargs,
+        )
+
+    @classmethod
+    def _find_matching_fn_abi(
+        cls,
+        fn_identifier: Optional[ABIElementIdentifier] = None,
+        *args: Sequence[Any],
+        **kwargs: Dict[str, Any],
+    ) -> ABIElement:
+        return get_abi_element(
+            cls.abi,
+            fn_identifier,
+            *args,
+            abi_codec=cls.w3.codec,
+            **kwargs,
+        )
+
+    @classmethod
+    def _get_event_abi(
+        cls,
+        event_name: Optional[str] = None,
+        argument_names: Optional[Sequence[str]] = None,
+    ) -> ABIEvent:
+        return get_event_abi(
+            abi=cls.abi, event_name=event_name, argument_names=argument_names
+        )
+
+    @combomethod
+    def _encode_constructor_data(
+        cls, *args: Sequence[Any], **kwargs: Dict[str, Any]
+    ) -> HexStr:
+        constructor_abi = find_constructor_abi_element_by_type(cls.abi)
+
+        if constructor_abi:
+            arguments = get_normalized_abi_inputs(constructor_abi, *args, **kwargs)
+
+            deploy_data = add_0x_prefix(
+                encode_abi(cls.w3, constructor_abi, arguments, data=cls.bytecode)
+            )
+        else:
+            if args or kwargs:
+                msg = "Constructor args were provided, but no constructor function was provided."  # noqa: E501
+                raise Web3TypeError(msg)
+
+            deploy_data = to_hex(cls.bytecode)
+
+        return deploy_data
 
 
 class BaseContractCaller:

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -38,6 +38,8 @@ from eth_utils import (
     get_normalized_abi_inputs,
     is_list_like,
     is_text,
+    keccak,
+    to_bytes,
     to_tuple,
 )
 from hexbytes import (
@@ -66,6 +68,7 @@ from web3._utils.empty import (
     empty,
 )
 from web3._utils.encoding import (
+    hexstr_if_str,
     to_4byte_hex,
     to_hex,
 )
@@ -130,8 +133,14 @@ if TYPE_CHECKING:
         Web3,
     )
 
-    from .async_contract import AsyncContractFunction  # noqa: F401
-    from .contract import ContractFunction  # noqa: F401
+    from .async_contract import (  # noqa: F401
+        AsyncContractEvent,
+        AsyncContractFunction,
+    )
+    from .contract import (  # noqa: F401
+        ContractEvent,
+        ContractFunction,
+    )
 
 
 class BaseContractEvent:
@@ -148,14 +157,18 @@ class BaseContractEvent:
     contract_abi: ABI = None
     abi: ABIEvent = None
 
-    def __init__(self, *argument_names: Tuple[str]) -> None:
+    def __init__(self, *argument_names: Tuple[str], abi: ABIEvent) -> None:
+        self.abi = abi
+        self.name = type(self).__name__
+
         if argument_names is None:
             # https://github.com/python/mypy/issues/6283
             self.argument_names = tuple()  # type: ignore
         else:
             self.argument_names = argument_names
 
-        self.abi = self._get_event_abi()
+    def __repr__(self) -> str:
+        return f"<Event {abi_to_signature(self.abi)}>"
 
     @classmethod
     def _get_event_abi(cls) -> ABIEvent:
@@ -258,8 +271,12 @@ class BaseContractEvent:
         return event_filter_params
 
     @classmethod
-    def factory(cls, class_name: str, **kwargs: Any) -> PropertyCheckingFactory:
-        return PropertyCheckingFactory(class_name, (cls,), kwargs)
+    def factory(
+        cls, class_name: str, **kwargs: Any
+    ) -> Union["ContractEvent", "AsyncContractEvent"]:
+        return PropertyCheckingFactory(class_name, (cls,), kwargs)(
+            abi=kwargs.get("abi")
+        )
 
     @staticmethod
     def check_for_forbidden_api_filter_arguments(
@@ -414,7 +431,7 @@ class BaseContractEvents:
         self,
         abi: ABI,
         w3: Union["Web3", "AsyncWeb3"],
-        contract_event_type: Type["BaseContractEvent"],
+        contract_event_type: Union[Type["ContractEvent"], Type["AsyncContractEvent"]],
         address: Optional[ChecksumAddress] = None,
     ) -> None:
         if abi:
@@ -430,6 +447,7 @@ class BaseContractEvents:
                         contract_abi=self.abi,
                         address=address,
                         event_name=event["name"],
+                        abi=event,
                     ),
                 )
 
@@ -658,7 +676,9 @@ class BaseContractFunction:
     def factory(
         cls, class_name: str, **kwargs: Any
     ) -> Union["ContractFunction", "AsyncContractFunction"]:
-        return PropertyCheckingFactory(class_name, (cls,), kwargs)(kwargs.get("abi"))
+        return PropertyCheckingFactory(class_name, (cls,), kwargs)(
+            abi=kwargs.get("abi")
+        )
 
 
 class BaseContractFunctions:
@@ -766,7 +786,7 @@ class BaseContract:
     ) -> HexStr:
         """
         Encodes the arguments using the Ethereum ABI for the contract function
-        that matches the given name and arguments..
+        that matches the given name and arguments.
 
         :param data: defaults to function selector
         """
@@ -786,16 +806,27 @@ class BaseContract:
 
         return encode_abi(cls.w3, element_info["abi"], element_info["arguments"], data)
 
+    #
+    # Functions API
+    #
     @combomethod
     def all_functions(
         self,
     ) -> "BaseContractFunction":
+        """
+        Return all functions in the contract.
+        """
         return self.find_functions_by_identifier(
             self.abi, self.w3, self.address, lambda _: True
         )
 
     @combomethod
     def get_function_by_signature(self, signature: str) -> "BaseContractFunction":
+        """
+        Return a distinct function with matching signature.
+        Raises a Web3ValueError if the signature is invalid or if there is no match or
+        more than one is found.
+        """
         if " " in signature:
             raise Web3ValueError(
                 "Function signature should not contain any spaces. "
@@ -812,6 +843,11 @@ class BaseContract:
 
     @combomethod
     def find_functions_by_name(self, fn_name: str) -> "BaseContractFunction":
+        """
+        Return all functions with matching name.
+        Raises a Web3ValueError if there is no match or more than one is found.
+        """
+
         def callable_check(fn_abi: ABIFunction) -> bool:
             return fn_abi["name"] == fn_name
 
@@ -821,6 +857,10 @@ class BaseContract:
 
     @combomethod
     def get_function_by_name(self, fn_name: str) -> "BaseContractFunction":
+        """
+        Return a distinct function with matching name.
+        Raises a Web3ValueError if there is no match or more than one is found.
+        """
         fns = self.find_functions_by_name(fn_name)
         return self.get_function_by_identifier(fns, "name")
 
@@ -828,6 +868,11 @@ class BaseContract:
     def get_function_by_selector(
         self, selector: Union[bytes, int, HexStr]
     ) -> "BaseContractFunction":
+        """
+        Return a distinct function with matching 4byte selector.
+        Raises a Web3ValueError if there is no match or more than one is found.
+        """
+
         def callable_check(fn_abi: ABIFunction) -> bool:
             return encode_hex(function_abi_to_4byte_selector(fn_abi)) == to_4byte_hex(
                 selector
@@ -842,6 +887,9 @@ class BaseContract:
     def decode_function_input(
         self, data: HexStr
     ) -> Tuple["BaseContractFunction", Dict[str, Any]]:
+        """
+        Return a Tuple of the function selector and decoded arguments.
+        """
         func = self.get_function_by_selector(HexBytes(data)[:4])
         arguments = decode_transaction_data(
             func.abi, data, normalizers=BASE_RETURN_NORMALIZERS
@@ -850,6 +898,11 @@ class BaseContract:
 
     @combomethod
     def find_functions_by_args(self, *args: Any) -> "BaseContractFunction":
+        """
+        Return all functions with matching args, checking each argument can be encoded
+        with the type.
+        """
+
         def callable_check(fn_abi: ABIFunction) -> bool:
             return check_if_arguments_can_be_encoded(
                 fn_abi,
@@ -864,8 +917,124 @@ class BaseContract:
 
     @combomethod
     def get_function_by_args(self, *args: Any) -> "BaseContractFunction":
+        """
+        Return a distinct function with matching args, checking each argument can be
+        encoded with the type.
+        Raises a Web3ValueError if there is no match or more than one is found.
+        """
         fns = self.find_functions_by_args(*args)
         return self.get_function_by_identifier(fns, "args")
+
+    #
+    #  Events API
+    #
+    @combomethod
+    def all_events(self) -> List["BaseContractEvent"]:
+        """
+        Return all events in the contract.
+        """
+        return self.find_events_by_identifier(
+            self.abi, self.w3, self.address, lambda _: True
+        )
+
+    @combomethod
+    def get_event_by_signature(self, signature: str) -> "BaseContractEvent":
+        """
+        Return a distinct event with matching signature.
+        Raises a Web3ValueError if the signature is invalid or if there is no match or
+        more than one is found.
+        """
+        if " " in signature:
+            raise Web3ValueError(
+                "Event signature should not contain any spaces. "
+                f"Found spaces in input: {signature}"
+            )
+
+        def callable_check(event_abi: ABIEvent) -> bool:
+            return abi_to_signature(event_abi) == signature
+
+        events = self.find_events_by_identifier(
+            self.abi, self.w3, self.address, callable_check
+        )
+        return self.get_event_by_identifier(events, "signature")
+
+    @combomethod
+    def find_events_by_name(self, event_name: str) -> List["BaseContractEvent"]:
+        """
+        Return all events with matching name.
+        Raises a Web3ValueError if there is no match or more than one is found.
+        """
+
+        def callable_check(fn_abi: ABIFunction) -> bool:
+            return fn_abi["name"] == event_name
+
+        return self.find_events_by_identifier(
+            self.abi, self.w3, self.address, callable_check
+        )
+
+    @combomethod
+    def get_event_by_name(self, event_name: str) -> "BaseContractEvent":
+        """
+        Return a distinct event with matching name.
+        Raises a Web3ValueError if there is no match or more than one is found.
+        """
+        events = self.find_events_by_name(event_name)
+        return self.get_event_by_identifier(events, "name")
+
+    @combomethod
+    def find_events_by_selector(
+        self, selector: Union[bytes, int, HexStr]
+    ) -> List["BaseContractEvent"]:
+        """
+        Return all events with matching selector.
+        Raises a Web3ValueError if there is no match or more than one is found.
+        """
+
+        def callable_check(event_abi: ABIEvent) -> bool:
+            return encode_hex(
+                keccak(text=abi_to_signature(event_abi).replace(" ", ""))
+            ) == encode_hex(hexstr_if_str(to_bytes, selector))
+
+        return self.find_events_by_identifier(
+            self.abi, self.w3, self.address, callable_check
+        )
+
+    @combomethod
+    def get_event_by_selector(
+        self, selector: Union[bytes, int, HexStr]
+    ) -> "BaseContractEvent":
+        """
+        Return a distinct event with matching keccak selector.
+        Raises a Web3ValueError if there is no match or more than one is found.
+        """
+        events = self.find_events_by_selector(selector)
+        return self.get_event_by_identifier(events, "selector")
+
+    @combomethod
+    def find_events_by_topic(self, topic: HexStr) -> List["BaseContractEvent"]:
+        """
+        Return all events with matching topic.
+        Raises a Web3ValueError if there is no match or more than one is found.
+        """
+
+        def callable_check(event_abi: ABIEvent) -> bool:
+            return (
+                encode_hex(keccak(text=abi_to_signature(event_abi).replace(" ", "")))
+                == topic
+            )
+
+        return self.find_events_by_identifier(
+            self.abi, self.w3, self.address, callable_check
+        )
+
+    @combomethod
+    def get_event_by_topic(self, topic: HexStr) -> "BaseContractEvent":
+        """
+        Return a distinct event with matching topic.
+        Raises a Web3ValueError if there is no match or more than one is found.
+        """
+        events = self.find_events_by_topic(topic)
+        return self.get_event_by_identifier(events, "topic")
 
     #
     # Private Helpers
@@ -952,6 +1121,26 @@ class BaseContract:
     def get_function_by_identifier(
         cls, fns: Sequence["BaseContractFunction"], identifier: str
     ) -> "BaseContractFunction":
+        raise NotImplementedError(
+            "This method should be implemented in the inherited class"
+        )
+
+    @combomethod
+    def find_events_by_identifier(
+        cls,
+        contract_abi: ABI,
+        w3: Union["Web3", "AsyncWeb3"],
+        address: ChecksumAddress,
+        callable_check: Callable[..., Any],
+    ) -> List[Any]:
+        raise NotImplementedError(
+            "This method should be implemented in the inherited class"
+        )
+
+    @combomethod
+    def get_event_by_identifier(
+        cls, fns: Sequence["BaseContractEvent"], identifier: str
+    ) -> "BaseContractEvent":
         raise NotImplementedError(
             "This method should be implemented in the inherited class"
         )

--- a/web3/contract/contract.py
+++ b/web3/contract/contract.py
@@ -14,6 +14,7 @@ from typing import (
 
 from eth_typing import (
     ABI,
+    ABIEvent,
     ChecksumAddress,
 )
 from eth_utils import (
@@ -96,6 +97,9 @@ from web3.types import (
     StateOverride,
     TxParams,
 )
+from web3.utils.abi import (
+    get_abi_element,
+)
 
 if TYPE_CHECKING:
     from ens import ENS  # noqa: F401
@@ -105,6 +109,17 @@ if TYPE_CHECKING:
 class ContractEvent(BaseContractEvent):
     # mypy types
     w3: "Web3"
+
+    def __call__(self) -> "ContractEvent":
+        clone = copy.copy(self)
+
+        if not self.abi:
+            self.abi = cast(
+                ABIEvent,
+                get_abi_element(self.contract_abi, self.event_name),
+            )
+
+        return clone
 
     @combomethod
     def get_logs(

--- a/web3/contract/contract.py
+++ b/web3/contract/contract.py
@@ -593,11 +593,8 @@ class Contract(BaseContract):
         address: ChecksumAddress,
         callable_check: Callable[..., Any],
     ) -> List["ContractEvent"]:
-        return cast(
-            List["ContractEvent"],
-            find_events_by_identifier(
-                contract_abi, w3, address, callable_check, ContractEvent
-            ),
+        return find_events_by_identifier(
+            contract_abi, w3, address, callable_check, ContractEvent
         )
 
     @combomethod

--- a/web3/contract/contract.py
+++ b/web3/contract/contract.py
@@ -75,7 +75,9 @@ from web3.contract.utils import (
     build_transaction_for_function,
     call_contract_function,
     estimate_gas_for_function,
+    find_events_by_identifier,
     find_functions_by_identifier,
+    get_event_by_identifier,
     get_function_by_identifier,
     transact_with_contract_function,
 )
@@ -237,6 +239,12 @@ class ContractEvent(BaseContractEvent):
         )
         builder.address = self.address
         return builder
+
+    @classmethod
+    def factory(cls, class_name: str, **kwargs: Any) -> Self:
+        return PropertyCheckingFactory(class_name, (cls,), kwargs)(
+            abi=kwargs.get("abi")
+        )
 
 
 class ContractEvents(BaseContractEvents):
@@ -561,6 +569,27 @@ class Contract(BaseContract):
         cls, fns: Sequence["ContractFunction"], identifier: str
     ) -> "ContractFunction":
         return get_function_by_identifier(fns, identifier)
+
+    @combomethod
+    def find_events_by_identifier(
+        cls,
+        contract_abi: ABI,
+        w3: "Web3",
+        address: ChecksumAddress,
+        callable_check: Callable[..., Any],
+    ) -> List["ContractEvent"]:
+        return cast(
+            List["ContractEvent"],
+            find_events_by_identifier(
+                contract_abi, w3, address, callable_check, ContractEvent
+            ),
+        )
+
+    @combomethod
+    def get_event_by_identifier(
+        cls, events: Sequence["ContractEvent"], identifier: str
+    ) -> "ContractEvent":
+        return get_event_by_identifier(events, identifier)
 
 
 class ContractCaller(BaseContractCaller):

--- a/web3/contract/utils.py
+++ b/web3/contract/utils.py
@@ -63,6 +63,7 @@ from web3.types import (
     BlockIdentifier,
     RPCEndpoint,
     StateOverride,
+    TContractEvent,
     TContractFn,
     TxParams,
 )
@@ -338,6 +339,9 @@ def find_functions_by_identifier(
     callable_check: Callable[..., Any],
     function_type: Type[TContractFn],
 ) -> List[TContractFn]:
+    """
+    Given a contract ABI, return a list of TContractFunction instances.
+    """
     fns_abi = filter_abi_by_type("function", contract_abi)
     return [
         function_type.factory(
@@ -356,6 +360,10 @@ def find_functions_by_identifier(
 def get_function_by_identifier(
     fns: Sequence[TContractFn], identifier: str
 ) -> TContractFn:
+    """
+    Check that the provided list of TContractFunction instances contains one element and
+    return it.
+    """
     if len(fns) > 1:
         raise Web3ValueError(
             f"Found multiple functions with matching {identifier}. " f"Found: {fns!r}"
@@ -363,6 +371,46 @@ def get_function_by_identifier(
     elif len(fns) == 0:
         raise Web3ValueError(f"Could not find any function with matching {identifier}")
     return fns[0]
+
+
+def find_events_by_identifier(
+    contract_abi: ABI,
+    w3: Union["Web3", "AsyncWeb3"],
+    address: ChecksumAddress,
+    callable_check: Callable[..., Any],
+    event_type: Type[TContractEvent],
+) -> List[TContractEvent]:
+    """
+    Given a contract ABI, return a list of TContractEvent instances.
+    """
+    event_abis = filter_abi_by_type("event", contract_abi)
+    return [
+        event_type.factory(
+            event_abi["name"],
+            w3=w3,
+            contract_abi=contract_abi,
+            address=address,
+            abi=event_abi,
+        )
+        for event_abi in event_abis
+        if callable_check(event_abi)
+    ]
+
+
+def get_event_by_identifier(
+    events: Sequence[TContractEvent], identifier: str
+) -> TContractEvent:
+    """
+    Check that the provided list of TContractEvent instances contains one element and
+    return it.
+    """
+    if len(events) > 1:
+        raise Web3ValueError(
+            f"Found multiple events with matching {identifier}. " f"Found: {events!r}"
+        )
+    elif len(events) == 0:
+        raise Web3ValueError(f"Could not find any event with matching {identifier}")
+    return events[0]
 
 
 # --- async --- #

--- a/web3/types.py
+++ b/web3/types.py
@@ -36,8 +36,14 @@ from web3._utils.compat import (
 )
 
 if TYPE_CHECKING:
-    from web3.contract.async_contract import AsyncContractFunction  # noqa: F401
-    from web3.contract.contract import ContractFunction  # noqa: F401
+    from web3.contract.async_contract import (  # noqa: F401
+        AsyncContractEvent,
+        AsyncContractFunction,
+    )
+    from web3.contract.contract import (  # noqa: F401
+        ContractEvent,
+        ContractFunction,
+    )
     from web3.main import (  # noqa: F401
         AsyncWeb3,
         Web3,
@@ -483,6 +489,7 @@ class GethWallet(TypedDict):
 # Contract types
 
 TContractFn = TypeVar("TContractFn", "ContractFunction", "AsyncContractFunction")
+TContractEvent = TypeVar("TContractEvent", "ContractEvent", "AsyncContractEvent")
 
 
 # Tracing types


### PR DESCRIPTION
### What was wrong?

Contract function classes provide functions for extracting contract components. Contract event API methods do not yet exist. The first set of methods for `find_events_by_identifier` and `get_event_by_identifier` should be added.

Contract Event APIs should be provided, namely `all_events`, `find_events_by_name` and `get_event_by_name`. 

### How was it fixed?

Implement functions for `Contract` classes to find many events or getting a single event by identifier, `find_events_by_identifier` and `get_event_by_identifier`.

Additional Event APIs are now available (`all_events`, `find_events_by_name`, `get_event_by_name`, `find_events_by_signature`, `get_event_by_signature`, `find_events_by_selector`, `get_event_by_selector`, `find_events_by_topic`, and `get_event_by_topic`)

### Todo:

- [x] Clean up commit history
- [X] Add or update documentation related to these changes
- [X] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.magic-safaris.com/sites/default/files/styles/content_/public/2020-11/Shoebill2%20%282%29_1.jpg?itok=Dm983e4U)
