### PR TITLE
send ccip-read post request with json payload

### DIFF
--- a/newsfragments/3512.bugfix.rst
+++ b/newsfragments/3512.bugfix.rst
@@ -1,0 +1,1 @@
+Send ``json``, not ``data`` with CCIP-Read POST requests.

--- a/web3/_utils/module_testing/module_testing_utils.py
+++ b/web3/_utils/module_testing/module_testing_utils.py
@@ -196,8 +196,8 @@ def async_mock_offchain_lookup_request_response(
         # mock response only to specified url while validating appropriate fields
         if url_from_args == mocked_request_url:
             assert kwargs["timeout"] == ClientTimeout(DEFAULT_HTTP_TIMEOUT)
-            if http_method.upper() == "post":
-                assert kwargs["data"] == {"data": calldata, "sender": sender}
+            if http_method.upper() == "POST":
+                assert kwargs["json"] == {"data": calldata, "sender": sender}
             return AsyncMockedResponse()
 
         # else, make a normal request (no mocking)

--- a/web3/_utils/module_testing/module_testing_utils.py
+++ b/web3/_utils/module_testing/module_testing_utils.py
@@ -147,7 +147,7 @@ def mock_offchain_lookup_request_response(
         if url_from_args == mocked_request_url:
             assert kwargs["timeout"] == DEFAULT_HTTP_TIMEOUT
             if http_method.upper() == "POST":
-                assert kwargs["data"] == {"data": calldata, "sender": sender}
+                assert kwargs["json"] == {"data": calldata, "sender": sender}
             return MockedResponse()
 
         # else, make a normal request (no mocking)

--- a/web3/utils/async_exception_handling.py
+++ b/web3/utils/async_exception_handling.py
@@ -59,7 +59,7 @@ async def async_handle_offchain_lookup(
             else:
                 response = await session.post(
                     formatted_url,
-                    data={"data": formatted_data, "sender": formatted_sender},
+                    json={"data": formatted_data, "sender": formatted_sender},
                     timeout=ClientTimeout(DEFAULT_HTTP_TIMEOUT),
                 )
         except Exception:

--- a/web3/utils/exception_handling.py
+++ b/web3/utils/exception_handling.py
@@ -52,12 +52,13 @@ def handle_offchain_lookup(
             if "{data}" in url and "{sender}" in url:
                 response = session.get(formatted_url, timeout=DEFAULT_HTTP_TIMEOUT)
             else:
+                payload = {
+                    "data": formatted_data,
+                    "sender": formatted_sender,
+                }
                 response = session.post(
                     formatted_url,
-                    data={
-                        "data": formatted_data,
-                        "sender": formatted_sender,
-                    },
+                    json=payload,
                     timeout=DEFAULT_HTTP_TIMEOUT,
                 )
         except Exception:

--- a/web3/utils/exception_handling.py
+++ b/web3/utils/exception_handling.py
@@ -52,13 +52,9 @@ def handle_offchain_lookup(
             if "{data}" in url and "{sender}" in url:
                 response = session.get(formatted_url, timeout=DEFAULT_HTTP_TIMEOUT)
             else:
-                payload = {
-                    "data": formatted_data,
-                    "sender": formatted_sender,
-                }
                 response = session.post(
                     formatted_url,
-                    json=payload,
+                    json={"data": formatted_data, "sender": formatted_sender},
                     timeout=DEFAULT_HTTP_TIMEOUT,
                 )
         except Exception:


### PR DESCRIPTION
### What was wrong?

ccip-read post request was failing due to, python `requests` package sends data as `application/x-www-form-urlencoded` when payload sent via `data=` flag.

### How was it fixed?

This PR instead sent the request payload as `application/json` content type.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

:dog:
