### PR TITLE
docs: use quotes around pip install command

### DIFF
--- a/docs/README-linux.md
+++ b/docs/README-linux.md
@@ -42,6 +42,6 @@ cd web3.py
 python3 -m venv venv
 . venv/bin/activate
 pip install --upgrade pip
-pip install -e .[dev]
+pip install -e ".[dev]"
 
 ```

--- a/newsfragments/3505.docs.rst
+++ b/newsfragments/3505.docs.rst
@@ -1,0 +1,1 @@
+Fix `pip install -e ".[dev]"` command in linux README.


### PR DESCRIPTION
### What was wrong?

While working with the project I initial ran into this snag when reading the `README-linux.md`.

This is the error I get
```
$ pip install -e .[dev]
zsh: no matches found: .[dev]
```

### How was it fixed?

It works now by adding double quotes. This seems to follow the convension used in other documentation: 
https://github.com/ethereum/web3.py/blob/abeed70aed5272e6adbc807edd9696561aa293fc/docs/contributing.rst?plain=1#L57

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)
