### PR TITLE
Add support for non-mainnet request cache validation thresholds

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -146,7 +146,7 @@ chain reorganization or while finality has not been reached, for example. The
 caching responses that depend on block data. By default, this option is configured
 to internal values deemed "safe" for the chain id you are connected to. If you are
 connected to mainnet Ethereum, this value is set to the ``finalized`` block number.
-If you are connected to another chain, this value is set to a time internal in seconds,
+If you are connected to another chain, this value is set to a time interval in seconds,
 from the current time, that is deemed "safe" for that chain's finality mechanism.
 
 **It's important to understand that, in order to perform these validations, extra

--- a/newsfragments/3508.bugfix.rst
+++ b/newsfragments/3508.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug where non-mainnet chains could not cache requests based on missing ``finalized`` block number.

--- a/newsfragments/3508.docs.rst
+++ b/newsfragments/3508.docs.rst
@@ -1,0 +1,1 @@
+Update the request caching documentation to clarify on when to reach for request caching and how to configure the request validation threshold for certain endpoints.

--- a/newsfragments/3508.feature.rst
+++ b/newsfragments/3508.feature.rst
@@ -1,0 +1,1 @@
+Allow a time interval, in seconds, to be used as the ``request_cache_validation_threshold`` for request caching. Keep a list of internal default values based on the chain id for some of the bigger chains.

--- a/tests/core/caching-utils/test_request_caching.py
+++ b/tests/core/caching-utils/test_request_caching.py
@@ -289,7 +289,7 @@ def test_block_id_param_caching_mainnet(
         assert len(w3.provider._request_cache.items()) == 0
         w3.manager.request_blocking(RPCEndpoint(endpoint), [block_id, False])
         cached_items = len(w3.provider._request_cache.items())
-        assert cached_items > 0 if should_cache else cached_items == 0
+        assert cached_items == 1 if should_cache else cached_items == 0
 
 
 @pytest.mark.parametrize(

--- a/web3/_utils/caching/caching_utils.py
+++ b/web3/_utils/caching/caching_utils.py
@@ -53,6 +53,9 @@ from web3._utils.rpc_abi import (
 from web3.exceptions import (
     Web3TypeError,
 )
+from web3.types import (
+    RPCEndpoint,
+)
 from web3.utils import (
     RequestCacheValidationThreshold,
 )
@@ -65,7 +68,6 @@ if TYPE_CHECKING:
     from web3.types import (  # noqa: F401
         AsyncMakeRequestFn,
         MakeRequestFn,
-        RPCEndpoint,
         RPCResponse,
     )
 
@@ -93,7 +95,7 @@ def generate_cache_key(value: Any) -> str:
 class RequestInformation:
     def __init__(
         self,
-        method: "RPCEndpoint",
+        method: RPCEndpoint,
         params: Any,
         response_formatters: Tuple[
             Union[Dict[str, Callable[..., Any]], Callable[..., Any]],
@@ -133,7 +135,7 @@ CHAIN_VALIDATION_THRESHOLD_DEFAULTS: Dict[
 
 def is_cacheable_request(
     provider: Union[ASYNC_PROVIDER_TYPE, SYNC_PROVIDER_TYPE],
-    method: "RPCEndpoint",
+    method: RPCEndpoint,
     params: Any,
 ) -> bool:
     if not (provider.cache_allowed_requests and method in provider.cacheable_requests):
@@ -173,7 +175,7 @@ BLOCKHASH_IN_PARAMS = {
 }
 
 INTERNAL_VALIDATION_MAP: Dict[
-    "RPCEndpoint",
+    RPCEndpoint,
     Callable[
         [SYNC_PROVIDER_TYPE, Sequence[Any], Dict[str, Any]],
         bool,
@@ -197,7 +199,9 @@ def set_threshold_if_empty(provider: SYNC_PROVIDER_TYPE) -> None:
         try:
             # turn off momentarily to avoid recursion
             provider.cache_allowed_requests = False
-            chain_id_result = provider.make_request("eth_chainId", [])["result"]
+            chain_id_result = provider.make_request(RPCEndpoint("eth_chainId"), [])[
+                "result"
+            ]
             chain_id = int(chain_id_result, 16)
 
             if current_threshold is empty:
@@ -214,7 +218,7 @@ def set_threshold_if_empty(provider: SYNC_PROVIDER_TYPE) -> None:
 
 def _should_cache_response(
     provider: SYNC_PROVIDER_TYPE,
-    method: "RPCEndpoint",
+    method: RPCEndpoint,
     params: Sequence[Any],
     response: "RPCResponse",
 ) -> bool:
@@ -232,10 +236,10 @@ def _should_cache_response(
 
 
 def handle_request_caching(
-    func: Callable[[SYNC_PROVIDER_TYPE, "RPCEndpoint", Any], "RPCResponse"]
+    func: Callable[[SYNC_PROVIDER_TYPE, RPCEndpoint, Any], "RPCResponse"]
 ) -> Callable[..., "RPCResponse"]:
     def wrapper(
-        provider: SYNC_PROVIDER_TYPE, method: "RPCEndpoint", params: Any
+        provider: SYNC_PROVIDER_TYPE, method: RPCEndpoint, params: Any
     ) -> "RPCResponse":
         if is_cacheable_request(provider, method, params):
             request_cache = provider._request_cache
@@ -266,7 +270,7 @@ ASYNC_VALIDATOR_TYPE = Callable[
     Union[bool, Coroutine[Any, Any, bool]],
 ]
 
-ASYNC_INTERNAL_VALIDATION_MAP: Dict["RPCEndpoint", ASYNC_VALIDATOR_TYPE] = {
+ASYNC_INTERNAL_VALIDATION_MAP: Dict[RPCEndpoint, ASYNC_VALIDATOR_TYPE] = {
     **{endpoint: always_cache_request for endpoint in ALWAYS_CACHE},
     **{
         endpoint: async_validate_from_block_id_in_params
@@ -292,7 +296,9 @@ async def async_set_threshold_if_empty(provider: ASYNC_PROVIDER_TYPE) -> None:
         try:
             # turn off momentarily to avoid recursion
             provider.cache_allowed_requests = False
-            chain_id_result = await provider.make_request("eth_chainId", [])
+            chain_id_result = await provider.make_request(
+                RPCEndpoint("eth_chainId"), []
+            )
             chain_id = int(chain_id_result["result"], 16)
 
             if current_threshold is empty:
@@ -309,7 +315,7 @@ async def async_set_threshold_if_empty(provider: ASYNC_PROVIDER_TYPE) -> None:
 
 async def _async_should_cache_response(
     provider: ASYNC_PROVIDER_TYPE,
-    method: "RPCEndpoint",
+    method: RPCEndpoint,
     params: Sequence[Any],
     response: "RPCResponse",
 ) -> bool:
@@ -333,11 +339,11 @@ async def _async_should_cache_response(
 
 def async_handle_request_caching(
     func: Callable[
-        [ASYNC_PROVIDER_TYPE, "RPCEndpoint", Any], Coroutine[Any, Any, "RPCResponse"]
+        [ASYNC_PROVIDER_TYPE, RPCEndpoint, Any], Coroutine[Any, Any, "RPCResponse"]
     ],
 ) -> Callable[..., Coroutine[Any, Any, "RPCResponse"]]:
     async def wrapper(
-        provider: ASYNC_PROVIDER_TYPE, method: "RPCEndpoint", params: Any
+        provider: ASYNC_PROVIDER_TYPE, method: RPCEndpoint, params: Any
     ) -> "RPCResponse":
         if is_cacheable_request(provider, method, params):
             request_cache = provider._request_cache

--- a/web3/_utils/caching/caching_utils.py
+++ b/web3/_utils/caching/caching_utils.py
@@ -193,27 +193,12 @@ def set_threshold_if_empty(provider: SYNC_PROVIDER_TYPE) -> None:
     if current_threshold is empty or isinstance(
         current_threshold, RequestCacheValidationThreshold
     ):
+        cache_allowed_requests = provider.cache_allowed_requests
         try:
             # turn off momentarily to avoid recursion
             provider.cache_allowed_requests = False
             chain_id_result = provider.make_request("eth_chainId", [])["result"]
             chain_id = int(chain_id_result, 16)
-
-            if (
-                isinstance(
-                    current_threshold,
-                    RequestCacheValidationThreshold,
-                )
-                and chain_id != 1
-            ):
-                provider.logger.debug(
-                    "Request cache validation threshold is set to "
-                    f"{current_threshold.value} "
-                    f"for chain with chain_id `{chain_id}` but this value only works "
-                    "on chain_id `1`. Setting to default value for chain_id "
-                    f"`{chain_id}`.",
-                )
-                provider.request_cache_validation_threshold = empty
 
             if current_threshold is empty:
                 provider.request_cache_validation_threshold = (
@@ -224,7 +209,7 @@ def set_threshold_if_empty(provider: SYNC_PROVIDER_TYPE) -> None:
         except Exception:
             provider.request_cache_validation_threshold = DEFAULT_VALIDATION_THRESHOLD
         finally:
-            provider.cache_allowed_requests = True
+            provider.cache_allowed_requests = cache_allowed_requests
 
 
 def _should_cache_response(
@@ -303,27 +288,12 @@ async def async_set_threshold_if_empty(provider: ASYNC_PROVIDER_TYPE) -> None:
     if current_threshold is empty or isinstance(
         current_threshold, RequestCacheValidationThreshold
     ):
+        cache_allowed_requests = provider.cache_allowed_requests
         try:
             # turn off momentarily to avoid recursion
             provider.cache_allowed_requests = False
             chain_id_result = await provider.make_request("eth_chainId", [])
             chain_id = int(chain_id_result["result"], 16)
-
-            if (
-                isinstance(
-                    current_threshold,
-                    RequestCacheValidationThreshold,
-                )
-                and chain_id != 1
-            ):
-                provider.logger.debug(
-                    "Request cache validation threshold is set to "
-                    f"{current_threshold.value} "
-                    f"for chain with chain_id `{chain_id}` but this value only works "
-                    "on chain_id `1`. Setting to default value for chain_id "
-                    f"`{chain_id}`.",
-                )
-                provider.request_cache_validation_threshold = empty
 
             if current_threshold is empty:
                 provider.request_cache_validation_threshold = (
@@ -334,7 +304,7 @@ async def async_set_threshold_if_empty(provider: ASYNC_PROVIDER_TYPE) -> None:
         except Exception:
             provider.request_cache_validation_threshold = DEFAULT_VALIDATION_THRESHOLD
         finally:
-            provider.cache_allowed_requests = True
+            provider.cache_allowed_requests = cache_allowed_requests
 
 
 async def _async_should_cache_response(

--- a/web3/_utils/caching/request_caching_validation.py
+++ b/web3/_utils/caching/request_caching_validation.py
@@ -44,6 +44,8 @@ def is_beyond_validation_threshold(
     try:
         threshold = provider.request_cache_validation_threshold
 
+        # turn off caching to prevent recursion
+        provider.cache_allowed_requests = False
         if isinstance(threshold, RequestCacheValidationThreshold):
             # if mainnet and threshold is "finalized" or "safe"
             threshold_block = provider.make_request(
@@ -72,6 +74,8 @@ def is_beyond_validation_threshold(
     except Exception as e:
         _error_log(provider, e)
         return False
+    finally:
+        provider.cache_allowed_requests = True
 
 
 def validate_from_block_id_in_params(
@@ -94,6 +98,9 @@ def validate_from_blocknum_in_result(
     result: Dict[str, Any],
 ) -> bool:
     try:
+        # turn off caching to prevent recursion
+        provider.cache_allowed_requests = False
+
         # transaction results
         if "blockNumber" in result:
             blocknum = result.get("blockNumber")
@@ -121,6 +128,8 @@ def validate_from_blocknum_in_result(
     except Exception as e:
         _error_log(provider, e)
         return False
+    finally:
+        provider.cache_allowed_requests = True
 
 
 def validate_from_blockhash_in_params(
@@ -129,6 +138,9 @@ def validate_from_blockhash_in_params(
     _result: Dict[str, Any],
 ) -> bool:
     try:
+        # turn off caching to prevent recursion
+        provider.cache_allowed_requests = False
+
         # make an extra call to get the block number from the hash
         block = provider.make_request("eth_getBlockByHash", [params[0], False])[
             "result"
@@ -141,6 +153,8 @@ def validate_from_blockhash_in_params(
     except Exception as e:
         _error_log(provider, e)
         return False
+    finally:
+        provider.cache_allowed_requests = True
 
 
 # -- async -- #
@@ -154,6 +168,8 @@ async def async_is_beyond_validation_threshold(
     try:
         threshold = provider.request_cache_validation_threshold
 
+        # turn off caching to prevent recursion
+        provider.cache_allowed_requests = False
         if isinstance(threshold, RequestCacheValidationThreshold):
             # if mainnet and threshold is "finalized" or "safe"
             threshold_block = await provider.make_request(
@@ -180,6 +196,8 @@ async def async_is_beyond_validation_threshold(
     except Exception as e:
         _error_log(provider, e)
         return False
+    finally:
+        provider.cache_allowed_requests = True
 
 
 async def async_validate_from_block_id_in_params(
@@ -202,6 +220,9 @@ async def async_validate_from_blocknum_in_result(
     result: Dict[str, Any],
 ) -> bool:
     try:
+        # turn off caching to prevent recursion
+        provider.cache_allowed_requests = False
+
         # transaction results
         if "blockNumber" in result:
             blocknum = result.get("blockNumber")
@@ -229,12 +250,17 @@ async def async_validate_from_blocknum_in_result(
     except Exception as e:
         _error_log(provider, e)
         return False
+    finally:
+        provider.cache_allowed_requests = True
 
 
 async def async_validate_from_blockhash_in_params(
     provider: ASYNC_PROVIDER_TYPE, params: Sequence[Any], _result: Dict[str, Any]
 ) -> bool:
     try:
+        # turn off caching to prevent recursion
+        provider.cache_allowed_requests = False
+
         # make an extra call to get the block number from the hash
         response = await provider.make_request("eth_getBlockByHash", [params[0], False])
         return await async_is_beyond_validation_threshold(
@@ -245,3 +271,5 @@ async def async_validate_from_blockhash_in_params(
     except Exception as e:
         _error_log(provider, e)
         return False
+    finally:
+        provider.cache_allowed_requests = True

--- a/web3/_utils/caching/request_caching_validation.py
+++ b/web3/_utils/caching/request_caching_validation.py
@@ -1,3 +1,4 @@
+import time
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -7,8 +8,8 @@ from typing import (
     Union,
 )
 
-from eth_utils import (
-    to_int,
+from web3.utils import (
+    RequestCacheValidationThreshold,
 )
 
 if TYPE_CHECKING:
@@ -31,99 +32,216 @@ def _error_log(
     )
 
 
-def is_beyond_validation_threshold(provider: SYNC_PROVIDER_TYPE, blocknum: int) -> bool:
+def always_cache_request(*_args: Any, **_kwargs: Any) -> bool:
+    return True
+
+
+def is_beyond_validation_threshold(
+    provider: SYNC_PROVIDER_TYPE,
+    blocknum: int = None,
+    block_timestamp: int = None,
+) -> bool:
     try:
-        # `threshold` is either "finalized" or "safe"
-        threshold = provider.request_cache_validation_threshold.value
-        response = provider.make_request("eth_getBlockByNumber", [threshold, False])
-        return blocknum <= to_int(hexstr=response["result"]["number"])
+        threshold = provider.request_cache_validation_threshold
+
+        if isinstance(threshold, RequestCacheValidationThreshold):
+            # if mainnet and threshold is "finalized" or "safe"
+            threshold_block = provider.make_request(
+                "eth_getBlockByNumber", [threshold.value, False]
+            )["result"]
+            # we should have a `blocknum` to compare against
+            return blocknum <= int(threshold_block["number"], 16)
+        elif isinstance(threshold, int):
+            if not block_timestamp:
+                # if validating via `blocknum` from params, we need to get the timestamp
+                # for the block with `blocknum`.
+                block = provider.make_request(
+                    "eth_getBlockByNumber", [hex(blocknum), False]
+                )["result"]
+                block_timestamp = int(block["timestamp"], 16)
+
+            # if validating via `block_timestamp` from result, we should have a
+            # `block_timestamp` to compare against
+            return block_timestamp <= time.time() - threshold
+        else:
+            provider.logger.error(
+                "Invalid request_cache_validation_threshold value. This should not "
+                f"have happened. Request not cached.\n    threshold: {threshold}"
+            )
+            return False
     except Exception as e:
         _error_log(provider, e)
         return False
 
 
-def always_cache_request(*_args: Any, **_kwargs: Any) -> bool:
-    return True
-
-
-def validate_blocknum_in_params(
-    provider: SYNC_PROVIDER_TYPE, params: Sequence[Any], _result: Dict[str, Any]
+def validate_from_block_id_in_params(
+    provider: SYNC_PROVIDER_TYPE,
+    params: Sequence[Any],
+    _result: Dict[str, Any],
 ) -> bool:
     block_id = params[0]
     if block_id == "earliest":
         # `earliest` should always be cacheable
         return True
-    blocknum = to_int(hexstr=block_id)
-    return is_beyond_validation_threshold(provider, blocknum)
+
+    blocknum = int(block_id, 16)
+    return is_beyond_validation_threshold(provider, blocknum=blocknum)
 
 
-def validate_blocknum_in_result(
-    provider: SYNC_PROVIDER_TYPE, _params: Sequence[Any], result: Dict[str, Any]
-) -> bool:
-    # `number` if block result, `blockNumber` if transaction result
-    blocknum = to_int(hexstr=result.get("number", result.get("blockNumber")))
-    return is_beyond_validation_threshold(provider, blocknum)
-
-
-def validate_blockhash_in_params(
-    provider: SYNC_PROVIDER_TYPE, params: Sequence[Any], _result: Dict[str, Any]
+def validate_from_blocknum_in_result(
+    provider: SYNC_PROVIDER_TYPE,
+    _params: Sequence[Any],
+    result: Dict[str, Any],
 ) -> bool:
     try:
-        # make an extra call to get the block number from the hash
-        response = provider.make_request("eth_getBlockByHash", [params[0], False])
+        # transaction results
+        if "blockNumber" in result:
+            blocknum = result.get("blockNumber")
+            # make an extra call to get the block values
+            block = provider.make_request("eth_getBlockByNumber", [blocknum, False])[
+                "result"
+            ]
+            return is_beyond_validation_threshold(
+                provider,
+                blocknum=int(blocknum, 16),
+                block_timestamp=int(block["timestamp"], 16),
+            )
+        elif "number" in result:
+            return is_beyond_validation_threshold(
+                provider,
+                blocknum=int(result["number"], 16),
+                block_timestamp=int(result["timestamp"], 16),
+            )
+        else:
+            provider.logger.error(
+                "Could not find block number in result. This should not have happened. "
+                f"Request not cached.\n    result: {result}",
+            )
+            return False
     except Exception as e:
         _error_log(provider, e)
         return False
 
-    blocknum = to_int(hexstr=response["result"]["number"])
-    return is_beyond_validation_threshold(provider, blocknum)
+
+def validate_from_blockhash_in_params(
+    provider: SYNC_PROVIDER_TYPE,
+    params: Sequence[Any],
+    _result: Dict[str, Any],
+) -> bool:
+    try:
+        # make an extra call to get the block number from the hash
+        block = provider.make_request("eth_getBlockByHash", [params[0], False])[
+            "result"
+        ]
+        return is_beyond_validation_threshold(
+            provider,
+            blocknum=int(block["number"], 16),
+            block_timestamp=int(block["timestamp"], 16),
+        )
+    except Exception as e:
+        _error_log(provider, e)
+        return False
 
 
 # -- async -- #
 
 
 async def async_is_beyond_validation_threshold(
-    provider: ASYNC_PROVIDER_TYPE, blocknum: int
+    provider: ASYNC_PROVIDER_TYPE,
+    blocknum: int = None,
+    block_timestamp: int = None,
 ) -> bool:
     try:
-        # `threshold` is either "finalized" or "safe"
-        threshold = provider.request_cache_validation_threshold.value
-        response = await provider.make_request(
-            "eth_getBlockByNumber", [threshold, False]
-        )
-        return blocknum <= to_int(hexstr=response["result"]["number"])
+        threshold = provider.request_cache_validation_threshold
+
+        if isinstance(threshold, RequestCacheValidationThreshold):
+            # if mainnet and threshold is "finalized" or "safe"
+            threshold_block = await provider.make_request(
+                "eth_getBlockByNumber", [threshold.value, False]
+            )
+            # we should have a `blocknum` to compare against
+            return blocknum <= int(threshold_block["result"]["number"], 16)
+        elif isinstance(threshold, int):
+            if not block_timestamp:
+                block = await provider.make_request(
+                    "eth_getBlockByNumber", [hex(blocknum), False]
+                )
+                block_timestamp = int(block["result"]["timestamp"], 16)
+
+            # if validating via `block_timestamp` from result, we should have a
+            # `block_timestamp` to compare against
+            return block_timestamp <= time.time() - threshold
+        else:
+            provider.logger.error(
+                "Invalid request_cache_validation_threshold value. This should not "
+                f"have happened. Request not cached.\n    threshold: {threshold}"
+            )
+            return False
     except Exception as e:
         _error_log(provider, e)
         return False
 
 
-async def async_validate_blocknum_in_params(
-    provider: ASYNC_PROVIDER_TYPE, params: Sequence[Any], _result: Dict[str, Any]
+async def async_validate_from_block_id_in_params(
+    provider: ASYNC_PROVIDER_TYPE,
+    params: Sequence[Any],
+    _result: Dict[str, Any],
 ) -> bool:
     block_id = params[0]
     if block_id == "earliest":
         # `earliest` should always be cacheable
         return True
-    blocknum = to_int(hexstr=params[0])
-    return await async_is_beyond_validation_threshold(provider, blocknum)
+
+    blocknum = int(block_id, 16)
+    return await async_is_beyond_validation_threshold(provider, blocknum=blocknum)
 
 
-async def async_validate_blocknum_in_result(
-    provider: ASYNC_PROVIDER_TYPE, _params: Sequence[Any], result: Dict[str, Any]
-) -> bool:
-    # `number` if block result, `blockNumber` if transaction result
-    blocknum = to_int(hexstr=result.get("number", result.get("blockNumber")))
-    return await async_is_beyond_validation_threshold(provider, blocknum)
-
-
-async def async_validate_blockhash_in_params(
-    provider: ASYNC_PROVIDER_TYPE, params: Sequence[Any], _result: Dict[str, Any]
+async def async_validate_from_blocknum_in_result(
+    provider: ASYNC_PROVIDER_TYPE,
+    _params: Sequence[Any],
+    result: Dict[str, Any],
 ) -> bool:
     try:
-        response = await provider.make_request("eth_getBlockByHash", [params[0], False])
+        # transaction results
+        if "blockNumber" in result:
+            blocknum = result.get("blockNumber")
+            # make an extra call to get the block values
+            block = await provider.make_request(
+                "eth_getBlockByNumber", [blocknum, False]
+            )
+            return await async_is_beyond_validation_threshold(
+                provider,
+                blocknum=int(blocknum, 16),
+                block_timestamp=int(block["result"]["timestamp"], 16),
+            )
+        elif "number" in result:
+            return await async_is_beyond_validation_threshold(
+                provider,
+                blocknum=int(result["number"], 16),
+                block_timestamp=int(result["timestamp"], 16),
+            )
+        else:
+            provider.logger.error(
+                "Could not find block number in result. This should not have happened. "
+                f"Request not cached.\n    result: {result}",
+            )
+            return False
     except Exception as e:
         _error_log(provider, e)
         return False
 
-    blocknum = to_int(hexstr=response["result"]["number"])
-    return await async_is_beyond_validation_threshold(provider, blocknum)
+
+async def async_validate_from_blockhash_in_params(
+    provider: ASYNC_PROVIDER_TYPE, params: Sequence[Any], _result: Dict[str, Any]
+) -> bool:
+    try:
+        # make an extra call to get the block number from the hash
+        response = await provider.make_request("eth_getBlockByHash", [params[0], False])
+        return await async_is_beyond_validation_threshold(
+            provider,
+            blocknum=int(response["result"]["number"], 16),
+            block_timestamp=int(response["result"]["timestamp"], 16),
+        )
+    except Exception as e:
+        _error_log(provider, e)
+        return False

--- a/web3/_utils/caching/request_caching_validation.py
+++ b/web3/_utils/caching/request_caching_validation.py
@@ -8,6 +8,9 @@ from typing import (
     Union,
 )
 
+from web3.types import (
+    RPCEndpoint,
+)
 from web3.utils import (
     RequestCacheValidationThreshold,
 )
@@ -50,7 +53,7 @@ def is_beyond_validation_threshold(
         if isinstance(threshold, RequestCacheValidationThreshold):
             # if mainnet and threshold is "finalized" or "safe"
             threshold_block = provider.make_request(
-                "eth_getBlockByNumber", [threshold.value, False]
+                RPCEndpoint("eth_getBlockByNumber"), [threshold.value, False]
             )["result"]
             # we should have a `blocknum` to compare against
             return blocknum <= int(threshold_block["number"], 16)
@@ -59,7 +62,7 @@ def is_beyond_validation_threshold(
                 # if validating via `blocknum` from params, we need to get the timestamp
                 # for the block with `blocknum`.
                 block = provider.make_request(
-                    "eth_getBlockByNumber", [hex(blocknum), False]
+                    RPCEndpoint("eth_getBlockByNumber"), [hex(blocknum), False]
                 )["result"]
                 block_timestamp = int(block["timestamp"], 16)
 
@@ -107,9 +110,9 @@ def validate_from_blocknum_in_result(
         if "blockNumber" in result:
             blocknum = result.get("blockNumber")
             # make an extra call to get the block values
-            block = provider.make_request("eth_getBlockByNumber", [blocknum, False])[
-                "result"
-            ]
+            block = provider.make_request(
+                RPCEndpoint("eth_getBlockByNumber"), [blocknum, False]
+            )["result"]
             return is_beyond_validation_threshold(
                 provider,
                 blocknum=int(blocknum, 16),
@@ -145,9 +148,9 @@ def validate_from_blockhash_in_params(
         provider.cache_allowed_requests = False
 
         # make an extra call to get the block number from the hash
-        block = provider.make_request("eth_getBlockByHash", [params[0], False])[
-            "result"
-        ]
+        block = provider.make_request(
+            RPCEndpoint("eth_getBlockByHash"), [params[0], False]
+        )["result"]
         return is_beyond_validation_threshold(
             provider,
             blocknum=int(block["number"], 16),
@@ -177,14 +180,14 @@ async def async_is_beyond_validation_threshold(
         if isinstance(threshold, RequestCacheValidationThreshold):
             # if mainnet and threshold is "finalized" or "safe"
             threshold_block = await provider.make_request(
-                "eth_getBlockByNumber", [threshold.value, False]
+                RPCEndpoint("eth_getBlockByNumber"), [threshold.value, False]
             )
             # we should have a `blocknum` to compare against
             return blocknum <= int(threshold_block["result"]["number"], 16)
         elif isinstance(threshold, int):
             if not block_timestamp:
                 block = await provider.make_request(
-                    "eth_getBlockByNumber", [hex(blocknum), False]
+                    RPCEndpoint("eth_getBlockByNumber"), [hex(blocknum), False]
                 )
                 block_timestamp = int(block["result"]["timestamp"], 16)
 
@@ -233,7 +236,7 @@ async def async_validate_from_blocknum_in_result(
             blocknum = result.get("blockNumber")
             # make an extra call to get the block values
             block = await provider.make_request(
-                "eth_getBlockByNumber", [blocknum, False]
+                RPCEndpoint("eth_getBlockByNumber"), [blocknum, False]
             )
             return await async_is_beyond_validation_threshold(
                 provider,
@@ -268,7 +271,9 @@ async def async_validate_from_blockhash_in_params(
         provider.cache_allowed_requests = False
 
         # make an extra call to get the block number from the hash
-        response = await provider.make_request("eth_getBlockByHash", [params[0], False])
+        response = await provider.make_request(
+            RPCEndpoint("eth_getBlockByHash"), [params[0], False]
+        )
         return await async_is_beyond_validation_threshold(
             provider,
             blocknum=int(response["result"]["number"], 16),

--- a/web3/_utils/caching/request_caching_validation.py
+++ b/web3/_utils/caching/request_caching_validation.py
@@ -41,6 +41,7 @@ def is_beyond_validation_threshold(
     blocknum: int = None,
     block_timestamp: int = None,
 ) -> bool:
+    cache_allowed_requests = provider.cache_allowed_requests
     try:
         threshold = provider.request_cache_validation_threshold
 
@@ -75,7 +76,7 @@ def is_beyond_validation_threshold(
         _error_log(provider, e)
         return False
     finally:
-        provider.cache_allowed_requests = True
+        provider.cache_allowed_requests = cache_allowed_requests
 
 
 def validate_from_block_id_in_params(
@@ -97,6 +98,7 @@ def validate_from_blocknum_in_result(
     _params: Sequence[Any],
     result: Dict[str, Any],
 ) -> bool:
+    cache_allowed_requests = provider.cache_allowed_requests
     try:
         # turn off caching to prevent recursion
         provider.cache_allowed_requests = False
@@ -129,7 +131,7 @@ def validate_from_blocknum_in_result(
         _error_log(provider, e)
         return False
     finally:
-        provider.cache_allowed_requests = True
+        provider.cache_allowed_requests = cache_allowed_requests
 
 
 def validate_from_blockhash_in_params(
@@ -137,6 +139,7 @@ def validate_from_blockhash_in_params(
     params: Sequence[Any],
     _result: Dict[str, Any],
 ) -> bool:
+    cache_allowed_requests = provider.cache_allowed_requests
     try:
         # turn off caching to prevent recursion
         provider.cache_allowed_requests = False
@@ -154,7 +157,7 @@ def validate_from_blockhash_in_params(
         _error_log(provider, e)
         return False
     finally:
-        provider.cache_allowed_requests = True
+        provider.cache_allowed_requests = cache_allowed_requests
 
 
 # -- async -- #
@@ -165,6 +168,7 @@ async def async_is_beyond_validation_threshold(
     blocknum: int = None,
     block_timestamp: int = None,
 ) -> bool:
+    cache_allowed_requests = provider.cache_allowed_requests
     try:
         threshold = provider.request_cache_validation_threshold
 
@@ -197,7 +201,7 @@ async def async_is_beyond_validation_threshold(
         _error_log(provider, e)
         return False
     finally:
-        provider.cache_allowed_requests = True
+        provider.cache_allowed_requests = cache_allowed_requests
 
 
 async def async_validate_from_block_id_in_params(
@@ -219,6 +223,7 @@ async def async_validate_from_blocknum_in_result(
     _params: Sequence[Any],
     result: Dict[str, Any],
 ) -> bool:
+    cache_allowed_requests = provider.cache_allowed_requests
     try:
         # turn off caching to prevent recursion
         provider.cache_allowed_requests = False
@@ -251,12 +256,13 @@ async def async_validate_from_blocknum_in_result(
         _error_log(provider, e)
         return False
     finally:
-        provider.cache_allowed_requests = True
+        provider.cache_allowed_requests = cache_allowed_requests
 
 
 async def async_validate_from_blockhash_in_params(
     provider: ASYNC_PROVIDER_TYPE, params: Sequence[Any], _result: Dict[str, Any]
 ) -> bool:
+    cache_allowed_requests = provider.cache_allowed_requests
     try:
         # turn off caching to prevent recursion
         provider.cache_allowed_requests = False
@@ -272,4 +278,4 @@ async def async_validate_from_blockhash_in_params(
         _error_log(provider, e)
         return False
     finally:
-        provider.cache_allowed_requests = True
+        provider.cache_allowed_requests = cache_allowed_requests

--- a/web3/_utils/module_testing/utils.py
+++ b/web3/_utils/module_testing/utils.py
@@ -35,6 +35,14 @@ class RequestMocker:
     Context manager to mock requests made by a web3 instance. This is meant to be used
     via a ``request_mocker`` fixture defined within the appropriate context.
 
+    ************************************************************************************
+    Important: When mocking results, it's important to keep in mind the types that
+        clients return. For example, what we commonly translate to integers are returned
+        as hex strings in the RPC response and should be mocked as such for more
+        accurate testing.
+    ************************************************************************************
+
+
     Example:
     -------
 

--- a/web3/_utils/module_testing/utils.py
+++ b/web3/_utils/module_testing/utils.py
@@ -113,10 +113,9 @@ class RequestMocker:
 
         return self
 
-    # define __exit__ with typing information
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         # mypy error: Cannot assign to a method
-        self.w3.provider.make_request = self._make_request  # type: ignore[method-assign]  # noqa: E501
+        self.w3.provider.make_request = self._make_request  # type: ignore[assignment]
         # reset request func cache to re-build request_func with original make_request
         self.w3.provider._request_func_cache = (None, None)
 
@@ -175,6 +174,7 @@ class RequestMocker:
             return mocked_response
 
     # -- async -- #
+
     async def __aenter__(self) -> "Self":
         # mypy error: Cannot assign to a method
         self.w3.provider.make_request = self._async_mock_request_handler  # type: ignore[method-assign]  # noqa: E501
@@ -184,7 +184,7 @@ class RequestMocker:
 
     async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         # mypy error: Cannot assign to a method
-        self.w3.provider.make_request = self._make_request  # type: ignore[method-assign]  # noqa: E501
+        self.w3.provider.make_request = self._make_request  # type: ignore[assignment]
         # reset request func cache to re-build request_func with original make_request
         self.w3.provider._request_func_cache = (None, None)
 

--- a/web3/providers/async_base.py
+++ b/web3/providers/async_base.py
@@ -10,6 +10,7 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    Union,
     cast,
 )
 
@@ -22,6 +23,10 @@ from eth_utils import (
 from web3._utils.caching import (
     CACHEABLE_REQUESTS,
     async_handle_request_caching,
+)
+from web3._utils.empty import (
+    Empty,
+    empty,
 )
 from web3._utils.encoding import (
     FriendlyJsonSerde,
@@ -88,8 +93,8 @@ class AsyncBaseProvider:
         cache_allowed_requests: bool = False,
         cacheable_requests: Set[RPCEndpoint] = None,
         request_cache_validation_threshold: Optional[
-            RequestCacheValidationThreshold
-        ] = RequestCacheValidationThreshold.FINALIZED,
+            Union[RequestCacheValidationThreshold, int, Empty]
+        ] = empty,
     ) -> None:
         self._request_cache = SimpleCache(1000)
         self.cache_allowed_requests = cache_allowed_requests

--- a/web3/providers/async_base.py
+++ b/web3/providers/async_base.py
@@ -22,7 +22,6 @@ from eth_utils import (
 
 from web3._utils.caching import (
     CACHEABLE_REQUESTS,
-    async_handle_request_caching,
 )
 from web3._utils.empty import (
     Empty,
@@ -137,7 +136,6 @@ class AsyncBaseProvider:
             self._batch_request_func_cache = (middleware, accumulator_fn)
         return self._batch_request_func_cache[-1]
 
-    @async_handle_request_caching
     async def make_request(self, method: RPCEndpoint, params: Any) -> RPCResponse:
         raise NotImplementedError("Providers must implement this method")
 

--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -20,7 +20,6 @@ from eth_utils import (
 
 from web3._utils.caching import (
     CACHEABLE_REQUESTS,
-    handle_request_caching,
 )
 from web3._utils.empty import (
     Empty,
@@ -109,7 +108,6 @@ class BaseProvider:
 
         return self._request_func_cache[-1]
 
-    @handle_request_caching
     def make_request(self, method: RPCEndpoint, params: Any) -> RPCResponse:
         raise NotImplementedError("Providers must implement this method")
 

--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -9,6 +9,7 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    Union,
     cast,
 )
 
@@ -20,6 +21,10 @@ from eth_utils import (
 from web3._utils.caching import (
     CACHEABLE_REQUESTS,
     handle_request_caching,
+)
+from web3._utils.empty import (
+    Empty,
+    empty,
 )
 from web3._utils.encoding import (
     FriendlyJsonSerde,
@@ -71,8 +76,8 @@ class BaseProvider:
         cache_allowed_requests: bool = False,
         cacheable_requests: Set[RPCEndpoint] = None,
         request_cache_validation_threshold: Optional[
-            RequestCacheValidationThreshold
-        ] = RequestCacheValidationThreshold.FINALIZED,
+            Union[RequestCacheValidationThreshold, int, Empty]
+        ] = empty,
     ) -> None:
         self._request_cache = SimpleCache(1000)
         self.cache_allowed_requests = cache_allowed_requests

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -32,6 +32,9 @@ from web3.types import (
 from .._utils.batching import (
     sort_batch_response_by_response_ids,
 )
+from .._utils.caching import (
+    handle_request_caching,
+)
 from ..exceptions import (
     Web3TypeError,
     Web3ValueError,
@@ -189,6 +192,7 @@ class IPCProvider(JSONBaseProvider):
                         timeout.sleep(0)
                         continue
 
+    @handle_request_caching
     def make_request(self, method: RPCEndpoint, params: Any) -> RPCResponse:
         self.logger.debug(
             f"Making request IPC. Path: {self.ipc_path}, Method: {method}"


### PR DESCRIPTION
### What was wrong?

closes #3506

### How was it fixed?

- If non-mainnet ethereum, allow the use of an integer value for the request cache validation threshold. Pre-configure "safe" default values for some common non-mainnet chain ids based on their varied finality mechanisms.
- This integer value represents the number of seconds from time.now() that the request cache deems as a safe enough time window to allow the request to be cached.
- Update the tests to reflect these changes.
- Added comprehensive testing around the caching logic, affected endpoints, and all relevant providers.

Unrelated:

- Add a note to the ``request_mocker`` to make sure that mocked results
  are of the correct expected types based on JSON-RPC spec (e.g. hex
  strings instead of ints for numbers, etc.)
- Removed request caching decorator from base providers since they don't implement `make_request`. This makes typing tighter around the code base as well.
- IPCProvider did not have request caching turned on. This PR turns that on.

### Todo:

- [x] Add or update documentation related to these changes. This documentation should detail the underlying mechanism of how (and why) to check certain endpoints against a validation threshold so that users know:

  1. When to reach for caching in the first place
  2. If they reach for caching, clarify internal calls can be made to get the necessary validation data
  3. Know how they can tweak the validation threshold to lower the number of internal calls made (or set it to ``None`` to cache any and all requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)
- [x] Clean up commit history

#### Cute Animal Picture

```
     __      __
    /  \____/  \
   (    o  o    )
    \    ∇     /
     \  \___/  /
      \_______/
        |   |
```