### PR TITLE
Encourage signing middleware injection before txn modifying middleware

### DIFF
--- a/docs/middleware.rst
+++ b/docs/middleware.rst
@@ -423,6 +423,11 @@ The ``build`` method for this middleware builder takes a single argument:
       * An ``eth_keys.PrivateKey`` object
       * A raw private key as a hex string or byte string
 
+.. note::
+        Since this middleware signs the transaction, any middleware that modifies the
+        transaction should run before this middleware. Therefore, it is recommended to
+        inject the signing middleware at the 0th layer of the middleware onion.
+
 .. code-block:: python
 
    >>> from web3 import Web3, EthereumTesterProvider
@@ -430,7 +435,7 @@ The ``build`` method for this middleware builder takes a single argument:
    >>> from web3.middleware import SignAndSendRawMiddlewareBuilder
    >>> from eth_account import Account
    >>> acct = Account.create('KEYSMASH FJAFJKLDSKF7JKFDJ 1530')
-   >>> w3.middleware_onion.add(SignAndSendRawMiddlewareBuilder.build(acct))
+   >>> w3.middleware_onion.inject(SignAndSendRawMiddlewareBuilder.build(acct), layer=0)
    >>> w3.eth.default_account = acct.address
 
 :ref:`Hosted nodes<local_vs_hosted>` (like Infura or Alchemy) only support signed
@@ -446,7 +451,7 @@ Instead, we can automate this process with
     >>> from eth_account import Account
     >>> import os
     >>> acct = w3.eth.account.from_key(os.environ.get('PRIVATE_KEY'))
-    >>> w3.middleware_onion.add(SignAndSendRawMiddlewareBuilder.build(acct))
+    >>> w3.middleware_onion.inject(SignAndSendRawMiddlewareBuilder.build(acct), layer=0)
     >>> w3.eth.default_account = acct.address
 
     >>> # use `eth_sendTransaction` to automatically sign and send the raw transaction
@@ -463,7 +468,7 @@ Similarly, with AsyncWeb3:
     >>> from eth_account import Account
     >>> import os
     >>> acct = async_w3.eth.account.from_key(os.environ.get('PRIVATE_KEY'))
-    >>> async_w3.middleware_onion.add(SignAndSendRawMiddlewareBuilder.build(acct))
+    >>> async_w3.middleware_onion.inject(SignAndSendRawMiddlewareBuilder.build(acct), layer=0)
     >>> async_w3.eth.default_account = acct.address
 
     >>> # use `eth_sendTransaction` to automatically sign and send the raw transaction

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -128,7 +128,7 @@ with the necessary parameters via the ``build()`` method.
 
     # v7
     from web3.middleware import SignAndSendRawMiddlewareBuilder
-    w3.middleware_onion.add(SignAndSendRawMiddlewareBuilder.build(private_key))
+    w3.middleware_onion.inject(SignAndSendRawMiddlewareBuilder.build(private_key), layer=0)
 
 
 Middleware Renaming and Removals

--- a/docs/transactions.rst
+++ b/docs/transactions.rst
@@ -90,8 +90,8 @@ utilize web3.py middleware to sign transactions from a particular account:
   })
 
   # Add acct2 as auto-signer:
-  w3.middleware_onion.add(SignAndSendRawMiddlewareBuilder.build(acct2))
-  # pk also works: w3.middleware_onion.add(SignAndSendRawMiddlewareBuilder.build(pk))
+  w3.middleware_onion.inject(SignAndSendRawMiddlewareBuilder.build(acct2), layer=0)
+  # pk also works: w3.middleware_onion.inject(SignAndSendRawMiddlewareBuilder.build(pk), layer=0)
 
   # Transactions from `acct2` will then be signed, under the hood, in the middleware:
   tx_hash = w3.eth.send_transaction({

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -151,7 +151,7 @@ Example ``account_test_script.py``
     assert private_key.startswith("0x"), "Private key must start with 0x hex prefix"
 
     account: LocalAccount = Account.from_key(private_key)
-    w3.middleware_onion.add(SignAndSendRawMiddlewareBuilder.build(account))
+    w3.middleware_onion.inject(SignAndSendRawMiddlewareBuilder.build(account), layer=0)
 
     print(f"Your hot wallet address is {account.address}")
 

--- a/newsfragments/3488.docs.rst
+++ b/newsfragments/3488.docs.rst
@@ -1,0 +1,1 @@
+Update documentation around ``SignAndSendRawMiddlewareBuilder`` injection into the middleware onion. It should be injected lower in the stack than any middleware that modifies the transaction, in order to ensure those modified fields are signed.

--- a/web3/_utils/async_transactions.py
+++ b/web3/_utils/async_transactions.py
@@ -87,9 +87,7 @@ TRANSACTION_DEFAULTS = {
 async def get_block_gas_limit(
     web3_eth: "AsyncEth", block_identifier: Optional[BlockIdentifier] = None
 ) -> int:
-    if block_identifier is None:
-        block_identifier = await web3_eth.block_number
-    block = await web3_eth.get_block(block_identifier)
+    block = await web3_eth.get_block(block_identifier or "latest")
     return block["gasLimit"]
 
 
@@ -104,8 +102,8 @@ async def get_buffered_gas_estimate(
 
     if gas_estimate > gas_limit:
         raise Web3ValueError(
-            "Contract does not appear to be deployable within the "
-            f"current network gas limits.  Estimated: {gas_estimate}. "
+            "Gas estimate for transaction is higher than current network gas limits. "
+            f"Transaction could not be sent. Estimated: {gas_estimate}. "
             f"Current gas limit: {gas_limit}"
         )
 

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -737,8 +737,8 @@ class AsyncEthModuleTest:
             "value": Wei(0),
             "gas": 21000,
         }
-        async_w3.middleware_onion.add(
-            SignAndSendRawMiddlewareBuilder.build(keyfile_account), "signing"
+        async_w3.middleware_onion.inject(
+            SignAndSendRawMiddlewareBuilder.build(keyfile_account), "signing", layer=0
         )
         txn_hash = await async_w3.eth.send_transaction(txn)
         assert isinstance(txn_hash, HexBytes)
@@ -3747,8 +3747,8 @@ class EthModuleTest:
             "value": Wei(0),
             "gas": 21000,
         }
-        w3.middleware_onion.add(
-            SignAndSendRawMiddlewareBuilder.build(keyfile_account), "signing"
+        w3.middleware_onion.inject(
+            SignAndSendRawMiddlewareBuilder.build(keyfile_account), "signing", layer=0
         )
         txn_hash = w3.eth.send_transaction(txn)
         assert isinstance(txn_hash, HexBytes)

--- a/web3/_utils/transactions.py
+++ b/web3/_utils/transactions.py
@@ -149,9 +149,7 @@ def fill_transaction_defaults(w3: "Web3", transaction: TxParams) -> TxParams:
 def get_block_gas_limit(
     w3: "Web3", block_identifier: Optional[BlockIdentifier] = None
 ) -> int:
-    if block_identifier is None:
-        block_identifier = w3.eth.block_number
-    block = w3.eth.get_block(block_identifier)
+    block = w3.eth.get_block(block_identifier or "latest")
     return block["gasLimit"]
 
 
@@ -166,8 +164,8 @@ def get_buffered_gas_estimate(
 
     if gas_estimate > gas_limit:
         raise Web3ValueError(
-            "Contract does not appear to be deployable within the "
-            f"current network gas limits.  Estimated: {gas_estimate}. "
+            "Gas estimate for transaction is higher than current network gas limits. "
+            f"Transaction could not be sent. Estimated: {gas_estimate}. "
             f"Current gas limit: {gas_limit}"
         )
 


### PR DESCRIPTION
### What was wrong?

Closes #2167

### How was it fixed?

- Encourage injecting the sign-and-send raw middleware at the 0th layer. Any middleware that modifies transaction params should be run before the signing middleware in order to sign the modified values.
- Add test for sign-and-send along with buffered gas estimate middleware

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![boxwink](https://github.com/user-attachments/assets/8e83498d-e766-45ab-b301-b40dc0bd503e)
