### PR TITLE
feat: implement `cchecksum` for ~2x faster checksumming

### DIFF
--- a/ens/async_ens.py
+++ b/ens/async_ens.py
@@ -12,6 +12,9 @@ from typing import (
     cast,
 )
 
+from cchecksum import (
+    to_checksum_address,
+)
 from eth_typing import (
     Address,
     ChecksumAddress,
@@ -22,7 +25,6 @@ from eth_utils import (
     is_address,
     is_binary_address,
     is_checksum_address,
-    to_checksum_address,
 )
 from eth_utils.toolz import (
     merge,

--- a/ens/ens.py
+++ b/ens/ens.py
@@ -11,6 +11,9 @@ from typing import (
     cast,
 )
 
+from cchecksum import (
+    to_checksum_address,
+)
 from eth_typing import (
     Address,
     ChecksumAddress,
@@ -21,7 +24,6 @@ from eth_utils import (
     is_address,
     is_binary_address,
     is_checksum_address,
-    to_checksum_address,
 )
 from eth_utils.toolz import (
     merge,

--- a/newsfragments/3550.performance.rst
+++ b/newsfragments/3550.performance.rst
@@ -1,0 +1,1 @@
+replace `eth_utils.to_checksum_address` with `cchecksum.to_checksum_address` for ~2x faster checksumming

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         "eth-hash[pycryptodome]>=0.5.1",
         "eth-typing>=5.0.0",
         "eth-utils>=5.0.0",
+        "cchecksum>=0.0.3,<1",
         "hexbytes>=1.2.0",
         "aiohttp>=3.7.4.post0",
         "pydantic>=2.4.0",

--- a/tests/core/eth-module/test_block_api.py
+++ b/tests/core/eth-module/test_block_api.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eth_utils import (
+from cchecksum import (
     to_checksum_address,
 )
 from hexbytes import (

--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -2,8 +2,10 @@ import collections
 import itertools
 import pytest
 
-from eth_utils import (
+from cchecksum import (
     to_checksum_address,
+)
+from eth_utils import (
     to_int,
 )
 from hexbytes import (

--- a/tests/ens/conftest.py
+++ b/tests/ens/conftest.py
@@ -2,11 +2,11 @@ import asyncio
 import json
 import pytest
 
+from cchecksum import (
+    to_checksum_address,
+)
 from eth_tester import (
     EthereumTester,
-)
-from eth_utils import (
-    to_checksum_address,
 )
 import pytest_asyncio
 

--- a/web3/_utils/ens.py
+++ b/web3/_utils/ens.py
@@ -10,6 +10,9 @@ from typing import (
     cast,
 )
 
+from cchecksum import (
+    to_checksum_address,
+)
 from eth_typing import (
     ChecksumAddress,
 )
@@ -17,7 +20,6 @@ from eth_utils import (
     is_0x_prefixed,
     is_hex,
     is_hex_address,
-    to_checksum_address,
 )
 
 from ens import (

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -13,6 +13,9 @@ from typing import (
     cast,
 )
 
+from cchecksum import (
+    to_checksum_address,
+)
 from eth_typing import (
     HexStr,
 )
@@ -32,7 +35,6 @@ from eth_utils.curried import (
     is_integer,
     is_null,
     is_string,
-    to_checksum_address,
     to_list,
     to_tuple,
 )

--- a/web3/_utils/normalizers.py
+++ b/web3/_utils/normalizers.py
@@ -11,6 +11,9 @@ from typing import (
     cast,
 )
 
+from cchecksum import (
+    to_checksum_address,
+)
 from eth_abi.exceptions import (
     ParseError,
 )
@@ -26,7 +29,6 @@ from eth_typing import (
 )
 from eth_utils import (
     to_bytes,
-    to_checksum_address,
     to_hex,
     to_text,
 )

--- a/web3/main.py
+++ b/web3/main.py
@@ -3,6 +3,9 @@ from types import (
     TracebackType,
 )
 
+from cchecksum import (
+    to_checksum_address,
+)
 from ens import (
     AsyncENS,
     ENS,
@@ -19,7 +22,6 @@ from eth_utils import (
     keccak as eth_utils_keccak,
     remove_0x_prefix,
     to_bytes,
-    to_checksum_address,
     to_int,
     to_text,
     to_wei,

--- a/web3/middleware/signing.py
+++ b/web3/middleware/signing.py
@@ -13,6 +13,9 @@ from typing import (
     cast,
 )
 
+from cchecksum import (
+    to_checksum_address,
+)
 from eth_account import (
     Account,
 )
@@ -30,7 +33,6 @@ from eth_typing import (
     HexStr,
 )
 from eth_utils import (
-    to_checksum_address,
     to_dict,
 )
 from eth_utils.curried import (

--- a/web3/utils/address.py
+++ b/web3/utils/address.py
@@ -1,3 +1,6 @@
+from cchecksum import (
+    to_checksum_address,
+)
 from eth_typing import (
     ChecksumAddress,
     HexAddress,
@@ -5,7 +8,6 @@ from eth_typing import (
 from eth_utils import (
     keccak,
     to_bytes,
-    to_checksum_address,
 )
 import rlp
 


### PR DESCRIPTION
### What was wrong?
I saw a low-hanging-fruit optimization opportunity in eth_utils.to_checksum_address


Related to Issue #
Closes #

### How was it fixed?
I re-implemented eth_utils.to_checksum_address in c [here](https://github.com/BobTheBuidler/cchecksum), published cchecksum to pypi, dropped-in the drop-in replacement into web3.py

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<https://images7.alphacoders.com/446/446978.jpg>)
