### PR TITLE
docs: fixed typos in pip install "web3[test]"

### DIFF
--- a/newsfragments/3480.bugfix.rst
+++ b/newsfragments/3480.bugfix.rst
@@ -1,0 +1,1 @@
+Add back dependency extra for 'tester'.

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,10 @@ from setuptools import (
 )
 
 extras_require = {
+    "tester": [
+        "eth-tester[py-evm]>=0.11.0b1,<0.13.0b1",
+        "py-geth>=5.0.0",
+    ],
     "dev": [
         "build>=0.9.0",
         "bumpversion>=0.5.3",
@@ -30,8 +34,6 @@ extras_require = {
     "test": [
         # Note: ethereum-maintained libraries in this list should be added to the
         # `install_pre_releases.py` script.
-        "eth-tester[py-evm]>=0.11.0b1,<0.13.0b1",
-        "py-geth>=5.0.0",
         "pytest-asyncio>=0.18.1,<0.23",
         "pytest-mock>=1.10",
         "pytest-xdist>=2.4.0",
@@ -40,7 +42,10 @@ extras_require = {
 }
 
 extras_require["dev"] = (
-    extras_require["dev"] + extras_require["docs"] + extras_require["test"]
+    extras_require["dev"]
+    + extras_require["docs"]
+    + extras_require["test"]
+    + extras_require["tester"]
 )
 
 


### PR DESCRIPTION
### What was wrong?

I tried to install the project with "tester", following the current documentation in a project and the dependencies for testing (eth_tester) were not installed.

When checking the current [setup.py](https://github.com/ethereum/web3.py/blob/c4d07a323d92995c5bfefb1763dc0587fa47771f/setup.py#L30) I found that the correct command to do would be `pip install web3[test]` and not `pip installl web3[tester]`.

### How was it fixed?

I changed the documentation in every reference I could find from `pip install web3[tester]` to `pip install web3[test]`.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![hedgehog-1215140_1920](https://github.com/user-attachments/assets/81b9bfde-3216-4814-8403-c12cad0023bb)

