### PR TITLE
Validate provider is correct type for the w3 class on init:

### DIFF
--- a/newsfragments/3490.misc.rst
+++ b/newsfragments/3490.misc.rst
@@ -1,0 +1,2 @@
+
+Validate against sync providers on ``AsyncWeb3`` init; validate against async providers on ``Web3`` init. This will provide better messaging when a web3 class is instantiated with an incompatible provider type.

--- a/tests/core/providers/test_provider_init.py
+++ b/tests/core/providers/test_provider_init.py
@@ -1,0 +1,59 @@
+import pytest
+
+from web3 import (
+    AsyncBaseProvider,
+    AsyncEthereumTesterProvider,
+    AsyncHTTPProvider,
+    AsyncIPCProvider,
+    AsyncWeb3,
+    BaseProvider,
+    EthereumTesterProvider,
+    HTTPProvider,
+    IPCProvider,
+    LegacyWebSocketProvider,
+    Web3,
+    WebSocketProvider,
+)
+from web3.exceptions import (
+    Web3ValidationError,
+)
+
+
+class ExtendsAsyncBaseProvider(AsyncBaseProvider):
+    pass
+
+
+class ExtendsBaseProvider(BaseProvider):
+    pass
+
+
+@pytest.mark.parametrize(
+    "provider_class",
+    (
+        AsyncBaseProvider,
+        ExtendsAsyncBaseProvider,
+        AsyncHTTPProvider,
+        AsyncIPCProvider,
+        WebSocketProvider,
+        AsyncEthereumTesterProvider,
+    ),
+)
+def test_init_web3_with_async_provider(provider_class):
+    with pytest.raises(Web3ValidationError):
+        Web3(provider_class())
+
+
+@pytest.mark.parametrize(
+    "provider_class",
+    (
+        BaseProvider,
+        ExtendsBaseProvider,
+        HTTPProvider,
+        LegacyWebSocketProvider,
+        IPCProvider,
+        EthereumTesterProvider,
+    ),
+)
+def test_init_async_web3_with_sync_provider(provider_class):
+    with pytest.raises(Web3ValidationError):
+        AsyncWeb3(provider_class())

--- a/tests/core/utilities/test_attach_modules.py
+++ b/tests/core/utilities/test_attach_modules.py
@@ -83,7 +83,7 @@ def test_attach_modules_multiple_levels_deep(module1):
 
 def test_attach_modules_with_wrong_module_format():
     mods = {"eth": (MockEth, MockEth, MockEth)}
-    w3 = Web3(EthereumTesterProvider, modules={})
+    w3 = Web3(EthereumTesterProvider(), modules={})
     with pytest.raises(
         Web3ValidationError, match="Module definitions can only have 1 or 2 elements"
     ):
@@ -94,7 +94,7 @@ def test_attach_modules_with_existing_modules():
     mods = {
         "eth": MockEth,
     }
-    w3 = Web3(EthereumTesterProvider, modules=mods)
+    w3 = Web3(EthereumTesterProvider(), modules=mods)
     with pytest.raises(
         Web3AttributeError,
         match=("The web3 object already has an attribute with that name"),

--- a/web3/main.py
+++ b/web3/main.py
@@ -87,6 +87,7 @@ from web3.eth import (
 )
 from web3.exceptions import (
     Web3TypeError,
+    Web3ValidationError,
     Web3ValueError,
 )
 from web3.geth import (
@@ -350,6 +351,24 @@ class BaseWeb3:
         return self.manager._batch_requests()
 
 
+def _validate_provider(
+    w3: Union["Web3", "AsyncWeb3"],
+    provider: Optional[Union[BaseProvider, AsyncBaseProvider]],
+) -> None:
+    if provider is not None:
+        if isinstance(w3, AsyncWeb3) and not isinstance(provider, AsyncBaseProvider):
+            raise Web3ValidationError(
+                "Provider must be an instance of `AsyncBaseProvider` for "
+                f"`AsyncWeb3`, got {type(provider)}."
+            )
+
+        if isinstance(w3, Web3) and not isinstance(provider, BaseProvider):
+            raise Web3ValidationError(
+                "Provider must be an instance of `BaseProvider` for `Web3`, "
+                f"got {type(provider)}."
+            )
+
+
 class Web3(BaseWeb3):
     # mypy types
     eth: Eth
@@ -372,6 +391,8 @@ class Web3(BaseWeb3):
         ] = None,
         ens: Union[ENS, "Empty"] = empty,
     ) -> None:
+        _validate_provider(self, provider)
+
         self.manager = self.RequestManager(self, provider, middleware)
         self.codec = ABICodec(build_strict_registry())
 
@@ -440,6 +461,8 @@ class AsyncWeb3(BaseWeb3):
         ] = None,
         ens: Union[AsyncENS, "Empty"] = empty,
     ) -> None:
+        _validate_provider(self, provider)
+
         self.manager = self.RequestManager(self, provider, middleware)
         self.codec = ABICodec(build_strict_registry())
 


### PR DESCRIPTION
### What was wrong?

Closes #3460

### How was it fixed?

Disallow sync providers on `AsyncWeb3` init; disallow async providers on `Web3` init. This will provide better messaging to users when they try to use the wrong provider type.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![SSPX0264](https://github.com/user-attachments/assets/8cd333ed-20d5-4769-a5e9-b34595658a6a)
