### PR TITLE
docs: batch_requests missing link

### DIFF
--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -101,8 +101,7 @@ and after the request was made.
 Now, middleware logic can be separated into ``request_processor`` and ``response_processor``
 functions that enable pre-request and post-response logic, respectively. This change offers
 a simpler, clearer interface for defining middleware, gives more flexibility for
-asynchronous operations and also paves the way for supporting batch requests - included in
-the roadmap for web3.py.
+asynchronous operations and also paved the way for supporting :ref:`batch_requests`.
 
 Major changes for migration are highlighted in this section. Consult the
 :ref:`middleware_internals` section of the documentation for specifics and examples on


### PR DESCRIPTION
### What was wrong?

nit: v7 migration doc referenced batch requests in the roadmap, so replaced with a link to the already available api.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://c02.purpledshub.com/uploads/sites/62/2023/08/raccoon-55669bb.jpg?w=1029&webp=1)
