### PR TITLE
Bugfix tx caching

### DIFF
--- a/newsfragments/3483.bugfix.rst
+++ b/newsfragments/3483.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug where sensitive requests that make use of block data should not be cached until some validation threshold deems it is safe to do so, when request caching is turned on.

--- a/newsfragments/3483.feature.rst
+++ b/newsfragments/3483.feature.rst
@@ -1,0 +1,1 @@
+Add a configuration for request caching that sets a threshold for validating cached requests that make use of block data. This can be turned off altogether by setting the threshold to ``None``.

--- a/tests/core/caching-utils/test_request_caching.py
+++ b/tests/core/caching-utils/test_request_caching.py
@@ -240,7 +240,8 @@ def test_blocknum_validation_against_validation_threshold_when_caching(
     ):
         assert len(w3.provider._request_cache.items()) == 0
         w3.manager.request_blocking(endpoint, [blocknum, False])
-        assert len(w3.provider._request_cache.items()) == int(should_cache)
+        cached_items = len(w3.provider._request_cache.items())
+        assert cached_items == 1 if should_cache else cached_items == 0
 
 
 @pytest.mark.parametrize(
@@ -281,7 +282,8 @@ def test_block_id_param_caching(
     ):
         assert len(w3.provider._request_cache.items()) == 0
         w3.manager.request_blocking(RPCEndpoint(endpoint), [block_id, False])
-        assert len(w3.provider._request_cache.items()) == int(should_cache)
+        cached_items = len(w3.provider._request_cache.items())
+        assert cached_items == 1 if should_cache else cached_items == 0
 
 
 @pytest.mark.parametrize(
@@ -530,7 +532,8 @@ async def test_async_blocknum_validation_against_validation_threshold(
     ):
         assert len(async_w3.provider._request_cache.items()) == 0
         await async_w3.manager.coro_request(endpoint, [blocknum, False])
-        assert len(async_w3.provider._request_cache.items()) == int(should_cache)
+        cached_items = len(async_w3.provider._request_cache.items())
+        assert cached_items == 1 if should_cache else cached_items == 0
 
 
 @pytest.mark.asyncio
@@ -572,7 +575,8 @@ async def test_async_block_id_param_caching(
     ):
         assert len(async_w3.provider._request_cache.items()) == 0
         await async_w3.manager.coro_request(RPCEndpoint(endpoint), [block_id, False])
-        assert len(async_w3.provider._request_cache.items()) == int(should_cache)
+        cached_items = len(async_w3.provider._request_cache.items())
+        assert cached_items == 1 if should_cache else cached_items == 0
 
 
 @pytest.mark.asyncio

--- a/web3/_utils/caching/__init__.py
+++ b/web3/_utils/caching/__init__.py
@@ -1,0 +1,12 @@
+from .request_caching_validation import (
+    ASYNC_PROVIDER_TYPE,
+    SYNC_PROVIDER_TYPE,
+)
+from .caching_utils import (
+    CACHEABLE_REQUESTS,
+    async_handle_request_caching,
+    generate_cache_key,
+    handle_request_caching,
+    is_cacheable_request,
+    RequestInformation,
+)

--- a/web3/_utils/caching/request_caching_validation.py
+++ b/web3/_utils/caching/request_caching_validation.py
@@ -82,10 +82,6 @@ def validate_blockhash_in_params(
 # -- async -- #
 
 
-async def async_always_cache_request(*_args: Any, **_kwargs: Any) -> bool:
-    return True
-
-
 async def async_is_beyond_validation_threshold(
     provider: ASYNC_PROVIDER_TYPE, blocknum: int
 ) -> bool:

--- a/web3/_utils/caching/request_caching_validation.py
+++ b/web3/_utils/caching/request_caching_validation.py
@@ -1,0 +1,133 @@
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Sequence,
+    TypeVar,
+    Union,
+)
+
+from eth_utils import (
+    to_int,
+)
+
+if TYPE_CHECKING:
+    from web3.providers import (  # noqa: F401
+        AsyncBaseProvider,
+        BaseProvider,
+    )
+
+UNCACHEABLE_BLOCK_IDS = {"finalized", "safe", "latest", "pending"}
+
+ASYNC_PROVIDER_TYPE = TypeVar("ASYNC_PROVIDER_TYPE", bound="AsyncBaseProvider")
+SYNC_PROVIDER_TYPE = TypeVar("SYNC_PROVIDER_TYPE", bound="BaseProvider")
+
+
+def _error_log(
+    provider: Union[ASYNC_PROVIDER_TYPE, SYNC_PROVIDER_TYPE], e: Exception
+) -> None:
+    provider.logger.error(
+        "There was an exception while caching the request.", exc_info=e
+    )
+
+
+def is_beyond_validation_threshold(provider: SYNC_PROVIDER_TYPE, blocknum: int) -> bool:
+    try:
+        # `threshold` is either "finalized" or "safe"
+        threshold = provider.request_cache_validation_threshold.value
+        response = provider.make_request("eth_getBlockByNumber", [threshold, False])
+        return blocknum <= to_int(hexstr=response["result"]["number"])
+    except Exception as e:
+        _error_log(provider, e)
+        return False
+
+
+def always_cache_request(*_args: Any, **_kwargs: Any) -> bool:
+    return True
+
+
+def validate_blocknum_in_params(
+    provider: SYNC_PROVIDER_TYPE, params: Sequence[Any], _result: Dict[str, Any]
+) -> bool:
+    block_id = params[0]
+    if block_id == "earliest":
+        # `earliest` should always be cacheable
+        return True
+    blocknum = to_int(hexstr=block_id)
+    return is_beyond_validation_threshold(provider, blocknum)
+
+
+def validate_blocknum_in_result(
+    provider: SYNC_PROVIDER_TYPE, _params: Sequence[Any], result: Dict[str, Any]
+) -> bool:
+    # `number` if block result, `blockNumber` if transaction result
+    blocknum = to_int(hexstr=result.get("number", result.get("blockNumber")))
+    return is_beyond_validation_threshold(provider, blocknum)
+
+
+def validate_blockhash_in_params(
+    provider: SYNC_PROVIDER_TYPE, params: Sequence[Any], _result: Dict[str, Any]
+) -> bool:
+    try:
+        # make an extra call to get the block number from the hash
+        response = provider.make_request("eth_getBlockByHash", [params[0], False])
+    except Exception as e:
+        _error_log(provider, e)
+        return False
+
+    blocknum = to_int(hexstr=response["result"]["number"])
+    return is_beyond_validation_threshold(provider, blocknum)
+
+
+# -- async -- #
+
+
+async def async_always_cache_request(*_args: Any, **_kwargs: Any) -> bool:
+    return True
+
+
+async def async_is_beyond_validation_threshold(
+    provider: ASYNC_PROVIDER_TYPE, blocknum: int
+) -> bool:
+    try:
+        # `threshold` is either "finalized" or "safe"
+        threshold = provider.request_cache_validation_threshold.value
+        response = await provider.make_request(
+            "eth_getBlockByNumber", [threshold, False]
+        )
+        return blocknum <= to_int(hexstr=response["result"]["number"])
+    except Exception as e:
+        _error_log(provider, e)
+        return False
+
+
+async def async_validate_blocknum_in_params(
+    provider: ASYNC_PROVIDER_TYPE, params: Sequence[Any], _result: Dict[str, Any]
+) -> bool:
+    block_id = params[0]
+    if block_id == "earliest":
+        # `earliest` should always be cacheable
+        return True
+    blocknum = to_int(hexstr=params[0])
+    return await async_is_beyond_validation_threshold(provider, blocknum)
+
+
+async def async_validate_blocknum_in_result(
+    provider: ASYNC_PROVIDER_TYPE, _params: Sequence[Any], result: Dict[str, Any]
+) -> bool:
+    # `number` if block result, `blockNumber` if transaction result
+    blocknum = to_int(hexstr=result.get("number", result.get("blockNumber")))
+    return await async_is_beyond_validation_threshold(provider, blocknum)
+
+
+async def async_validate_blockhash_in_params(
+    provider: ASYNC_PROVIDER_TYPE, params: Sequence[Any], _result: Dict[str, Any]
+) -> bool:
+    try:
+        response = await provider.make_request("eth_getBlockByHash", [params[0], False])
+    except Exception as e:
+        _error_log(provider, e)
+        return False
+
+    blocknum = to_int(hexstr=response["result"]["number"])
+    return await async_is_beyond_validation_threshold(provider, blocknum)

--- a/web3/providers/async_base.py
+++ b/web3/providers/async_base.py
@@ -42,6 +42,7 @@ from web3.types import (
     RPCResponse,
 )
 from web3.utils import (
+    RequestCacheValidationThreshold,
     SimpleCache,
 )
 
@@ -86,10 +87,14 @@ class AsyncBaseProvider:
         self,
         cache_allowed_requests: bool = False,
         cacheable_requests: Set[RPCEndpoint] = None,
+        request_cache_validation_threshold: Optional[
+            RequestCacheValidationThreshold
+        ] = RequestCacheValidationThreshold.FINALIZED,
     ) -> None:
         self._request_cache = SimpleCache(1000)
         self.cache_allowed_requests = cache_allowed_requests
         self.cacheable_requests = cacheable_requests or CACHEABLE_REQUESTS
+        self.request_cache_validation_threshold = request_cache_validation_threshold
 
     async def request_func(
         self, async_w3: "AsyncWeb3", middleware_onion: MiddlewareOnion

--- a/web3/providers/async_base.py
+++ b/web3/providers/async_base.py
@@ -1,5 +1,6 @@
 import asyncio
 import itertools
+import logging
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -59,6 +60,10 @@ if TYPE_CHECKING:
 
 
 class AsyncBaseProvider:
+    # Set generic logger for the provider. Override in subclasses for more specificity.
+    logger: logging.Logger = logging.getLogger(
+        "web3.providers.async_base.AsyncBaseProvider"
+    )
     _request_func_cache: Tuple[
         Tuple[Middleware, ...], Callable[..., Coroutine[Any, Any, RPCResponse]]
     ] = (None, None)
@@ -159,6 +164,8 @@ class AsyncBaseProvider:
 
 
 class AsyncJSONBaseProvider(AsyncBaseProvider):
+    logger = logging.getLogger("web3.providers.async_base.AsyncJSONBaseProvider")
+
     def __init__(self, **kwargs: Any) -> None:
         self.request_counter = itertools.count()
         super().__init__(**kwargs)

--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -6,6 +6,7 @@ from typing import (
     Any,
     Callable,
     List,
+    Optional,
     Set,
     Tuple,
     cast,
@@ -39,6 +40,7 @@ from web3.types import (
     RPCResponse,
 )
 from web3.utils import (
+    RequestCacheValidationThreshold,
     SimpleCache,
 )
 
@@ -68,10 +70,14 @@ class BaseProvider:
         self,
         cache_allowed_requests: bool = False,
         cacheable_requests: Set[RPCEndpoint] = None,
+        request_cache_validation_threshold: Optional[
+            RequestCacheValidationThreshold
+        ] = RequestCacheValidationThreshold.FINALIZED,
     ) -> None:
         self._request_cache = SimpleCache(1000)
         self.cache_allowed_requests = cache_allowed_requests
         self.cacheable_requests = cacheable_requests or CACHEABLE_REQUESTS
+        self.request_cache_validation_threshold = request_cache_validation_threshold
 
     def request_func(
         self, w3: "Web3", middleware_onion: MiddlewareOnion

--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -1,4 +1,5 @@
 import itertools
+import logging
 import threading
 from typing import (
     TYPE_CHECKING,
@@ -46,6 +47,8 @@ if TYPE_CHECKING:
 
 
 class BaseProvider:
+    # Set generic logger for the provider. Override in subclasses for more specificity.
+    logger: logging.Logger = logging.getLogger("web3.providers.base.BaseProvider")
     # a tuple of (middleware, request_func)
     _request_func_cache: Tuple[Tuple[Middleware, ...], Callable[..., RPCResponse]] = (
         None,
@@ -104,6 +107,8 @@ class BaseProvider:
 
 
 class JSONBaseProvider(BaseProvider):
+    logger = logging.getLogger("web3.providers.base.JSONBaseProvider")
+
     _is_batching: bool = False
     _batch_request_func_cache: Tuple[
         Tuple[Middleware, ...], Callable[..., List[RPCResponse]]

--- a/web3/utils/__init__.py
+++ b/web3/utils/__init__.py
@@ -36,6 +36,7 @@ from .async_exception_handling import (
     async_handle_offchain_lookup,
 )
 from .caching import (
+    RequestCacheValidationThreshold,
     SimpleCache,
 )
 from .exception_handling import (
@@ -67,6 +68,7 @@ __all__ = [
     "log_topic_to_bytes",
     "get_create_address",
     "async_handle_offchain_lookup",
+    "RequestCacheValidationThreshold",
     "SimpleCache",
     "handle_offchain_lookup",
 ]

--- a/web3/utils/caching.py
+++ b/web3/utils/caching.py
@@ -2,6 +2,9 @@ import asyncio
 from collections import (
     OrderedDict,
 )
+from enum import (
+    Enum,
+)
 import time
 from typing import (
     Any,
@@ -10,6 +13,11 @@ from typing import (
     Optional,
     Tuple,
 )
+
+
+class RequestCacheValidationThreshold(Enum):
+    FINALIZED = "finalized"
+    SAFE = "safe"
 
 
 class SimpleCache:


### PR DESCRIPTION
### What was wrong?

Closes #1086

### How was it fixed?

Validate certain cached requests against a validation threshold:

- Validate requests deemed unsafe to cache when they are not yet
  within a validation threshold of the chain. These requests
  rely on data from blocks and are only cached if the blocks they
  rely on are within this configured threshold.

- Allow threshold to be configurable to `finalized`, `safe`, or
  turned off by setting to `None`. Default this value to `finalized` 
  (safest option). Configuration is done via an enum.

- Never cache requests that make use of block identifiers:
  `finalized`, `safe`, `latest`, and `pending`. These are moving
  targets and will never be static, thus should never be cached.
  `earliest` should not be an issue.

- Add tests around the validation threshold boundary to make sure
  we cache only when appropriate, based on the configured options.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![20240903_124522](https://github.com/user-attachments/assets/3db53986-c4b3-42cd-ae1f-a23eef96efad)
