### PR TITLE
Fix buffer issues with async IPC; add tests

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -269,6 +269,10 @@ AsyncIPCProvider
     JSON-RPC server.
 
     *  ``ipc_path`` is the filesystem path to the IPC socket:
+    *  ``read_buffer_limit`` is the maximum size of data, in bytes, that can be read
+       from the socket at one time. Defaults to 20MB (20 * 1024 * 1024). Raises
+       ``ReadBufferLimitReached`` if the limit is reached, suggesting that the buffer
+       limit be increased.
 
     This provider inherits from the
     :class:`~web3.providers.persistent.PersistentConnectionProvider` class. Refer to

--- a/newsfragments/3492.feature.rst
+++ b/newsfragments/3492.feature.rst
@@ -1,1 +1,1 @@
-Add a configuration option for the ``read_buffer_limit`` for ``AsyncIPCProvider`` in order to control the expected message size limit. Set this default value to 20MB.
+Add a configuration option for the ``read_buffer_limit`` for ``AsyncIPCProvider`` in order to control the expected message size limit (defaults to 20MB). Add ``ReadBufferLimitReached`` for when the read limit is reached, extend from ``PersistentConnectionError``.

--- a/newsfragments/3492.feature.rst
+++ b/newsfragments/3492.feature.rst
@@ -1,0 +1,1 @@
+Add a configuration option for the ``read_buffer_limit`` for ``AsyncIPCProvider`` in order to control the expected message size limit. Set this default value to 20MB.

--- a/newsfragments/3492.performance.rst
+++ b/newsfragments/3492.performance.rst
@@ -1,0 +1,1 @@
+Improve logic for reading from the async IPC socket in order to properly handle and adjust the handling of large messages. This improves reading speeds in general.

--- a/tests/core/providers/test_async_ipc_provider.py
+++ b/tests/core/providers/test_async_ipc_provider.py
@@ -19,6 +19,9 @@ from web3 import (
 from web3.datastructures import (
     AttributeDict,
 )
+from web3.exceptions import (
+    ReadBufferLimitReached,
+)
 from web3.providers import (
     AsyncIPCProvider,
 )
@@ -312,7 +315,13 @@ async def test_async_ipc_reader_can_read_20mb_message(
 async def test_async_ipc_reader_raises_on_msg_over_20mb(
     jsonrpc_ipc_pipe_path, serve_larger_than_20mb_response
 ):
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ReadBufferLimitReached,
+        match=(
+            rf"Read buffer limit of `{TWENTY_MB}` bytes was reached. "
+            "Consider increasing the ``read_buffer_limit`` on the AsyncIPCProvider."
+        ),
+    ):
         async with AsyncWeb3(
             AsyncIPCProvider(pathlib.Path(jsonrpc_ipc_pipe_path))
         ) as w3:

--- a/tests/core/providers/test_async_ipc_provider.py
+++ b/tests/core/providers/test_async_ipc_provider.py
@@ -337,4 +337,8 @@ async def test_async_ipc_read_buffer_limit_is_configurable(
             pathlib.Path(jsonrpc_ipc_pipe_path), read_buffer_limit=TWENTY_MB + 1024
         )
     ) as w3:
-        await w3.provider.make_request("method", [])
+        response = await w3.provider.make_request("method", [])
+        assert (
+            len(response["result"])
+            == TWENTY_MB - len(SIZED_MSG_START) - len(SIZED_MSG_END) + 1024
+        )

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -334,7 +334,20 @@ class TaskNotRunning(Web3Exception):
         super().__init__(message)
 
 
-class PersistentConnectionClosedOK(Web3Exception):
+class PersistentConnectionError(Web3Exception):
+    """
+    Raised when a persistent connection encounters an error.
+    """
+
+
+class ReadBufferLimitReached(PersistentConnectionError):
+    """
+    Raised when the read buffer limit is reached while reading data from a persistent
+    connection.
+    """
+
+
+class PersistentConnectionClosedOK(PersistentConnectionError):
     """
     Raised when a persistent connection is closed gracefully by the server.
     """

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -340,7 +340,7 @@ class PersistentConnectionError(Web3Exception):
     """
 
 
-class ReadBufferLimitReached(PersistentConnectionError):
+class ReadBufferLimitReached(PersistentConnectionError, Web3ValueError):
     """
     Raised when the read buffer limit is reached while reading data from a persistent
     connection.


### PR DESCRIPTION
### What was wrong?

Closes #3485

### How was it fixed?

- Move to a `readline()` approach on the stream reader for IPC. The older implementation for the original IPC would read in chunks but this isn't ideal and, it turns out, opting for readline while allowing control of the buffer limit lends itself quite nicely to plucking well-formed responses from the socket.

### Todo:

- [x] Clean up commit history / elaborate on commit message
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![ezgif com-animated-gif-maker](https://github.com/user-attachments/assets/9009755f-b4bc-4afd-a2b9-eab4f8a52273)

