### PR TITLE
add check bytes length in get_create2_address

### DIFF
--- a/newsfragments/3525.misc.rst
+++ b/newsfragments/3525.misc.rst
@@ -1,0 +1,1 @@
+Validate the salt length as 32 bytes for ``web3.utils.address.get_create2_address``.

--- a/tests/core/utilities/test_address.py
+++ b/tests/core/utilities/test_address.py
@@ -1,5 +1,8 @@
 import pytest
 
+from web3.exceptions import (
+    Web3ValidationError,
+)
 from web3.utils.address import (
     get_create2_address,
     get_create_address,
@@ -69,3 +72,16 @@ def test_address_get_create_address(sender, nonce, expected):
 def test_address_get_create2_address(sender, salt, init_code, expected):
     actual = get_create2_address(sender, salt, init_code)
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "salt",
+    ("0x", "0x00", "0x0000", f"0x{'00' * 31}", f"0x{'00' * 33}"),
+)
+def test_salt_length_validation(salt):
+    with pytest.raises(Web3ValidationError):
+        get_create2_address(
+            f"0x{'00' * 20}",
+            salt,
+            "0x00",
+        )

--- a/web3/utils/address.py
+++ b/web3/utils/address.py
@@ -30,6 +30,9 @@ def get_create2_address(
     Determine the resulting `CREATE2` opcode contract address for a sender, salt and
     bytecode.
     """
+    if len(to_bytes(hexstr=salt)) != 32:
+        raise TypeError(f"`salt` must be 32 bytes, {len(to_bytes(hexstr=salt))} != 32")
+
     contract_address = keccak(
         b"\xff"
         + to_bytes(hexstr=sender)

--- a/web3/utils/address.py
+++ b/web3/utils/address.py
@@ -9,6 +9,9 @@ from eth_utils import (
 )
 import rlp
 
+from web3.exceptions import (
+    Web3ValidationError,
+)
 from web3.types import (
     HexStr,
     Nonce,
@@ -31,7 +34,9 @@ def get_create2_address(
     bytecode.
     """
     if len(to_bytes(hexstr=salt)) != 32:
-        raise TypeError(f"`salt` must be 32 bytes, {len(to_bytes(hexstr=salt))} != 32")
+        raise Web3ValidationError(
+            f"`salt` must be 32 bytes, {len(to_bytes(hexstr=salt))} != 32"
+        )
 
     contract_address = keccak(
         b"\xff"


### PR DESCRIPTION
### What was wrong?

I did not correctly determine the address through the create 2 opcode, I thought I had a problem with the smart contract, but it turns out that the length of the salt should be 32 bytes, this was not checked in web3 py

### How was it fixed?

added a check

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)