### PR TITLE
feature(eth): add eth_blobBaseFee

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -200,6 +200,19 @@ The following methods are available on the ``web3.eth`` namespace.
         >>> web3.eth.get_storage_at('0x6C8f2A135f6ed072DE4503Bd7C4999a1a17F824B', 0)
         '0x00000000000000000000000000000000000000000000000000120a0b063499d4'
 
+.. py:method:: Eth.blob_base_fee
+
+    Fetches the expected base fee for blobs in the next block.
+
+    * Delegates to ``eth_blobBaseFee`` RPC Method
+
+    Returns the expected base fee in Wei.
+
+    .. code-block:: python
+
+        >>> web3.eth.blob_base_fee()
+        537070730
+
 
 .. py:method:: Eth.get_proof(account, positions, block_identifier=eth.default_block)
 

--- a/newsfragments/3527.feature.rst
+++ b/newsfragments/3527.feature.rst
@@ -1,0 +1,2 @@
+- Support for ``w3.eth.blob_base_fee``
+- Async support for ``w3.eth.blob_base_fee``

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -836,6 +836,7 @@ def subscription_formatter(value: Any) -> Union[HexBytes, HexStr, Dict[str, Any]
 PYTHONIC_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
     # Eth
     RPC.eth_accounts: apply_list_to_array_formatter(to_checksum_address),
+    RPC.eth_blobBaseFee: to_integer_if_hex,
     RPC.eth_blockNumber: to_integer_if_hex,
     RPC.eth_chainId: to_integer_if_hex,
     RPC.eth_call: HexBytes,

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -2613,6 +2613,11 @@ class EthModuleTest:
         assert len(accounts) != 0
         assert all(is_checksum_address(account) for account in accounts)
 
+    def test_eth_blob_base_fee(self, w3: "Web3") -> None:
+        blob_base_fee = w3.eth.blob_base_fee
+        assert is_integer(blob_base_fee)
+        assert blob_base_fee >= 0
+
     def test_eth_block_number(self, w3: "Web3") -> None:
         block_number = w3.eth.block_number
         assert is_integer(block_number)

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -1842,6 +1842,12 @@ class AsyncEthModuleTest:
         assert all(is_checksum_address(account) for account in accounts)
 
     @pytest.mark.asyncio
+    async def test_async_eth_blob_base_fee(self, async_w3: "AsyncWeb3") -> None:
+        blob_base_fee = await async_w3.eth.blob_base_fee
+        assert is_integer(blob_base_fee)
+        assert blob_base_fee >= 0
+
+    @pytest.mark.asyncio
     async def test_async_eth_get_logs_without_logs(
         self, async_w3: "AsyncWeb3", async_block_with_txn_with_log: BlockData
     ) -> None:

--- a/web3/_utils/rpc_abi.py
+++ b/web3/_utils/rpc_abi.py
@@ -48,6 +48,7 @@ class RPC:
 
     # eth
     eth_accounts = RPCEndpoint("eth_accounts")
+    eth_blobBaseFee = RPCEndpoint("eth_blobBaseFee")
     eth_blockNumber = RPCEndpoint("eth_blockNumber")
     eth_call = RPCEndpoint("eth_call")
     eth_createAccessList = RPCEndpoint("eth_createAccessList")

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -127,6 +127,17 @@ class AsyncEth(BaseEth):
     async def accounts(self) -> Tuple[ChecksumAddress]:
         return await self._accounts()
 
+    # eth_blobBaseFee
+
+    _eth_blobBaseFee: Method[Callable[[], Awaitable[Wei]]] = Method(
+        RPC.eth_blobBaseFee,
+        is_property=True,
+    )
+
+    @property
+    async def blob_base_fee(self) -> Wei:
+        return await self._eth_blobBaseFee()
+
     # eth_blockNumber
 
     get_block_number: Method[Callable[[], Awaitable[BlockNumber]]] = Method(

--- a/web3/eth/eth.py
+++ b/web3/eth/eth.py
@@ -119,6 +119,17 @@ class Eth(BaseEth):
     def accounts(self) -> Tuple[ChecksumAddress]:
         return self._accounts()
 
+    # eth_blobBaseFee
+
+    _eth_blobBaseFee: Method[Callable[[], Wei]] = Method(
+        RPC.eth_blobBaseFee,
+        is_property=True,
+    )
+
+    @property
+    def blob_base_fee(self) -> Wei:
+        return self._eth_blobBaseFee()
+
     # eth_blockNumber
 
     get_block_number: Method[Callable[[], BlockNumber]] = Method(

--- a/web3/providers/eth_tester/defaults.py
+++ b/web3/providers/eth_tester/defaults.py
@@ -246,6 +246,7 @@ API_ENDPOINTS = {
         "chainId": static_return(131277322940537),  # from fixture generation file
         "feeHistory": call_eth_tester("get_fee_history"),
         "maxPriorityFeePerGas": static_return(10**9),
+        "blobBaseFee": static_return(10**9),
         "gasPrice": static_return(10**9),  # must be >= base fee post-London
         "accounts": call_eth_tester("get_accounts"),
         "blockNumber": compose(


### PR DESCRIPTION
### What was wrong?
Related to Issue #3527
Closes #3527

### How was it fixed?
- Support added for `eth_blobBaseFee`
- Async support added for `eth_blobBaseFee`
---
While running tests, the `TestEthereumTesterEthModule` raise that the RPC method eth_blobBaseFee is unknown. It seems like updating eth-tester might resolve the issue, but I am not entirely certain.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="513" alt="image" src="https://github.com/user-attachments/assets/dff330f5-44d7-429e-b1c1-9e89182b6588">
