### PR TITLE
Title: Correct "OSX" to "macOS" in README-osx.md

### DIFF
--- a/docs/README-osx.md
+++ b/docs/README-osx.md
@@ -20,7 +20,7 @@ brew install openssl libffi autoconf automake libtool
 brew install leveldb
 ```
 
-> If you are on `>=OSX 10.15 Catalina` you may encounter the following error with the default `ZSH` shell. This can be fixed by wrapping the `[dev]` part in quotes.
+> If you are on `>= macOS 10.15 Catalina` you may encounter the following error with the default `ZSH` shell. This can be fixed by wrapping the `[dev]` part in quotes.
 
 ```sh
 pip install -e .[dev]


### PR DESCRIPTION
### What was wrong?
The README for macOS had a typo, incorrectly referring to "OSX" instead of "macOS."

### How was it fixed?
The typo was corrected by updating "OSX" to "macOS" in the relevant section of `README-osx.md`.

### Todo:
- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

### Why is this important?
Correcting "OSX" to "macOS" ensures accuracy and consistency with the official naming conventions used by Apple. This prevents confusion and aligns with best practices in documentation.

#### Cute Animal Picture
(https://i.pinimg.com/736x/68/79/25/687925314776cf55ffd56d36d6d36a27.jpg)