### PR TITLE
AsyncBeacon: fix AttributeError by using aiohttp.ClientTimeout throughout

### DIFF
--- a/newsfragments/3503.bugfix.rst
+++ b/newsfragments/3503.bugfix.rst
@@ -1,0 +1,1 @@
+Properly wrap ``AsyncBeacon.request_timeout`` float in a ``aiohttp.ClientTimeout`` when making requests.

--- a/tests/beacon/test_async_beacon.py
+++ b/tests/beacon/test_async_beacon.py
@@ -52,6 +52,11 @@ async def test_async_beacon_user_request_timeout():
         await beacon.get_validators()
 
 
+@pytest.mark.asyncio
+async def test_async_beacon_request_timeout_type(async_beacon):
+    assert isinstance(async_beacon.request_timeout, float)
+
+
 # Beacon endpoint tests:
 
 

--- a/tests/beacon/test_beacon.py
+++ b/tests/beacon/test_beacon.py
@@ -41,6 +41,10 @@ def test_beacon_user_defined_request_timeout():
         beacon.get_validators()
 
 
+def test_beacon_request_timeout_type(beacon):
+    assert isinstance(beacon.request_timeout, float)
+
+
 # Beacon endpoint tests:
 
 

--- a/web3/beacon/async_beacon.py
+++ b/web3/beacon/async_beacon.py
@@ -5,6 +5,9 @@ from typing import (
     Optional,
 )
 
+from aiohttp import (
+    ClientTimeout,
+)
 from eth_typing import (
     URI,
     HexStr,
@@ -72,7 +75,7 @@ class AsyncBeacon:
     ) -> Dict[str, Any]:
         uri = URI(self.base_url + endpoint_uri)
         return await self._request_session_manager.async_json_make_get_request(
-            uri, params=params, timeout=self.request_timeout
+            uri, params=params, timeout=ClientTimeout(self.request_timeout)
         )
 
     # [ BEACON endpoints ]


### PR DESCRIPTION
Hello! I'm going to make a few pull request for some stuff I've been working on.

This fixes an issue I was having when using the `async_beacon`


### What was wrong?

```
Traceback (most recent call last):
  File "/home/lukas/Documents/git/web3.py/test-script.py", line 33, in <module>
    loop.run_until_complete(main())
  File "/usr/lib64/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/lukas/Documents/git/web3.py/test-script.py", line 22, in main
    validator = await beacon.get_validator(str(validator_id))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lukas/Documents/git/web3.py/web3/beacon/async_beacon.py", line 114, in get_validator
    return await self._async_make_get_request(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lukas/Documents/git/web3.py/web3/beacon/async_beacon.py", line 77, in _async_make_get_request
    return await self._request_session_manager.async_json_make_get_request(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lukas/Documents/git/web3.py/web3/_utils/http_session_manager.py", line 248, in async_json_make_get_request
    response = await self.async_get_response_from_get_request(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lukas/Documents/git/web3.py/web3/_utils/http_session_manager.py", line 239, in async_get_response_from_get_request
    session = await self.async_cache_and_return_session(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lukas/Documents/git/web3.py/web3/_utils/http_session_manager.py", line 228, in async_cache_and_return_session
    request_timeout.total or DEFAULT_HTTP_TIMEOUT + 0.1,
    ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'float' object has no attribute 'total'
```
### How was it fixed?

by wrapping the `request_timeout` parameter with `aiohttp.ClientTimeout`

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

### More info

I'm able to trigger this issue with this example script
```
import asyncio

from web3.beacon import AsyncBeacon

import logging

import sys

async def main():

    beacon = AsyncBeacon("http://192.168.1.112:5052")

    beacon._request_session_manager.logger.setLevel(logging.DEBUG)

    handler = logging.StreamHandler(stream=sys.stdout)
    handler.setLevel(logging.DEBUG)

    beacon._request_session_manager.logger.addHandler(handler)

    for validator_id in range(1, 500, 1):
        validator = await beacon.get_validator(str(validator_id))

        print(f"{validator_id}: {validator}")

        await asyncio.sleep(0.5)

if __name__ == "__main__":

    loop = asyncio.new_event_loop()
    asyncio.set_event_loop(loop)

    loop.run_until_complete(main())

```