### PR TITLE
Silence some warnings related to copying itertools objects

### DIFF
--- a/web3/_utils/module_testing/utils.py
+++ b/web3/_utils/module_testing/utils.py
@@ -1,7 +1,6 @@
 from asyncio import (
     iscoroutinefunction,
 )
-import copy
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -132,7 +131,7 @@ class RequestMocker:
             return self._make_request(method, params)
 
         request_id = (
-            next(copy.deepcopy(self.w3.provider.request_counter))
+            next(self.w3.provider.request_counter)
             if hasattr(self.w3.provider, "request_counter")
             else 1
         )
@@ -201,7 +200,7 @@ class RequestMocker:
             return await self._make_request(method, params)
 
         request_id = (
-            next(copy.deepcopy(self.w3.provider.request_counter))
+            next(self.w3.provider.request_counter)
             if hasattr(self.w3.provider, "request_counter")
             else 1
         )


### PR DESCRIPTION
### What was wrong?

Related to Issue #3511

### How was it fixed?

Don't deepcopy the `itertools.count()` counter object for the request mocker. This should get rid of most warnings related to this in the test suite. It'll be a bit more difficult to tackle the `PersistentConnectionProvider` case (in its request information cache) of copying the request counter. We may have to switch to a different object for the counter itself in order to avoid copying an itertools object.

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
