### PR TITLE
bugfix: include new line delimiter in messages sent over IPC

### DIFF
--- a/newsfragments/3537.bugfix.rst
+++ b/newsfragments/3537.bugfix.rst
@@ -1,0 +1,1 @@
+Include an end-of-line delimiter when writing to the socket with ``AsyncIPCProvider``.

--- a/newsfragments/3537.bugfix.rst
+++ b/newsfragments/3537.bugfix.rst
@@ -1,1 +1,1 @@
-Include an end-of-line delimiter when writing to the socket with ``AsyncIPCProvider``.
+Include an end-of-line delimiter when sending messages via IPC with the ``IPCProvider`` and ``AsyncIPCProvider``.

--- a/tests/core/providers/test_ipc_provider.py
+++ b/tests/core/providers/test_ipc_provider.py
@@ -9,6 +9,7 @@ from threading import (
 )
 import time
 from unittest.mock import (
+    Mock,
     patch,
 )
 
@@ -185,3 +186,14 @@ def test_web3_auto_gethdev(request_mocker):
 
     assert "extraData" not in block
     assert block.proofOfAuthorityData == b"\xff" * 33
+
+
+def test_ipc_provider_write_messages_end_with_new_line_delimiter(jsonrpc_ipc_pipe_path):
+    provider = IPCProvider(pathlib.Path(jsonrpc_ipc_pipe_path), timeout=3)
+    provider._socket.sock = Mock()
+    provider._socket.sock.recv.return_value = b'{"id":1, "result": {}}\n'
+
+    provider.make_request("method", [])
+
+    request_data = b'{"jsonrpc": "2.0", "method": "method", "params": [], "id": 0}'
+    provider._socket.sock.sendall.assert_called_with(request_data + b"\n")

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -164,7 +164,7 @@ class IPCProvider(JSONBaseProvider):
     def _make_request(self, request: bytes) -> RPCResponse:
         with self._lock, self._socket as sock:
             try:
-                sock.sendall(request)
+                sock.sendall(request + b"\n")
             except BrokenPipeError:
                 # one extra attempt, then give up
                 sock = self._socket.reset()

--- a/web3/providers/persistent/async_ipc.py
+++ b/web3/providers/persistent/async_ipc.py
@@ -116,7 +116,7 @@ class AsyncIPCProvider(PersistentConnectionProvider):
 
     async def _socket_send(self, request_data: bytes) -> None:
         try:
-            self._writer.write(request_data)
+            self._writer.write(request_data + b"\n")
             await self._writer.drain()
         except OSError as e:
             # Broken pipe


### PR DESCRIPTION
### What was wrong?

- ``IPCProvider`` and ``AsyncIPCProvider`` should use a delimiter to separate messages when writing to the socket.

### How was it fixed?

- Add `b"\n"` at the end of the encoded message when sending messages via IPC. Tests passed before because Geth accounts for this. However, when testing against Nethermind, all calls will hang without these changes.
- Add tests to make sure we don't accidentally remove this at some point.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

```
        ,--._______,-.
       ,','  ,    .  ,_`-.
      / /  ,' , _` ``. |  )       `-..
     (,';'""`/ '"`-._ ` \/ ______    \\
       : ,o.-`- ,o.  )\` -'      `---.))
       : , d8b ^-.   '|   `.      `    `.
       |/ __:_     `. |  ,  `       `    \
       | ( ,-.`-.    ;'  ;   `       :    ;
       | |  ,   `.      /     ;      :    \
       ;-'`:::._,`.__),'             :     ;
      / ,  `-   `--                  ;     |
     /  \                   `       ,      |
    (    `     :              :    ,\      |
     \   `.    :     :        :  ,'  \    :
      \    `|-- `     \ ,'    ,-'     :-.-';
      :     |`--.______;     |        :    :
       :    /           |    |         |   \
       |    ;           ;    ;        /     ;
     _/--' |           :`-- /         \_:_:_|
   ,',','  |           |___ \           

```
