### PR TITLE
Refactor install extras

### DIFF
--- a/newsfragments/3495.internal.rst
+++ b/newsfragments/3495.internal.rst
@@ -1,0 +1,1 @@
+Re-organize the install extras. Re-define the ``test`` extra to always include the ``tester`` extra since it's needed for testing.

--- a/setup.py
+++ b/setup.py
@@ -6,21 +6,16 @@ from setuptools import (
 
 extras_require = {
     "tester": [
+        # Note: ethereum-maintained libraries in this list should be added to the
+        # `install_pre_releases.py` script.
         "eth-tester[py-evm]>=0.11.0b1,<0.13.0b1",
         "py-geth>=5.0.0",
     ],
     "dev": [
         "build>=0.9.0",
         "bumpversion>=0.5.3",
-        "flaky>=3.7.0",
-        "hypothesis>=3.31.2",
         "ipython",
-        "mypy==1.10.0",
-        "pre-commit>=3.4.0",
-        "pytest-asyncio>=0.21.2,<0.23",
-        "pytest-mock>=1.10",
         "setuptools>=38.6.0",
-        "tox>=4.0.0",
         "tqdm>4.32",
         "twine>=1.13",
         "wheel",
@@ -32,12 +27,15 @@ extras_require = {
         "towncrier>=21,<22",
     ],
     "test": [
-        # Note: ethereum-maintained libraries in this list should be added to the
-        # `install_pre_releases.py` script.
         "pytest-asyncio>=0.18.1,<0.23",
         "pytest-mock>=1.10",
         "pytest-xdist>=2.4.0",
         "pytest>=7.0.0",
+        "flaky>=3.7.0",
+        "hypothesis>=3.31.2",
+        "tox>=4.0.0",
+        "mypy==1.10.0",
+        "pre-commit>=3.4.0",
     ],
 }
 
@@ -47,6 +45,7 @@ extras_require["dev"] = (
     + extras_require["test"]
     + extras_require["tester"]
 )
+extras_require["test"] = extras_require["test"] + extras_require["tester"]
 
 
 with open("./README.md") as readme:

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,9 @@ commands=
     integration-ethtester: pytest {posargs:tests/integration/test_ethereum_tester.py}
     docs: make check-docs-ci
 deps =
-    .[dev]
+    .[test]
+    ; install both `docs` and `test` dependencies for the `docs` environment
+    docs: .[docs]
 passenv =
     GETH_BINARY
     GOROOT


### PR DESCRIPTION
### What was fixed

- We [recently](https://github.com/ethereum/web3.py/pull/3480/files) added back the `tester` install extra. The `test` extra, however, will always require `eth-tester` and `py-geth` to run. Re-define the `test` extra as `test` + `tester` below.

- Leave dependencies needed for test runs only on the `test` extra,  removing them from the `dev` extra. The `dev` extra is re-defined below and pulls in all of the `test` extra dependencies.

- Use the ``test`` install extra for running the tests with CI, rather than the whole of the ``dev`` extra. This should help us catch any issues with the ``test`` extra as well. Use ``docs`` + ``test`` for the docs run.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![149051_559272406631_18002879_32491667_4977974_n](https://github.com/user-attachments/assets/8f6f59aa-bbc3-4dad-8254-76b16925bfee)
