### PR TITLE
tests/beacon: use fixture for user_defined_request_timeout tests

### DIFF
--- a/tests/beacon/test_async_beacon.py
+++ b/tests/beacon/test_async_beacon.py
@@ -46,10 +46,10 @@ async def test_async_cl_beacon_raises_exception_on_invalid_url(async_beacon):
 
 
 @pytest.mark.asyncio
-async def test_async_beacon_user_request_timeout():
-    beacon = AsyncBeacon(base_url=BASE_URL, request_timeout=0.001)
+async def test_async_beacon_user_request_timeout(async_beacon):
+    async_beacon.request_timeout = 0.001
     with pytest.raises(TimeoutError):
-        await beacon.get_validators()
+        await async_beacon.get_validators()
 
 
 # Beacon endpoint tests:

--- a/tests/beacon/test_beacon.py
+++ b/tests/beacon/test_beacon.py
@@ -35,8 +35,8 @@ def test_cl_beacon_raises_exception_on_invalid_url(beacon):
         beacon._make_get_request(BASE_URL + "/eth/v1/beacon/nonexistent")
 
 
-def test_beacon_user_defined_request_timeout():
-    beacon = Beacon(base_url=BASE_URL, request_timeout=0.001)
+def test_beacon_user_defined_request_timeout(beacon):
+    beacon.request_timeout = 0.001
     with pytest.raises(Timeout):
         beacon.get_validators()
 


### PR DESCRIPTION
### What was wrong?

Running `pytest -rP tests/beacon/test_async_beacon.py` makes the following warning:
```
tests/beacon/test_async_beacon.py::test_async_beacon_user_request_timeout
  /home/lukas/Documents/git/web3.py/venv/lib64/python3.13/site-packages/aiohttp/client.py:417: ResourceWarning: Unclosed client session <aiohttp.client.ClientSession object at 0x7f9562d34a50>
```

The change to the synchronous beacon class test is just to make it uniform

### How was it fixed?

By using the fixture so that the closure runs and cleans up the aiohttp.client.ClientSession after the test

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)
