### PR TITLE
remove verbose RPC error logging

### DIFF
--- a/newsfragments/3546.misc.rst
+++ b/newsfragments/3546.misc.rst
@@ -1,0 +1,1 @@
+Remove error logging the user message on RPC errors. The user message is available on the exception and the response itself is logged at the debug level.

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -255,9 +255,8 @@ def _validate_response(
             web3_rpc_error = Web3RPCError(repr(error), rpc_response=response)
 
         response = apply_error_formatters(error_formatters, response)
-
-        logger.error(web3_rpc_error.user_message)
         logger.debug(f"RPC error response: {response}")
+
         raise web3_rpc_error
 
     elif "result" not in response and not is_subscription_response:


### PR DESCRIPTION
Currently RPC error responses are logged and thrown. The application should decide whether the thrown error should be logged or not. All logged information are part of the thrown exception and often RPC errors are handled gracefully by the application logic. The current situation is that even handled errors are spamming the console and the only way to get rid of them is to completely disable the web3.manager.RequestManager logger.