### PR TITLE
pin websockets <14 due to breaking changes

### DIFF
--- a/newsfragments/3529.internal.rst
+++ b/newsfragments/3529.internal.rst
@@ -1,0 +1,1 @@
+Pin ``websockets<14`` due to breaking changes

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         "requests>=2.23.0",
         "typing-extensions>=4.0.1",
         "types-requests>=2.0.0",
-        "websockets>=10.0.0",
+        "websockets>=10.0.0,<14.0.0",
         "pyunormalize>=15.0.0",
     ],
     python_requires=">=3.8, <4",


### PR DESCRIPTION
### What was wrong?

`websockets v14` has breaking changes - https://websockets.readthedocs.io/en/stable/project/changelog.html#backwards-incompatible-changes

### How was it fixed?

Pin to `<14` for now. They also dropped `py38` with the same release, so change to `>=14` once we do the same.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/0a2b7560-028b-4a0d-8107-5a6a13d69909)
