### PR TITLE
Changes related to eth-typing bugfix for ABIEvent type

### DIFF
--- a/newsfragments/3510.bugfix.rst
+++ b/newsfragments/3510.bugfix.rst
@@ -1,0 +1,1 @@
+Changes related to an `eth-typing` bugfix, input types for ``ABIEvent``: ``ABIComponent`` -> ``ABIComponentIndexed``.

--- a/web3/_utils/abi.py
+++ b/web3/_utils/abi.py
@@ -110,19 +110,11 @@ def receive_func_abi_exists(contract_abi: ABI) -> Sequence[ABIReceive]:
 
 
 def get_indexed_event_inputs(event_abi: ABIEvent) -> Sequence[ABIComponentIndexed]:
-    return [
-        cast(ABIComponentIndexed, arg)
-        for arg in event_abi["inputs"]
-        if cast(ABIComponentIndexed, arg)["indexed"] is True
-    ]
+    return [arg for arg in event_abi["inputs"] if arg["indexed"] is True]
 
 
-def exclude_indexed_event_inputs(event_abi: ABIEvent) -> Sequence[ABIComponent]:
-    return [
-        arg
-        for arg in event_abi["inputs"]
-        if cast(ABIComponentIndexed, arg)["indexed"] is False
-    ]
+def exclude_indexed_event_inputs(event_abi: ABIEvent) -> Sequence[ABIComponentIndexed]:
+    return [arg for arg in event_abi["inputs"] if arg["indexed"] is False]
 
 
 def filter_by_argument_name(

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -21,7 +21,6 @@ from eth_abi.exceptions import (
 )
 from eth_typing import (
     ABI,
-    ABIComponentIndexed,
     ABIElement,
     ABIEvent,
     ABIFunction,
@@ -295,7 +294,7 @@ class BaseContractEvent:
             # if no non-indexed args in argument filters, since indexed args are
             # filtered pre-call to ``eth_getLogs`` by building specific ``topics``.
             not any(
-                not cast(ABIComponentIndexed, arg)["indexed"]
+                not arg["indexed"]
                 for arg in event_abi["inputs"]
                 if arg["name"] in argument_filters
             )


### PR DESCRIPTION
### What was wrong?

Related to Issue ethereum/eth-typing#92

### How was it fixed?

- Casting no longer needed.

### Todo:

- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

```
      /^-----^\
      V  o o  V
       |  Y  |
        \ Q /
       / - \
       |    \
       |     \     )
       || (___\==== 
```