### PR TITLE
add py3.13 to supported versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ workflows:
       - common:
           matrix:
             parameters:
-              python_minor_version: ["8", "9", "10", "11", "12"]
+              python_minor_version: ["8", "9", "10", "11", "12", "13"]
               tox_env: [
                 "lint",
                 "core",
@@ -238,7 +238,7 @@ workflows:
       - geth:
           matrix:
             parameters:
-              python_minor_version: ["8", "9", "10", "11", "12"]
+              python_minor_version: ["8", "9", "10", "11", "12", "13"]
               tox_env: [
                 "integration-goethereum-ipc",
                 "integration-goethereum-ipc_async",
@@ -257,7 +257,7 @@ workflows:
       - windows-wheel:
           matrix:
             parameters:
-              python_minor_version: ["10", "11", "12"]
+              python_minor_version: ["10", "11", "12", "13"]
           name: "py3<< matrix.python_minor_version >>-windows-wheel"
 
 

--- a/newsfragments/3493.internal.rst
+++ b/newsfragments/3493.internal.rst
@@ -1,0 +1,1 @@
+Add python 3.13 support

--- a/setup.py
+++ b/setup.py
@@ -100,5 +100,6 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-    py{38,39,310,311,312}-{ens,core,lint,wheel}
-    py{38,39,310,311,312}-integration-{goethereum,ethtester}
+    py{38,39,310,311,312,313}-{ens,core,lint,wheel}
+    py{38,39,310,311,312,313}-integration-{goethereum,ethtester}
     docs
     benchmark
     windows-wheel
@@ -50,8 +50,9 @@ basepython =
     py310: python3.10
     py311: python3.11
     py312: python3.12
+    py313: python3.13
 
-[testenv:py{38,39,310,311,312}-lint]
+[testenv:py{38,39,310,311,312,313}-lint]
 deps=pre-commit
 extras=dev
 commands=
@@ -66,7 +67,7 @@ commands=
     python {toxinidir}/web3/tools/benchmark/main.py --num-calls 100
 
 
-[testenv:py{38,39,310,311,312}-wheel]
+[testenv:py{38,39,310,311,312,313}-wheel]
 deps=
     wheel
     build[virtualenv]


### PR DESCRIPTION
### What was wrong?

py3.13 is here! And CI supports it

### How was it fixed?

Add 3.13 to supported and tested versions.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/f4d77318-d2f2-4ce2-9ca6-67e390b64d0d)
