### PR TITLE
Adds typing hints documentation

### DIFF
--- a/docs/web3.types.rst
+++ b/docs/web3.types.rst
@@ -1,0 +1,81 @@
+TYPES
+=====
+
+.. py:module:: web3.types
+
+The ``web3.types`` exposes the available modules that enables you to define the data types for the various web3 methods
+
+The following types are available on the ``web3.types``:
+
+.. py:class:: TFunc
+.. py:class:: TParams 
+.. py:class:: TReturn
+.. py:class:: TValue
+.. py:class:: BlockParams
+.. py:class:: BlockIdentifier
+.. py:class:: LatestBlockParam
+.. py:class:: ABIElementIdentifier
+.. py:class:: _Hash32
+.. py:class:: EnodeURI
+.. py:class:: ENS
+.. py:class:: Nonce
+.. py:class:: RPCEndpoint
+.. py:class:: Timestamp
+.. py:class:: Wei
+.. py:class:: Gwei
+.. py:class:: Formatters
+.. py:class:: AccessListEntry
+.. py:class:: AccessList
+.. py:class:: EventData
+.. py:class:: RPCError
+.. py:class:: TxData
+.. py:class:: TxParams
+.. py:class:: WithdrawalData
+.. py:class:: BlockData
+.. py:class:: LogReceipt
+.. py:class:: SubscriptionResponse
+.. py:class:: BlockTypeSubscriptionResponse
+.. py:class:: TransactionTypeSubscriptionResponse
+.. py:class:: LogsSubscriptionResponse
+.. py:class:: SyncProgress
+.. py:class:: SyncingSubscriptionResponse
+.. py:class:: GethSyncingStatus
+.. py:class:: GethSyncingSubscriptionResult
+.. py:class:: GethSyncingSubscriptionResponse
+.. py:class:: EthSubscriptionParams
+.. py:class:: RPCId
+.. py:class:: RPCResponse
+.. py:class:: FormattedEthSubscriptionResponse
+.. py:class:: CreateAccessListResponse
+.. py:class:: MakeRequestFn
+.. py:class:: MakeBatchRequestFn
+.. py:class:: AsyncMakeRequestFn
+.. py:class:: AsyncMakeBatchRequestFn
+.. py:class:: FormattersDict
+.. py:class:: FilterParams
+.. py:class:: FeeHistory
+.. py:class:: StateOverrideParams
+.. py:class:: StateOverride
+.. py:class:: GasPriceStrategy
+.. py:class:: TxReceipt
+.. py:class:: BlockReceipts
+.. py:class:: SignedTx
+.. py:class:: StorageProof
+.. py:class:: MerkleProof
+.. py:class:: Protocol
+.. py:class:: NodeInfo
+.. py:class:: Peer
+.. py:class:: SyncStatus
+.. py:class:: Uncle
+.. py:class:: PendingTx
+.. py:class:: TxPoolContent
+.. py:class:: TxPoolInspect
+.. py:class:: TxPoolStatus
+.. py:class:: GethWallet
+.. py:class:: TContractFn
+.. py:class:: BlockTrace
+.. py:class:: FilterTrace
+.. py:class:: TraceMode
+.. py:class:: TraceFilterParams
+.. py:class:: SubscriptionType
+.. py:class:: LogsSubscriptionArg


### PR DESCRIPTION
### What was wrong?

Related to Issue #1628
Closes #1628

### How was it fixed?

Created a new web3.types.rst file in the docs to list all the possible type hints available in the types file.

### Todo:

- [ ] Clean up commit history
- [X] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fcache.lovethispic.com%2Fuploaded_images%2F360223-Baby-Duck.jpeg&f=1&nofb=1&ipt=52743abc11a2723ac6a2a292875e7e918b455f83e35b2d41d9b28d1218e33a6e&ipo=images)
