### PR TITLE
Fix incorrect use of __file__ variable in configuration script

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@
 
 import os
 
-DIR = os.path.dirname("__file__")
+DIR = os.path.dirname(__file__)
 with open(os.path.join(DIR, "../setup.py"), "r") as f:
     for line in f:
         if "version=" in line:


### PR DESCRIPTION
**Description:**

This update corrects an issue in the documentation build configuration file where the `__file__` variable was mistakenly enclosed in quotes:

```python
DIR = os.path.dirname("__file__")
```

It should be:

```python
DIR = os.path.dirname(__file__)
```

The `__file__` variable is a special built-in Python variable that points to the current script’s file path. Enclosing it in quotes turned it into a string literal rather than a reference to the actual file path, which could have led to incorrect directory resolution or errors during execution.

#### Cute Animal Picture

![Guest Who?](https://www.treehugger.com/thmb/f6bheAPa7Dj-aWhyfBpZAyKQnXo=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/GettyImages-163520909-a51a026d2f794fc9b7fc1283806a7248.jpg)

