### PR TITLE
pin websockets<14 due to breaking changes v6

### DIFF
--- a/newsfragments/3531.internal.rst
+++ b/newsfragments/3531.internal.rst
@@ -1,0 +1,1 @@
+Pin to ``websockets<14`` due to breaking changes

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
         "pywin32>=223;platform_system=='Windows'",
         "requests>=2.16.0",
         "typing-extensions>=4.0.1",
-        "websockets>=10.0.0",
+        "websockets>=10.0.0,<14.0.0",
         "pyunormalize>=15.0.0",
     ],
     python_requires=">=3.7.2",


### PR DESCRIPTION
### What was wrong?

Breaking changes in `websockets v14`

This is v6 version of #3529 

### How was it fixed?

pin `websockets<14`

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/a0636542-5bb0-4d6e-8394-95fbbd772d3b)
