### PR TITLE
Allow ContractEvent to be called without parentheses

### DIFF
--- a/tests/core/contracts/test_extracting_event_data.py
+++ b/tests/core/contracts/test_extracting_event_data.py
@@ -1184,6 +1184,16 @@ def test_receipt_processing_with_no_flag(indexed_event_contract, dup_txn_receipt
         assert len(returned_log) == 0
 
 
+def test_process_log_instance(w3, emitter, wait_for_transaction):
+    txn_hash = emitter.functions.logNoArgs(which=1).transact()
+    txn_receipt = wait_for_transaction(w3, txn_hash)
+    rich_log = emitter.events.LogNoArguments.process_log(txn_receipt["logs"][0])
+    assert rich_log["args"] == {}
+    assert rich_log.args == {}
+    assert is_same_address(rich_log["address"], emitter.address)
+    assert rich_log["event"] == "LogNoArguments"
+
+
 def test_single_log_processing_with_errors(indexed_event_contract, dup_txn_receipt):
     event_instance = indexed_event_contract.events.LogSingleWithIndex()
 

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -211,7 +211,7 @@ class BaseContractEvent:
 
     @combomethod
     def process_log(self, log: HexStr) -> EventData:
-        return get_event_data(self.w3.codec, self.abi, log)
+        return get_event_data(self.w3.codec, self._get_event_abi(), log)
 
     @combomethod
     def _get_event_filter_params(


### PR DESCRIPTION
### What was wrong?

Related to Issue #
Closes #

### How was it fixed?

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
