### PR TITLE
Subscription management implementation

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -445,13 +445,12 @@ the user is done with it.
 .. code-block:: python
 
     >>> async def new_heads_handler(
-    ...     async_w3: AsyncWeb3,
-    ...     sx: EthSubscription,
-    ...     response: BlockData,
+    ...     context: NewHeadsSubscriptionContext,
     ... ) -> None:
-    ...     print(f"New block header: {response}\n")
-    ...     if response["number"] > 1234567:
-    ...         await sx.unsubscribe()
+    ...     result = context.result
+    ...     print(f"New block header: {result}\n")
+    ...     if result["number"] > 1234567:
+    ...         await context.subscription.unsubscribe()
 
     >>> async def ws_subscription_example():
     ...     async with AsyncWeb3(WebSocketProvider(f"ws://127.0.0.1:8546")) as w3:
@@ -483,30 +482,27 @@ connections.
     >>> from web3.utils.subscriptions import (
     ...     EthSubscription,
     ...     NewHeadsSubscription,
+    ...     NewHeadsSubscriptionContext,
     ...     PendingTxSubscription,
+    ...     PendingTxSubscriptionContext,
     ...     LogsSubscription,
+    ...     LogsSubscriptionContext,
     ... )
 
     >>> async def new_heads_handler(
-    ...     async_w3: AsyncWeb3,
-    ...     sx: EthSubscription,
-    ...     response: BlockData,
+    ...     context: NewHeadsSubscriptionContext,
     ... ) -> None:
-    ...     print(f"New block header: {response}\n")
-    ...     if response["number"] > 1234567:
-    ...         await sx.unsubscribe()
+    ...     print(f"New block header: {context.result}\n")
+    ...     if context.result["number"] > 1234567:
+    ...         await context.subscription.unsubscribe()
 
     >>> async def pending_txs_handler(
-    ...     async_w3: AsyncWeb3,
-    ...     sx: EthSubscription,
-    ...     response: TxData,
+    ...     context: PendingTxSubscriptionContext,
     ... ) -> None:
     ...     ...
 
     >>> async def log_handler(
-    ...     async_w3: AsyncWeb3,
-    ...     sx: EthSubscription,
-    ...     response: LogData,
+    ...     context: LogsSubscriptionContext,
     ... ) -> None:
     ...     ...
 

--- a/newsfragments/3554.feature.rst
+++ b/newsfragments/3554.feature.rst
@@ -1,0 +1,1 @@
+Add a subscription manager to persistent connection providers, with support for handler methods for ``eth_subscribe`` subscriptions.

--- a/tests/core/providers/test_async_ipc_provider.py
+++ b/tests/core/providers/test_async_ipc_provider.py
@@ -364,5 +364,5 @@ async def test_async_ipc_provider_write_messages_end_with_new_line_delimiter(
 
         await w3.provider.make_request("method", [])
 
-        request_data = b'{"jsonrpc": "2.0", "method": "method", "params": [], "id": 0}'
+        request_data = b'{"id": 0, "jsonrpc": "2.0", "method": "method", "params": []}'
         w3.provider._writer.write.assert_called_with(request_data + b"\n")

--- a/tests/core/providers/test_async_ipc_provider.py
+++ b/tests/core/providers/test_async_ipc_provider.py
@@ -180,9 +180,11 @@ async def test_disconnect_cleanup(
     provider._request_processor._request_response_cache.cache("0", "0x1337")
     provider._request_processor._request_information_cache.cache("0", "0x1337")
     provider._request_processor._subscription_response_queue.put_nowait({"id": "0"})
+    provider._request_processor._handler_subscription_queue.put_nowait({"id": "0"})
     assert len(provider._request_processor._request_response_cache) == 1
     assert len(provider._request_processor._request_information_cache) == 1
     assert provider._request_processor._subscription_response_queue.qsize() == 1
+    assert provider._request_processor._handler_subscription_queue.qsize() == 1
 
     await w3.provider.disconnect()
 
@@ -192,6 +194,7 @@ async def test_disconnect_cleanup(
     assert len(provider._request_processor._request_response_cache) == 0
     assert len(provider._request_processor._request_information_cache) == 0
     assert provider._request_processor._subscription_response_queue.empty()
+    assert provider._request_processor._handler_subscription_queue.empty()
 
 
 async def _raise_connection_closed(*_args, **_kwargs):

--- a/tests/core/providers/test_websocket_provider.py
+++ b/tests/core/providers/test_websocket_provider.py
@@ -270,11 +270,13 @@ async def test_listen_event_awaits_msg_processing_when_subscription_queue_is_ful
     sub_request_information = RequestInformation(
         method=RPCEndpoint("eth_subscribe"),
         params=["mock"],
-        response_formatters=(),
+        response_formatters=[[], [], []],
         subscription_id=sub_id,
     )
     async_w3.provider._request_processor._request_information_cache.cache(
-        "", sub_request_information
+        # cache key is the result of `generate_cache_key` with the sub_id as the arg
+        "0138b5d63d66121d8a6e680d23720fa7",
+        sub_request_information,
     )
 
     mocked_sub = {
@@ -305,8 +307,8 @@ async def test_listen_event_awaits_msg_processing_when_subscription_queue_is_ful
     async_w3.provider._listen_event.set.assert_not_called()
 
     async for message in async_w3.socket.process_subscriptions():
-        # assert the very next message is the mocked subscription
-        assert message == mocked_sub
+        # assert the very next message is the formatted mocked subscription
+        assert message == mocked_sub["params"]
         break
 
     # assert we set the _listen_event after we consume the message

--- a/tests/core/providers/test_websocket_provider.py
+++ b/tests/core/providers/test_websocket_provider.py
@@ -20,6 +20,7 @@ from web3 import (
 )
 from web3._utils.caching import (
     RequestInformation,
+    generate_cache_key,
 )
 from web3._utils.module_testing.module_testing_utils import (
     WebSocketMessageStreamMock,
@@ -274,8 +275,7 @@ async def test_listen_event_awaits_msg_processing_when_subscription_queue_is_ful
         subscription_id=sub_id,
     )
     async_w3.provider._request_processor._request_information_cache.cache(
-        # cache key is the result of `generate_cache_key` with the sub_id as the arg
-        "0138b5d63d66121d8a6e680d23720fa7",
+        generate_cache_key(sub_id),
         sub_request_information,
     )
 

--- a/tests/core/subscriptions/test_subscription_manager.py
+++ b/tests/core/subscriptions/test_subscription_manager.py
@@ -1,0 +1,104 @@
+import itertools
+import pytest
+from unittest.mock import (
+    AsyncMock,
+)
+
+import pytest_asyncio
+
+from web3 import (
+    AsyncWeb3,
+    PersistentConnectionProvider,
+)
+from web3.exceptions import (
+    Web3ValueError,
+)
+from web3.providers.persistent.subscription_manager import (
+    SubscriptionManager,
+)
+from web3.utils.subscriptions import (
+    LogsSubscription,
+    NewHeadsSubscription,
+    PendingTxSubscription,
+)
+
+
+class MockProvider(PersistentConnectionProvider):
+    socket_recv = AsyncMock()
+    socket_send = AsyncMock()
+
+
+@pytest_asyncio.fixture
+async def subscription_manager():
+    countr = itertools.count()
+    _w3 = AsyncWeb3(MockProvider())
+    _w3.eth._subscribe = AsyncMock()
+    _w3.eth._subscribe.side_effect = lambda *_: f"0x{str(next(countr))}"
+    _w3.eth._unsubscribe = AsyncMock()
+    _w3.eth._unsubscribe.return_value = True
+    yield SubscriptionManager(_w3)
+
+
+@pytest.mark.asyncio
+async def test_subscription_manager_raises_for_sx_with_the_same_label(
+    subscription_manager,
+):
+    sx1 = NewHeadsSubscription(label="foo")
+    await subscription_manager.subscribe(sx1)
+
+    with pytest.raises(
+        Web3ValueError,
+        match="Subscription label already exists. Subscriptions must have unique "
+        "labels.\n    label: foo",
+    ):
+        sx2 = LogsSubscription(label="foo")
+        await subscription_manager.subscribe(sx2)
+
+    # make sure the subscription was subscribed to and not added to the manager
+    assert subscription_manager.subscriptions == [sx1]
+    assert subscription_manager._subscriptions_by_label == {"foo": sx1}
+    assert subscription_manager._subscriptions_by_id == {"0x0": sx1}
+
+
+@pytest.mark.asyncio
+async def test_subscription_manager_get_by_id(subscription_manager):
+    sx = NewHeadsSubscription(label="foo")
+    await subscription_manager.subscribe(sx)
+    assert subscription_manager.get_by_id("0x0") == sx
+    assert subscription_manager.get_by_id("0x1") is None
+
+
+@pytest.mark.asyncio
+async def test_subscription_manager_get_by_label(subscription_manager):
+    sx = NewHeadsSubscription(label="foo")
+    await subscription_manager.subscribe(sx)
+    assert subscription_manager.get_by_label("foo") == sx
+    assert subscription_manager.get_by_label("bar") is None
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_one_by_one_clears_all_subscriptions(
+    subscription_manager,
+):
+    sx1 = NewHeadsSubscription(label="foo")
+    sx2 = PendingTxSubscription(label="bar")
+    await subscription_manager.subscribe(sx1)
+    await subscription_manager.subscribe(sx2)
+
+    await subscription_manager.unsubscribe(sx1)
+    assert subscription_manager.subscriptions == [sx2]
+
+    await subscription_manager.unsubscribe(sx2)
+    assert subscription_manager.subscriptions == []
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_all_clears_all_subscriptions(subscription_manager):
+    sx1 = NewHeadsSubscription(label="foo")
+    sx2 = PendingTxSubscription(label="bar")
+    await subscription_manager.subscribe([sx1, sx2])
+
+    await subscription_manager.unsubscribe_all()
+    assert subscription_manager.subscriptions == []
+    assert subscription_manager._subscriptions_by_id == {}
+    assert subscription_manager._subscriptions_by_label == {}

--- a/tests/core/subscriptions/test_subscription_manager.py
+++ b/tests/core/subscriptions/test_subscription_manager.py
@@ -40,39 +40,39 @@ async def subscription_manager():
 
 
 @pytest.mark.asyncio
-async def test_subscription_manager_raises_for_sx_with_the_same_label(
+async def test_subscription_manager_raises_for_sub_with_the_same_label(
     subscription_manager,
 ):
-    sx1 = NewHeadsSubscription(label="foo")
-    await subscription_manager.subscribe(sx1)
+    sub1 = NewHeadsSubscription(label="foo")
+    await subscription_manager.subscribe(sub1)
 
     with pytest.raises(
         Web3ValueError,
         match="Subscription label already exists. Subscriptions must have unique "
         "labels.\n    label: foo",
     ):
-        sx2 = LogsSubscription(label="foo")
-        await subscription_manager.subscribe(sx2)
+        sub2 = LogsSubscription(label="foo")
+        await subscription_manager.subscribe(sub2)
 
     # make sure the subscription was subscribed to and not added to the manager
-    assert subscription_manager.subscriptions == [sx1]
-    assert subscription_manager._subscriptions_by_label == {"foo": sx1}
-    assert subscription_manager._subscriptions_by_id == {"0x0": sx1}
+    assert subscription_manager.subscriptions == [sub1]
+    assert subscription_manager._subscriptions_by_label == {"foo": sub1}
+    assert subscription_manager._subscriptions_by_id == {"0x0": sub1}
 
 
 @pytest.mark.asyncio
 async def test_subscription_manager_get_by_id(subscription_manager):
-    sx = NewHeadsSubscription(label="foo")
-    await subscription_manager.subscribe(sx)
-    assert subscription_manager.get_by_id("0x0") == sx
+    sub = NewHeadsSubscription(label="foo")
+    await subscription_manager.subscribe(sub)
+    assert subscription_manager.get_by_id("0x0") == sub
     assert subscription_manager.get_by_id("0x1") is None
 
 
 @pytest.mark.asyncio
 async def test_subscription_manager_get_by_label(subscription_manager):
-    sx = NewHeadsSubscription(label="foo")
-    await subscription_manager.subscribe(sx)
-    assert subscription_manager.get_by_label("foo") == sx
+    sub = NewHeadsSubscription(label="foo")
+    await subscription_manager.subscribe(sub)
+    assert subscription_manager.get_by_label("foo") == sub
     assert subscription_manager.get_by_label("bar") is None
 
 
@@ -80,23 +80,23 @@ async def test_subscription_manager_get_by_label(subscription_manager):
 async def test_unsubscribe_one_by_one_clears_all_subscriptions(
     subscription_manager,
 ):
-    sx1 = NewHeadsSubscription(label="foo")
-    sx2 = PendingTxSubscription(label="bar")
-    await subscription_manager.subscribe(sx1)
-    await subscription_manager.subscribe(sx2)
+    sub1 = NewHeadsSubscription(label="foo")
+    sub2 = PendingTxSubscription(label="bar")
+    await subscription_manager.subscribe(sub1)
+    await subscription_manager.subscribe(sub2)
 
-    await subscription_manager.unsubscribe(sx1)
-    assert subscription_manager.subscriptions == [sx2]
+    await subscription_manager.unsubscribe(sub1)
+    assert subscription_manager.subscriptions == [sub2]
 
-    await subscription_manager.unsubscribe(sx2)
+    await subscription_manager.unsubscribe(sub2)
     assert subscription_manager.subscriptions == []
 
 
 @pytest.mark.asyncio
 async def test_unsubscribe_all_clears_all_subscriptions(subscription_manager):
-    sx1 = NewHeadsSubscription(label="foo")
-    sx2 = PendingTxSubscription(label="bar")
-    await subscription_manager.subscribe([sx1, sx2])
+    sub1 = NewHeadsSubscription(label="foo")
+    sub2 = PendingTxSubscription(label="bar")
+    await subscription_manager.subscribe([sub1, sub2])
 
     await subscription_manager.unsubscribe_all()
     assert subscription_manager.subscriptions == []

--- a/tests/core/subscriptions/test_subscription_manager.py
+++ b/tests/core/subscriptions/test_subscription_manager.py
@@ -56,8 +56,11 @@ async def test_subscription_manager_raises_for_sub_with_the_same_label(
 
     # make sure the subscription was subscribed to and not added to the manager
     assert subscription_manager.subscriptions == [sub1]
-    assert subscription_manager._subscriptions_by_label == {"foo": sub1}
-    assert subscription_manager._subscriptions_by_id == {"0x0": sub1}
+    sub_container = subscription_manager._subscription_container
+    assert len(sub_container) == 1
+    assert sub_container.subscriptions == [sub1]
+    assert sub_container.subscriptions_by_id == {"0x0": sub1}
+    assert sub_container.subscriptions_by_label == {"foo": sub1}
 
 
 @pytest.mark.asyncio
@@ -97,8 +100,13 @@ async def test_unsubscribe_all_clears_all_subscriptions(subscription_manager):
     sub1 = NewHeadsSubscription(label="foo")
     sub2 = PendingTxSubscription(label="bar")
     await subscription_manager.subscribe([sub1, sub2])
+    assert subscription_manager.subscriptions == [sub1, sub2]
 
     await subscription_manager.unsubscribe_all()
     assert subscription_manager.subscriptions == []
-    assert subscription_manager._subscriptions_by_id == {}
-    assert subscription_manager._subscriptions_by_label == {}
+
+    sub_container = subscription_manager._subscription_container
+    assert len(sub_container) == 0
+    assert sub_container.subscriptions == []
+    assert sub_container.subscriptions_by_id == {}
+    assert sub_container.subscriptions_by_label == {}

--- a/tests/core/subscriptions/test_subscriptions.py
+++ b/tests/core/subscriptions/test_subscriptions.py
@@ -1,7 +1,4 @@
 import pytest
-from unittest.mock import (
-    Mock,
-)
 
 from web3.utils.subscriptions import (
     LogsSubscription,
@@ -64,9 +61,8 @@ def test_logs_subscription_properties(handler):
         "0x0000000000000000000000000000000000000000000000000000000000000001",
         "0x0000000000000000000000000000000000000000000000000000000000000002",
     ]
-    event = Mock()
     logs_subscription = LogsSubscription(
-        address=address, topics=topics, handler=handler, event=event, label="logs label"
+        address=address, topics=topics, handler=handler, label="logs label"
     )
     assert logs_subscription._handler is handler
     assert logs_subscription.label == "logs label"
@@ -76,7 +72,6 @@ def test_logs_subscription_properties(handler):
     )
     assert logs_subscription.address == address
     assert logs_subscription.topics == topics
-    assert logs_subscription.event is event
 
 
 def test_syncing_subscription_properties(handler):

--- a/tests/core/subscriptions/test_subscriptions.py
+++ b/tests/core/subscriptions/test_subscriptions.py
@@ -28,6 +28,7 @@ def test_pending_tx_subscription_properties_default(handler):
     )
     assert pending_tx_subscription._handler is handler
     assert pending_tx_subscription.label == "pending tx label"
+    assert pending_tx_subscription.full_transactions is False
     assert pending_tx_subscription.subscription_params == (
         "newPendingTransactions",
         False,
@@ -40,6 +41,7 @@ def test_pending_tx_subscription_properties_full_transactions(handler):
     )
     assert pending_tx_subscription._handler is handler
     assert pending_tx_subscription.label == "pending tx label"
+    assert pending_tx_subscription.full_transactions is True
     assert pending_tx_subscription.subscription_params == (
         "newPendingTransactions",
         True,

--- a/tests/core/subscriptions/test_subscriptions.py
+++ b/tests/core/subscriptions/test_subscriptions.py
@@ -1,0 +1,86 @@
+import pytest
+from unittest.mock import (
+    Mock,
+)
+
+from web3.utils.subscriptions import (
+    LogsSubscription,
+    NewHeadsSubscription,
+    PendingTxSubscription,
+    SyncingSubscription,
+)
+
+
+@pytest.fixture
+def handler():
+    pass
+
+
+def test_new_heads_subscription_properties(handler):
+    new_heads_subscription = NewHeadsSubscription(
+        handler=handler, label="new heads label"
+    )
+    assert new_heads_subscription._handler is handler
+    assert new_heads_subscription.label == "new heads label"
+    assert new_heads_subscription.subscription_params == ("newHeads",)
+
+
+def test_pending_tx_subscription_properties_default(handler):
+    pending_tx_subscription = PendingTxSubscription(
+        handler=handler, label="pending tx label"
+    )
+    assert pending_tx_subscription._handler is handler
+    assert pending_tx_subscription.label == "pending tx label"
+    assert pending_tx_subscription.subscription_params == (
+        "newPendingTransactions",
+        False,
+    )
+
+
+def test_pending_tx_subscription_properties_full_transactions(handler):
+    pending_tx_subscription = PendingTxSubscription(
+        full_transactions=True, handler=handler, label="pending tx label"
+    )
+    assert pending_tx_subscription._handler is handler
+    assert pending_tx_subscription.label == "pending tx label"
+    assert pending_tx_subscription.subscription_params == (
+        "newPendingTransactions",
+        True,
+    )
+
+
+def test_logs_subscription_properties_default(handler):
+    logs_subscription = LogsSubscription(handler=handler, label="logs label")
+    assert logs_subscription._handler is handler
+    assert logs_subscription.label == "logs label"
+    assert logs_subscription.subscription_params == ("logs", {})
+    assert logs_subscription.address is None
+    assert logs_subscription.topics is None
+
+
+def test_logs_subscription_properties(handler):
+    address = "0x1234567890123456789012345678901234567890"
+    topics = [
+        "0x0000000000000000000000000000000000000000000000000000000000000001",
+        "0x0000000000000000000000000000000000000000000000000000000000000002",
+    ]
+    event = Mock()
+    logs_subscription = LogsSubscription(
+        address=address, topics=topics, handler=handler, event=event, label="logs label"
+    )
+    assert logs_subscription._handler is handler
+    assert logs_subscription.label == "logs label"
+    assert logs_subscription.subscription_params == (
+        "logs",
+        {"address": address, "topics": topics},
+    )
+    assert logs_subscription.address == address
+    assert logs_subscription.topics == topics
+    assert logs_subscription.event is event
+
+
+def test_syncing_subscription_properties(handler):
+    syncing_subscription = SyncingSubscription(handler=handler, label="syncing label")
+    assert syncing_subscription._handler is handler
+    assert syncing_subscription.label == "syncing label"
+    assert syncing_subscription.subscription_params == ("syncing",)

--- a/tests/integration/go_ethereum/conftest.py
+++ b/tests/integration/go_ethereum/conftest.py
@@ -94,7 +94,7 @@ def base_geth_command_arguments(geth_binary, datadir):
         datadir,
         "--dev",
         "--dev.period",
-        "1",
+        "2",
         "--password",
         os.path.join(datadir, "keystore", "pw.txt"),
     )

--- a/tests/integration/go_ethereum/test_goethereum_http.py
+++ b/tests/integration/go_ethereum/test_goethereum_http.py
@@ -1,5 +1,8 @@
 import pytest
 
+from aiohttp import (
+    ClientTimeout,
+)
 import pytest_asyncio
 
 from tests.utils import (
@@ -70,7 +73,7 @@ def geth_command_arguments(rpc_port, base_geth_command_arguments, get_geth_versi
 @pytest.fixture(scope="module")
 def w3(geth_process, endpoint_uri):
     wait_for_http(endpoint_uri)
-    return Web3(Web3.HTTPProvider(endpoint_uri))
+    return Web3(Web3.HTTPProvider(endpoint_uri, request_kwargs={"timeout": 10}))
 
 
 class TestGoEthereumWeb3ModuleTest(GoEthereumWeb3ModuleTest):
@@ -119,7 +122,9 @@ class TestGoEthereumTxPoolModuleTest(GoEthereumTxPoolModuleTest):
 @pytest_asyncio.fixture(scope="module")
 async def async_w3(geth_process, endpoint_uri):
     await wait_for_aiohttp(endpoint_uri)
-    _w3 = AsyncWeb3(AsyncHTTPProvider(endpoint_uri))
+    _w3 = AsyncWeb3(
+        AsyncHTTPProvider(endpoint_uri, request_kwargs={"timeout": ClientTimeout(10)})
+    )
     return _w3
 
 

--- a/tests/integration/go_ethereum/test_goethereum_ipc.py
+++ b/tests/integration/go_ethereum/test_goethereum_ipc.py
@@ -56,7 +56,7 @@ def geth_ipc_path(datadir):
 @pytest.fixture(scope="module")
 def w3(geth_process, geth_ipc_path):
     wait_for_socket(geth_ipc_path)
-    return Web3(Web3.IPCProvider(geth_ipc_path, timeout=30))
+    return Web3(Web3.IPCProvider(geth_ipc_path, timeout=10))
 
 
 class TestGoEthereumWeb3ModuleTest(GoEthereumWeb3ModuleTest):
@@ -101,7 +101,7 @@ class TestGoEthereumAdminModuleTest(GoEthereumAdminModuleTest):
 @pytest_asyncio.fixture(scope="module")
 async def async_w3(geth_process, geth_ipc_path):
     await wait_for_async_socket(geth_ipc_path)
-    async with AsyncWeb3(AsyncIPCProvider(geth_ipc_path)) as _aw3:
+    async with AsyncWeb3(AsyncIPCProvider(geth_ipc_path, request_timeout=10)) as _aw3:
         yield _aw3
 
 

--- a/tests/integration/go_ethereum/test_goethereum_ws/test_async_await_w3.py
+++ b/tests/integration/go_ethereum/test_goethereum_ws/test_async_await_w3.py
@@ -27,9 +27,8 @@ from ..utils import (
 @pytest_asyncio.fixture(scope="module")
 async def async_w3(geth_process, endpoint_uri):
     await wait_for_aiohttp(endpoint_uri)
-
     # await the persistent connection itself
-    return await AsyncWeb3(WebSocketProvider(endpoint_uri))
+    return await AsyncWeb3(WebSocketProvider(endpoint_uri, request_timeout=10))
 
 
 class TestGoEthereumAsyncWeb3ModuleTest(GoEthereumAsyncWeb3ModuleTest):

--- a/tests/integration/go_ethereum/test_goethereum_ws/test_async_ctx_manager_w3.py
+++ b/tests/integration/go_ethereum/test_goethereum_ws/test_async_ctx_manager_w3.py
@@ -27,9 +27,8 @@ from ..utils import (
 @pytest_asyncio.fixture(scope="module")
 async def async_w3(geth_process, endpoint_uri):
     await wait_for_aiohttp(endpoint_uri)
-
     # async context manager pattern
-    async with AsyncWeb3(WebSocketProvider(endpoint_uri)) as w3:
+    async with AsyncWeb3(WebSocketProvider(endpoint_uri, request_timeout=10)) as w3:
         yield w3
 
 

--- a/tests/integration/go_ethereum/test_goethereum_ws/test_async_iterator_w3.py
+++ b/tests/integration/go_ethereum/test_goethereum_ws/test_async_iterator_w3.py
@@ -27,9 +27,8 @@ from ..utils import (
 @pytest_asyncio.fixture(scope="module")
 async def async_w3(geth_process, endpoint_uri):
     await wait_for_aiohttp(endpoint_uri)
-
     # async iterator pattern
-    async for w3 in AsyncWeb3(WebSocketProvider(endpoint_uri)):
+    async for w3 in AsyncWeb3(WebSocketProvider(endpoint_uri, request_timeout=10)):
         return w3
 
 

--- a/web3/_utils/caching/request_caching_validation.py
+++ b/web3/_utils/caching/request_caching_validation.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from web3.providers import (  # noqa: F401
         AsyncBaseProvider,
         BaseProvider,
+        PersistentConnectionProvider,
     )
 
 UNCACHEABLE_BLOCK_IDS = {"finalized", "safe", "latest", "pending"}

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -1991,9 +1991,8 @@ class AsyncEthModuleTest:
         # Test with None overflowing
         filter_params: FilterParams = {
             "fromBlock": BlockNumber(0),
-            "topics": [None, None, None],
+            "topics": [None, None, None, None],
         }
-
         result = await async_w3.eth.get_logs(filter_params)
         assert len(result) == 0
 

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -58,7 +58,6 @@ from web3._utils.module_testing.module_testing_utils import (
     assert_contains_log,
     async_mock_offchain_lookup_request_response,
     flaky_geth_dev_mining,
-    flaky_with_xfail_on_exception,
     mock_offchain_lookup_request_response,
 )
 from web3._utils.module_testing.utils import (
@@ -77,7 +76,6 @@ from web3.exceptions import (
     MultipleFailedRequests,
     NameNotFound,
     OffchainLookup,
-    RequestTimedOut,
     TimeExhausted,
     TooManyRequests,
     TransactionNotFound,
@@ -2390,10 +2388,6 @@ class AsyncEthModuleTest:
         with pytest.raises(Web3ValueError):
             await async_w3.eth.replace_transaction(txn_hash, txn_params)
 
-    @flaky_with_xfail_on_exception(
-        reason="Very flaky on CI runs, hard to reproduce locally.",
-        exception=RequestTimedOut,
-    )
     @pytest.mark.asyncio
     async def test_async_eth_replace_transaction_gas_price_defaulting_minimum(
         self, async_w3: "AsyncWeb3", async_keyfile_account_address: ChecksumAddress
@@ -2417,10 +2411,6 @@ class AsyncEthModuleTest:
             gas_price * 1.125
         )  # minimum gas price
 
-    @flaky_with_xfail_on_exception(
-        reason="Very flaky on CI runs, hard to reproduce locally.",
-        exception=RequestTimedOut,
-    )
     @pytest.mark.asyncio
     async def test_async_eth_replace_transaction_gas_price_defaulting_strategy_higher(
         self, async_w3: "AsyncWeb3", async_keyfile_account_address: ChecksumAddress
@@ -2436,7 +2426,7 @@ class AsyncEthModuleTest:
 
         two_gwei_in_wei = async_w3.to_wei(2, "gwei")
 
-        def higher_gas_price_strategy(async_w3: "AsyncWeb3", txn: TxParams) -> Wei:
+        def higher_gas_price_strategy(_async_w3: "AsyncWeb3", _txn: TxParams) -> Wei:
             return two_gwei_in_wei
 
         async_w3.eth.set_gas_price_strategy(higher_gas_price_strategy)
@@ -2449,16 +2439,11 @@ class AsyncEthModuleTest:
         )  # Strategy provides higher gas price
         async_w3.eth.set_gas_price_strategy(None)  # reset strategy
 
-    @flaky_with_xfail_on_exception(
-        reason="Very flaky on CI runs, hard to reproduce locally.",
-        exception=RequestTimedOut,
-    )
     @pytest.mark.asyncio
     async def test_async_eth_replace_transaction_gas_price_defaulting_strategy_lower(
         self, async_w3: "AsyncWeb3", async_keyfile_account_address: ChecksumAddress
     ) -> None:
         gas_price = async_w3.to_wei(2, "gwei")
-
         txn_params: TxParams = {
             "from": async_keyfile_account_address,
             "to": async_keyfile_account_address,

--- a/web3/_utils/module_testing/module_testing_utils.py
+++ b/web3/_utils/module_testing/module_testing_utils.py
@@ -106,6 +106,7 @@ def assert_contains_log(
     emitter_contract_address: ChecksumAddress,
     txn_hash_with_log: HexStr,
 ) -> None:
+    assert len(result) > 0
     log_entry = result[0]
     assert log_entry["blockNumber"] == block_with_txn_with_log["number"]
     assert log_entry["blockHash"] == block_with_txn_with_log["hash"]

--- a/web3/_utils/module_testing/module_testing_utils.py
+++ b/web3/_utils/module_testing/module_testing_utils.py
@@ -106,7 +106,6 @@ def assert_contains_log(
     emitter_contract_address: ChecksumAddress,
     txn_hash_with_log: HexStr,
 ) -> None:
-    assert len(result) == 1
     log_entry = result[0]
     assert log_entry["blockNumber"] == block_with_txn_with_log["number"]
     assert log_entry["blockHash"] == block_with_txn_with_log["hash"]

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -117,6 +117,7 @@ from web3.types import (
     BlockIdentifier,
     EventData,
     FilterParams,
+    LogReceipt,
     TContractFn,
     TxParams,
     TxReceipt,
@@ -253,7 +254,7 @@ class BaseContractEvent:
             yield rich_log
 
     @combomethod
-    def process_log(self, log: HexStr) -> EventData:
+    def process_log(self, log: LogReceipt) -> EventData:
         return get_event_data(self.w3.codec, self.abi, log)
 
     @combomethod

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -719,8 +719,8 @@ class AsyncEth(BaseEth):
                 bool,  # newPendingTransactions, full_transactions
             ]
         ] = None,
-        handler: Optional[EthSubscriptionHandler[EthSubscription[Any], Any]] = None,
-        event: Optional["AsyncContractEvent"] = None,
+        handler: Optional[EthSubscriptionHandler] = None,
+        handler_context: Dict[str, Any] = None,
         label: Optional[str] = None,
     ) -> HexStr:
         if not isinstance(self.w3.provider, PersistentConnectionProvider):
@@ -732,7 +732,7 @@ class AsyncEth(BaseEth):
         sx = EthSubscription._create_type_aware_subscription(
             subscription_params=(subscription_type, subscription_arg),
             handler=handler,
-            event=event,
+            handler_context=handler_context or {},
             label=label,
         )
         return await self.w3.subscription_manager.subscribe(sx)

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -720,7 +720,7 @@ class AsyncEth(BaseEth):
             ]
         ] = None,
         handler: Optional[EthSubscriptionHandler] = None,
-        handler_context: Dict[str, Any] = None,
+        handler_context: Optional[Dict[str, Any]] = None,
         label: Optional[str] = None,
     ) -> HexStr:
         if not isinstance(self.w3.provider, PersistentConnectionProvider):
@@ -729,13 +729,13 @@ class AsyncEth(BaseEth):
                 "persistent connections."
             )
 
-        sx = EthSubscription._create_type_aware_subscription(
+        sub = EthSubscription._create_type_aware_subscription(
             subscription_params=(subscription_type, subscription_arg),
             handler=handler,
             handler_context=handler_context or {},
             label=label,
         )
-        return await self.w3.subscription_manager.subscribe(sx)
+        return await self.w3.subscription_manager.subscribe(sub)
 
     _unsubscribe: Method[Callable[[HexStr], Awaitable[bool]]] = Method(
         RPC.eth_unsubscribe,
@@ -749,9 +749,9 @@ class AsyncEth(BaseEth):
                 "persistent connections."
             )
 
-        for sx in self.w3.subscription_manager.subscriptions:
-            if sx._id == subscription_id:
-                return await sx.unsubscribe()
+        for sub in self.w3.subscription_manager.subscriptions:
+            if sub._id == subscription_id:
+                return await sub.unsubscribe()
 
         raise Web3ValueError(
             f"Cannot unsubscribe subscription with id `{subscription_id}`. "

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -108,6 +108,7 @@ from web3.utils.subscriptions import (
 
 if TYPE_CHECKING:
     from web3 import AsyncWeb3  # noqa: F401
+    from web3.contract.async_contract import AsyncContractEvent  # noqa: F401
 
 
 class AsyncEth(BaseEth):
@@ -718,7 +719,8 @@ class AsyncEth(BaseEth):
                 bool,  # newPendingTransactions, full_transactions
             ]
         ] = None,
-        handler: Optional[EthSubscriptionHandler] = None,
+        handler: Optional[EthSubscriptionHandler[EthSubscription[Any], Any]] = None,
+        event: Optional["AsyncContractEvent"] = None,
         label: Optional[str] = None,
     ) -> HexStr:
         if not isinstance(self.w3.provider, PersistentConnectionProvider):
@@ -727,12 +729,12 @@ class AsyncEth(BaseEth):
                 "persistent connections."
             )
 
-        params = (
-            (subscription_type, subscription_arg)
-            if subscription_arg is not None
-            else (subscription_type,)
+        sx = EthSubscription._create_type_aware_subscription(
+            subscription_params=(subscription_type, subscription_arg),
+            handler=handler,
+            event=event,
+            label=label,
         )
-        sx = EthSubscription(subscription_params=params, handler=handler, label=label)
         return await self.w3.subscription_manager.subscribe(sx)
 
     _unsubscribe: Method[Callable[[HexStr], Awaitable[bool]]] = Method(

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -353,6 +353,13 @@ class PersistentConnectionClosedOK(PersistentConnectionError):
     """
 
 
+class SubscriptionProcessingFinished(Web3Exception):
+    """
+    Raised to alert the subscription manager that the processing of subscriptions
+    has finished.
+    """
+
+
 class Web3RPCError(Web3Exception):
     """
     Raised when a JSON-RPC response contains an error field.

--- a/web3/main.py
+++ b/web3/main.py
@@ -148,6 +148,9 @@ from web3.tracing import (
 from web3.types import (
     Wei,
 )
+from web3.providers.persistent.subscription_manager import (
+    SubscriptionManager,
+)
 
 if TYPE_CHECKING:
     from web3._utils.batching import RequestBatcher  # noqa: F401
@@ -508,7 +511,20 @@ class AsyncWeb3(BaseWeb3):
             new_ens.w3 = self  # set self object reference for ``AsyncENS.w3``
         self._ens = new_ens
 
-    # -- persistent connection methods -- #
+    # -- persistent connection settings -- #
+
+    _subscription_manager: SubscriptionManager = None
+
+    @property
+    @persistent_connection_provider_method()
+    def subscription_manager(self) -> SubscriptionManager:
+        """
+        Access the subscription manager for the current PersistentConnectionProvider.
+        """
+        if not self._subscription_manager:
+            self._subscription_manager = SubscriptionManager(self)
+
+        return self._subscription_manager
 
     @property
     @persistent_connection_provider_method()

--- a/web3/main.py
+++ b/web3/main.py
@@ -513,7 +513,8 @@ class AsyncWeb3(BaseWeb3):
 
     # -- persistent connection settings -- #
 
-    _subscription_manager: SubscriptionManager = None
+    _subscription_manager: Optional[SubscriptionManager] = None
+    _persistent_connection: Optional["PersistentConnection"] = None
 
     @property
     @persistent_connection_provider_method()
@@ -523,13 +524,14 @@ class AsyncWeb3(BaseWeb3):
         """
         if not self._subscription_manager:
             self._subscription_manager = SubscriptionManager(self)
-
         return self._subscription_manager
 
     @property
     @persistent_connection_provider_method()
     def socket(self) -> PersistentConnection:
-        return PersistentConnection(self)
+        if self._persistent_connection is None:
+            self._persistent_connection = PersistentConnection(self)
+        return self._persistent_connection
 
     # w3 = await AsyncWeb3(PersistentConnectionProvider(...))
     @persistent_connection_provider_method(

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -544,15 +544,18 @@ class RequestManager:
     def _persistent_message_stream(self) -> "_AsyncPersistentMessageStream":
         return _AsyncPersistentMessageStream(self)
 
-    async def _get_next_message(self) -> RPCResponse:
+    async def _get_next_message(self) -> Optional[RPCResponse]:
         return await self._message_stream().__anext__()
 
-    async def _message_stream(self) -> AsyncGenerator[RPCResponse, None]:
+    async def _message_stream(
+        self,
+    ) -> AsyncGenerator[Optional[RPCResponse], None]:
         if not isinstance(self._provider, PersistentConnectionProvider):
             raise Web3TypeError(
                 "Only providers that maintain an open, persistent connection "
                 "can listen to streams."
             )
+        async_w3 = cast("AsyncWeb3", self.w3)
 
         if self._provider._message_listener_task is None:
             raise ProviderConnectionError(
@@ -564,13 +567,25 @@ class RequestManager:
                 response = await self._request_processor.pop_raw_response(
                     subscription=True
                 )
-                if (
-                    response is not None
-                    and response.get("params", {}).get("subscription")
-                    in self._request_processor.active_subscriptions
-                ):
-                    # if response is an active subscription response, process it
-                    yield await self._process_response(response)
+                if response is not None:
+                    sx_response = await self._process_response(response)
+
+                    # call the handler is there is one, else yield the response to any
+                    # listeners
+                    for sx in async_w3.subscription_manager.subscriptions:
+                        if (
+                            sx_response.get("subscription") == sx.id
+                            and sx._handler is not None
+                        ):
+                            await sx._handler(async_w3, sx, sx_response["result"])
+                    yield sx_response
+                else:
+                    # if response is not an active subscription response, log it
+                    self.logger.debug(
+                        "Received inactive subscription from socket:\n"
+                        f"    {self._provider.get_endpoint_uri_or_ipc_path()}, "
+                        f"    response: {response}"
+                    )
             except TaskNotRunning:
                 await asyncio.sleep(0)
                 self._provider._handle_listener_task_exceptions()
@@ -643,5 +658,5 @@ class _AsyncPersistentMessageStream:
     def __aiter__(self) -> Self:
         return self
 
-    async def __anext__(self) -> RPCResponse:
+    async def __anext__(self) -> Optional[RPCResponse]:
         return await self.manager._get_next_message()

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -73,6 +73,9 @@ from web3.types import (
     RPCEndpoint,
     RPCResponse,
 )
+from web3.utils.subscriptions import (
+    EthSubscriptionContext,
+)
 
 if TYPE_CHECKING:
     from web3.main import (  # noqa: F401
@@ -580,7 +583,14 @@ class RequestManager:
                 )
                 # call the handler if there is one, else yield response to any listeners
                 if sx and sx._handler:
-                    await sx._handler(async_w3, sx, formatted_sx_response.get("result"))
+                    await sx._handler(
+                        EthSubscriptionContext(
+                            async_w3,
+                            sx,
+                            formatted_sx_response["result"],
+                            **sx._handler_context,
+                        )
+                    )
                     yield None
                 yield formatted_sx_response
             except TaskNotRunning:

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -573,26 +573,26 @@ class RequestManager:
                 response = await self._request_processor.pop_raw_response(
                     subscription=True
                 )
-                formatted_sx_response = cast(
+                formatted_sub_response = cast(
                     FormattedEthSubscriptionResponse,
                     await self._process_response(response),
                 )
 
-                sx = async_w3.subscription_manager.get_by_id(
-                    formatted_sx_response["subscription"]
+                sub = async_w3.subscription_manager.get_by_id(
+                    formatted_sub_response["subscription"]
                 )
                 # call the handler if there is one, else yield response to any listeners
-                if sx and sx._handler:
-                    await sx._handler(
+                if sub and sub._handler:
+                    await sub._handler(
                         EthSubscriptionContext(
                             async_w3,
-                            sx,
-                            formatted_sx_response["result"],
-                            **sx._handler_context,
+                            sub,
+                            formatted_sub_response["result"],
+                            **sub._handler_context,
                         )
                     )
                     yield None
-                yield formatted_sx_response
+                yield formatted_sub_response
             except TaskNotRunning:
                 await asyncio.sleep(0)
                 self._provider._handle_listener_task_exceptions()

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -293,9 +293,6 @@ class RequestManager:
             provider = cast(PersistentConnectionProvider, self.provider)
             self._request_processor: RequestProcessor = provider._request_processor
 
-    w3: Union["AsyncWeb3", "Web3"] = None
-    _provider = None
-
     @property
     def provider(self) -> Union["BaseProvider", "AsyncBaseProvider"]:
         return self._provider

--- a/web3/method.py
+++ b/web3/method.py
@@ -203,7 +203,7 @@ class Method(Generic[TFunc]):
     def process_params(
         self, module: "Module", *args: Any, **kwargs: Any
     ) -> Tuple[
-        Tuple[Union[RPCEndpoint, Callable[..., RPCEndpoint]], Tuple[Any, ...]],
+        Tuple[Union[RPCEndpoint, Callable[..., RPCEndpoint]], Tuple[RPCEndpoint, ...]],
         Tuple[
             Union[TReturn, Dict[str, Callable[..., Any]]],
             Callable[..., Any],

--- a/web3/module.py
+++ b/web3/module.py
@@ -32,6 +32,7 @@ from web3.providers.persistent import (
     PersistentConnectionProvider,
 )
 from web3.types import (
+    FormattedEthSubscriptionResponse,
     RPCEndpoint,
     RPCResponse,
 )
@@ -121,8 +122,17 @@ def retrieve_async_method_call_fn(
     async_w3: "AsyncWeb3",
     module: "Module",
     method: Method[Callable[..., Any]],
-) -> Callable[..., Coroutine[Any, Any, Optional[Union[RPCResponse, AsyncLogFilter]]]]:
-    async def caller(*args: Any, **kwargs: Any) -> Union[RPCResponse, AsyncLogFilter]:
+) -> Callable[
+    ...,
+    Coroutine[
+        Any,
+        Any,
+        Optional[Union[RPCResponse, FormattedEthSubscriptionResponse, AsyncLogFilter]],
+    ],
+]:
+    async def caller(
+        *args: Any, **kwargs: Any
+    ) -> Union[RPCResponse, FormattedEthSubscriptionResponse, AsyncLogFilter]:
         try:
             (method_str, params), response_formatters = method.process_params(
                 module, *args, **kwargs

--- a/web3/module.py
+++ b/web3/module.py
@@ -75,7 +75,7 @@ def retrieve_request_information_for_batching(
         )
         if isinstance(w3.provider, PersistentConnectionProvider):
             w3.provider._request_processor.cache_request_information(
-                cast(RPCEndpoint, method_str), params, response_formatters
+                None, cast(RPCEndpoint, method_str), params, response_formatters
             )
         return (cast(RPCEndpoint, method_str), params), response_formatters
 
@@ -141,31 +141,17 @@ def retrieve_async_method_call_fn(
             return AsyncLogFilter(eth_module=module, filter_id=err.filter_id)
 
         if isinstance(async_w3.provider, PersistentConnectionProvider):
-            provider = async_w3.provider
-            cache_key = provider._request_processor.cache_request_information(
-                cast(RPCEndpoint, method_str), params, response_formatters
+            return await async_w3.manager.socket_request(
+                cast(RPCEndpoint, method_str),
+                params,
+                response_formatters=response_formatters,
             )
-
-            try:
-                method_str = cast(RPCEndpoint, method_str)
-                return await async_w3.manager.socket_request(method_str, params)
-            except Exception as e:
-                if (
-                    cache_key is not None
-                    and cache_key
-                    in provider._request_processor._request_information_cache
-                ):
-                    provider._request_processor.pop_cached_request_information(
-                        cache_key
-                    )
-                raise e
         else:
             (
                 result_formatters,
                 error_formatters,
                 null_result_formatters,
             ) = response_formatters
-
             result = await async_w3.manager.coro_request(
                 method_str, params, error_formatters, null_result_formatters
             )

--- a/web3/providers/async_base.py
+++ b/web3/providers/async_base.py
@@ -83,10 +83,6 @@ class AsyncBaseProvider:
     global_ccip_read_enabled: bool = True
     ccip_read_max_redirects: int = 4
 
-    # request caching
-    _request_cache: SimpleCache
-    _request_cache_lock: asyncio.Lock = asyncio.Lock()
-
     def __init__(
         self,
         cache_allowed_requests: bool = False,
@@ -96,6 +92,8 @@ class AsyncBaseProvider:
         ] = empty,
     ) -> None:
         self._request_cache = SimpleCache(1000)
+        self._request_cache_lock: asyncio.Lock = asyncio.Lock()
+
         self.cache_allowed_requests = cache_allowed_requests
         self.cacheable_requests = cacheable_requests or CACHEABLE_REQUESTS
         self.request_cache_validation_threshold = request_cache_validation_threshold
@@ -172,11 +170,9 @@ class AsyncBaseProvider:
 
 
 class AsyncJSONBaseProvider(AsyncBaseProvider):
-    logger = logging.getLogger("web3.providers.async_base.AsyncJSONBaseProvider")
-
     def __init__(self, **kwargs: Any) -> None:
-        self.request_counter = itertools.count()
         super().__init__(**kwargs)
+        self.request_counter = itertools.count()
 
     def encode_rpc_request(self, method: RPCEndpoint, params: Any) -> bytes:
         request_id = next(self.request_counter)

--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -66,10 +66,6 @@ class BaseProvider:
     global_ccip_read_enabled: bool = True
     ccip_read_max_redirects: int = 4
 
-    # request caching
-    _request_cache: SimpleCache
-    _request_cache_lock: threading.Lock = threading.Lock()
-
     def __init__(
         self,
         cache_allowed_requests: bool = False,
@@ -79,6 +75,8 @@ class BaseProvider:
         ] = empty,
     ) -> None:
         self._request_cache = SimpleCache(1000)
+        self._request_cache_lock: threading.Lock = threading.Lock()
+
         self.cache_allowed_requests = cache_allowed_requests
         self.cacheable_requests = cacheable_requests or CACHEABLE_REQUESTS
         self.request_cache_validation_threshold = request_cache_validation_threshold
@@ -124,8 +122,8 @@ class JSONBaseProvider(BaseProvider):
     ] = (None, None)
 
     def __init__(self, **kwargs: Any) -> None:
-        self.request_counter = itertools.count()
         super().__init__(**kwargs)
+        self.request_counter = itertools.count()
 
     def encode_rpc_request(self, method: RPCEndpoint, params: Any) -> bytes:
         rpc_dict = {

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -146,6 +146,7 @@ class IPCProvider(JSONBaseProvider):
         timeout: int = 30,
         **kwargs: Any,
     ) -> None:
+        super().__init__(**kwargs)
         if ipc_path is None:
             self.ipc_path = get_default_ipc_path()
         elif isinstance(ipc_path, str) or isinstance(ipc_path, Path):
@@ -156,7 +157,6 @@ class IPCProvider(JSONBaseProvider):
         self.timeout = timeout
         self._lock = threading.Lock()
         self._socket = PersistantSocket(self.ipc_path)
-        super().__init__(**kwargs)
 
     def __str__(self) -> str:
         return f"<{self.__class__.__name__} {self.ipc_path}>"

--- a/web3/providers/legacy_websocket.py
+++ b/web3/providers/legacy_websocket.py
@@ -102,6 +102,7 @@ class LegacyWebSocketProvider(JSONBaseProvider):
         websocket_timeout: int = DEFAULT_WEBSOCKET_TIMEOUT,
         **kwargs: Any,
     ) -> None:
+        super().__init__(**kwargs)
         self.endpoint_uri = URI(endpoint_uri)
         self.websocket_timeout = websocket_timeout
         if self.endpoint_uri is None:
@@ -120,7 +121,6 @@ class LegacyWebSocketProvider(JSONBaseProvider):
                     f"in websocket_kwargs, found: {found_restricted_keys}"
                 )
         self.conn = PersistentWebSocket(self.endpoint_uri, websocket_kwargs)
-        super().__init__(**kwargs)
 
     def __str__(self) -> str:
         return f"WS connection {self.endpoint_uri}"

--- a/web3/providers/persistent/async_ipc.py
+++ b/web3/providers/persistent/async_ipc.py
@@ -14,6 +14,7 @@ from typing import (
 )
 
 from web3.types import (
+    RPCEndpoint,
     RPCResponse,
 )
 
@@ -77,7 +78,7 @@ class AsyncIPCProvider(PersistentConnectionProvider):
             return False
 
         try:
-            await self.make_request("web3_clientVersion", [])
+            await self.make_request(RPCEndpoint("web3_clientVersion"), [])
             return True
         except (OSError, ProviderConnectionError) as e:
             if show_traceback:

--- a/web3/providers/persistent/async_ipc.py
+++ b/web3/providers/persistent/async_ipc.py
@@ -140,6 +140,7 @@ class AsyncIPCProvider(PersistentConnectionProvider):
         )
 
     async def _provider_specific_disconnect(self) -> None:
+        # this should remain idempotent
         if self._writer and not self._writer.is_closing():
             self._writer.close()
             await self._writer.wait_closed()

--- a/web3/providers/persistent/async_ipc.py
+++ b/web3/providers/persistent/async_ipc.py
@@ -59,15 +59,15 @@ class AsyncIPCProvider(PersistentConnectionProvider):
         # `PersistentConnectionProvider` kwargs can be passed through
         **kwargs: Any,
     ) -> None:
+        # initialize the ipc_path before calling the super constructor
         if ipc_path is None:
             self.ipc_path = get_default_ipc_path()
         elif isinstance(ipc_path, str) or isinstance(ipc_path, Path):
             self.ipc_path = str(Path(ipc_path).expanduser().resolve())
         else:
             raise Web3TypeError("ipc_path must be of type string or pathlib.Path")
-
-        self.read_buffer_limit = read_buffer_limit
         super().__init__(**kwargs)
+        self.read_buffer_limit = read_buffer_limit
 
     def __str__(self) -> str:
         return f"<{self.__class__.__name__} {self.ipc_path}>"

--- a/web3/providers/persistent/persistent.py
+++ b/web3/providers/persistent/persistent.py
@@ -190,9 +190,12 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
     def _message_listener_callback(
         self, message_listener_task: "asyncio.Task[None]"
     ) -> None:
-        # Puts a `TaskNotRunning` in the queue to signal the end of the listener task
-        # to any running subscription streams that are awaiting a response.
+        # Puts a `TaskNotRunning` in appropriate queues to signal the end of the
+        # listener task to any listeners relying on the queues.
         self._request_processor._subscription_response_queue.put_nowait(
+            TaskNotRunning(message_listener_task)
+        )
+        self._request_processor._handler_subscription_queue.put_nowait(
             TaskNotRunning(message_listener_task)
         )
 

--- a/web3/providers/persistent/persistent.py
+++ b/web3/providers/persistent/persistent.py
@@ -65,6 +65,7 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
         subscription_response_queue_size: int = 500,
         silence_listener_task_exceptions: bool = False,
         max_connection_retries: int = 5,
+        label: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -75,6 +76,7 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
         self.request_timeout = request_timeout
         self.silence_listener_task_exceptions = silence_listener_task_exceptions
         self._max_connection_retries = max_connection_retries
+        self.label = label or self.get_endpoint_uri_or_ipc_path()
 
     def get_endpoint_uri_or_ipc_path(self) -> str:
         if hasattr(self, "endpoint_uri"):

--- a/web3/providers/persistent/persistent_connection.py
+++ b/web3/providers/persistent/persistent_connection.py
@@ -2,9 +2,11 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
+    Union,
 )
 
 from web3.types import (
+    FormattedEthSubscriptionResponse,
     RPCEndpoint,
     RPCResponse,
 )
@@ -37,7 +39,9 @@ class PersistentConnection:
         """
         return self._manager._request_processor.active_subscriptions
 
-    async def make_request(self, method: RPCEndpoint, params: Any) -> RPCResponse:
+    async def make_request(
+        self, method: RPCEndpoint, params: Any
+    ) -> Union[RPCResponse, FormattedEthSubscriptionResponse]:
         """
         Make a request to the persistent connection and return the response. This method
         does not process the response as it would when invoking a method via the
@@ -48,7 +52,7 @@ class PersistentConnection:
         :param params: The RPC method parameters, e.g. `["0x1337", False]`.
 
         :return: The processed response from the persistent connection.
-        :rtype: RPCResponse
+        :rtype: Union[RPCResponse, FormattedEthSubscriptionResponse]
         """
         return await self._manager.socket_request(method, params)
 
@@ -63,14 +67,14 @@ class PersistentConnection:
         """
         await self._manager.send(method, params)
 
-    async def recv(self) -> RPCResponse:
+    async def recv(self) -> Union[RPCResponse, FormattedEthSubscriptionResponse]:
         """
         Receive the next unprocessed response for a request from the persistent
         connection.
 
         :return: The next unprocessed response for a request from the persistent
                  connection.
-        :rtype: RPCResponse
+        :rtype: Union[RPCResponse, FormattedEthSubscriptionResponse]
         """
         return await self._manager.recv()
 

--- a/web3/providers/persistent/subscription_container.py
+++ b/web3/providers/persistent/subscription_container.py
@@ -1,0 +1,56 @@
+from typing import (
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+)
+
+from eth_typing import (
+    HexStr,
+)
+
+from web3.utils import (
+    EthSubscription,
+)
+
+
+class SubscriptionContainer:
+    def __init__(self) -> None:
+        self.subscriptions: List[EthSubscription[Any]] = []
+        self.subscriptions_by_id: Dict[HexStr, EthSubscription[Any]] = {}
+        self.subscriptions_by_label: Dict[str, EthSubscription[Any]] = {}
+
+    def __len__(self) -> int:
+        return len(self.subscriptions)
+
+    def __iter__(self) -> Iterator[EthSubscription[Any]]:
+        return iter(self.subscriptions)
+
+    def add_subscription(self, subscription: EthSubscription[Any]) -> None:
+        self.subscriptions.append(subscription)
+        self.subscriptions_by_id[subscription.id] = subscription
+        self.subscriptions_by_label[subscription.label] = subscription
+
+    def remove_subscription(self, subscription: EthSubscription[Any]) -> None:
+        self.subscriptions.remove(subscription)
+        self.subscriptions_by_id.pop(subscription.id)
+        self.subscriptions_by_label.pop(subscription.label)
+
+    def get_by_id(self, sub_id: HexStr) -> EthSubscription[Any]:
+        return self.subscriptions_by_id.get(sub_id)
+
+    def get_by_label(self, label: str) -> EthSubscription[Any]:
+        return self.subscriptions_by_label.get(label)
+
+    @property
+    def handler_subscriptions(self) -> List[EthSubscription[Any]]:
+        return [sub for sub in self.subscriptions if sub._handler is not None]
+
+    def get_handler_subscription_by_id(
+        self, sub_id: HexStr
+    ) -> Optional[EthSubscription[Any]]:
+        sub = self.get_by_id(sub_id)
+        if sub and sub._handler:
+            return sub
+        return None

--- a/web3/providers/persistent/subscription_manager.py
+++ b/web3/providers/persistent/subscription_manager.py
@@ -66,7 +66,7 @@ class SubscriptionManager:
                     f"unique labels.\n    label: {subscriptions.label}"
                 )
 
-            subscriptions._manager = self
+            subscriptions.manager = self
             sx_id = await self._w3.eth._subscribe(*subscriptions.subscription_params)
             subscriptions._id = sx_id
             self._subscriptions_by_label[subscriptions.label] = subscriptions
@@ -93,7 +93,9 @@ class SubscriptionManager:
         subscription manager.
 
         :param subscription: The subscription to unsubscribe from.
-        :return: True if unsubscribing was successful, False otherwise.
+        :type subscription: EthSubscription
+        :return: `True` if unsubscribing was successful, `False` otherwise.
+        :rtype: bool
         """
         if subscription not in self.subscriptions:
             raise Web3ValueError(
@@ -122,10 +124,15 @@ class SubscriptionManager:
         if all(unsubscribed):
             self.logger.info("Successfully unsubscribed from all subscriptions.")
         else:
-            self.logger.warning(
-                "Failed to unsubscribe from all subscriptions. Some subscriptions may "
-                "still be active."
-            )
+            if len(self.subscriptions) > 0:
+                self.logger.warning(
+                    "Failed to unsubscribe from all subscriptions. Some subscriptions "
+                    "are still active."
+                )
+                self.logger.debug(
+                    "Failed to unsubscribe from some subscriptions."
+                    f"\n    subscriptions={self.subscriptions}"
+                )
 
     async def _handle_subscriptions(self, run_forever: bool = False) -> None:
         while run_forever or len(self.subscriptions) > 0:
@@ -138,6 +145,7 @@ class SubscriptionManager:
         indefinitely.
 
         :param run_forever: If `True`, the method will run indefinitely.
+        :type run_forever: bool
         :return: None
         """
         await self._handle_subscriptions(run_forever=run_forever)

--- a/web3/providers/persistent/subscription_manager.py
+++ b/web3/providers/persistent/subscription_manager.py
@@ -1,0 +1,103 @@
+from typing import (
+    TYPE_CHECKING,
+    List,
+    Sequence,
+    Union,
+    cast,
+    overload,
+)
+
+from eth_typing import (
+    HexStr,
+)
+from typing_extensions import (
+    TypeVar,
+)
+
+from web3.exceptions import (
+    Web3TypeError,
+    Web3ValueError,
+)
+from web3.utils import (
+    EthSubscription,
+)
+
+if TYPE_CHECKING:
+    from web3 import AsyncWeb3  # noqa: F401
+    from web3.providers.persistent import PersistentConnectionProvider  # noqa: F401
+
+
+T = TypeVar("T", bound="EthSubscription")
+
+
+class SubscriptionManager:
+    def __init__(self, w3: "AsyncWeb3") -> None:
+        self._w3 = w3
+        self._provider = cast("PersistentConnectionProvider", w3.provider)
+        self.subscriptions: List[EthSubscription] = []
+
+    @overload
+    async def subscribe(self, subscriptions: T) -> HexStr:
+        ...
+
+    @overload
+    async def subscribe(self, subscriptions: Sequence[T]) -> List[HexStr]:
+        ...
+
+    async def subscribe(
+        self, subscriptions: Union[T, Sequence[T]]
+    ) -> Union[HexStr, List[HexStr]]:
+        if isinstance(subscriptions, EthSubscription):
+            subscriptions._manager = self
+            sx_id = await self._w3.eth._subscribe(*subscriptions.subscription_params)
+            subscriptions._id = sx_id
+            self.subscriptions.append(subscriptions)
+            self._provider.logger.info(
+                f"Successfully subscribed to subscription:\n    "
+                f"label: {subscriptions.label}\n    id: {sx_id}"
+            )
+            return sx_id
+        elif isinstance(subscriptions, Sequence):
+            if len(subscriptions) == 0:
+                raise Web3ValueError("No subscriptions provided.")
+
+            sx_ids = []
+            for sx in subscriptions:
+                await self.subscribe(sx)
+                sx_ids.append(sx._id)
+
+            return sx_ids
+        else:
+            raise Web3TypeError(
+                "Expected a Subscription or a sequence of Subscriptions."
+            )
+
+    async def unsubscribe(self, subscription: EthSubscription) -> bool:
+        if subscription not in self.subscriptions:
+            raise Web3ValueError(
+                f"Subscription not found or is not being managed by the subscription "
+                f"manager.\n    label: {subscription.label}\n    id: {subscription._id}"
+            )
+
+        if await self._w3.eth._unsubscribe(subscription.id):
+            self.subscriptions.remove(subscription)
+            return True
+        return False
+
+    async def unsubscribe_all(self) -> None:
+        for sx in self.subscriptions:
+            await self.unsubscribe(sx)
+
+        self._provider.logger.info("Successfully unsubscribed from all subscriptions.")
+
+    async def _handle_subscriptions(self, run_forever: bool = False) -> None:
+        self._provider.logger.info("Subscription manager processing started.")
+        while True:
+            if not run_forever and len(self.subscriptions) == 0:
+                break
+            await self._w3.manager._get_next_message()
+
+        self._provider.logger.info("Subscription manager processing ended.")
+
+    async def handle_subscriptions(self, run_forever: bool = False) -> None:
+        await self._handle_subscriptions(run_forever=run_forever)

--- a/web3/providers/persistent/subscription_manager.py
+++ b/web3/providers/persistent/subscription_manager.py
@@ -73,6 +73,13 @@ class SubscriptionManager:
             )
 
     async def unsubscribe(self, subscription: EthSubscription) -> bool:
+        """
+        Used to unsubscribe from a subscription that is being managed by the
+        subscription manager.
+
+        :param subscription: The subscription to unsubscribe from.
+        :return: True if unsubscribing was successful, False otherwise.
+        """
         if subscription not in self.subscriptions:
             raise Web3ValueError(
                 f"Subscription not found or is not being managed by the subscription "
@@ -85,6 +92,12 @@ class SubscriptionManager:
         return False
 
     async def unsubscribe_all(self) -> None:
+        """
+        Used to unsubscribe from all subscriptions that are being managed by the
+        subscription manager.
+
+        :return: None
+        """
         for sx in self.subscriptions:
             await self.unsubscribe(sx)
 
@@ -100,4 +113,12 @@ class SubscriptionManager:
         self._provider.logger.info("Subscription manager processing ended.")
 
     async def handle_subscriptions(self, run_forever: bool = False) -> None:
+        """
+        Used to process all subscriptions. It will run until all subscriptions are
+        unsubscribed from or, if `run_forever` is set to `True`, it will run
+        indefinitely.
+
+        :param run_forever: If `True`, the method will run indefinitely.
+        :return: None
+        """
         await self._handle_subscriptions(run_forever=run_forever)

--- a/web3/providers/persistent/subscription_manager.py
+++ b/web3/providers/persistent/subscription_manager.py
@@ -3,10 +3,7 @@ import logging
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
-    Iterator,
     List,
-    Optional,
     Sequence,
     Union,
     cast,
@@ -23,6 +20,9 @@ from web3.exceptions import (
     Web3TypeError,
     Web3ValueError,
 )
+from web3.providers.persistent.subscription_container import (
+    SubscriptionContainer,
+)
 from web3.types import (
     FormattedEthSubscriptionResponse,
     RPCResponse,
@@ -38,47 +38,6 @@ if TYPE_CHECKING:
         PersistentConnectionProvider,
         RequestProcessor,
     )
-
-
-class SubscriptionContainer:
-    def __init__(self) -> None:
-        self.subscriptions: List[EthSubscription[Any]] = []
-        self.subscriptions_by_id: Dict[HexStr, EthSubscription[Any]] = {}
-        self.subscriptions_by_label: Dict[str, EthSubscription[Any]] = {}
-
-    def __len__(self) -> int:
-        return len(self.subscriptions)
-
-    def __iter__(self) -> Iterator[EthSubscription[Any]]:
-        return iter(self.subscriptions)
-
-    def add_subscription(self, subscription: EthSubscription[Any]) -> None:
-        self.subscriptions.append(subscription)
-        self.subscriptions_by_id[subscription.id] = subscription
-        self.subscriptions_by_label[subscription.label] = subscription
-
-    def remove_subscription(self, subscription: EthSubscription[Any]) -> None:
-        self.subscriptions.remove(subscription)
-        self.subscriptions_by_id.pop(subscription.id)
-        self.subscriptions_by_label.pop(subscription.label)
-
-    def get_by_id(self, sub_id: HexStr) -> EthSubscription[Any]:
-        return self.subscriptions_by_id.get(sub_id)
-
-    def get_by_label(self, label: str) -> EthSubscription[Any]:
-        return self.subscriptions_by_label.get(label)
-
-    @property
-    def handler_subscriptions(self) -> List[EthSubscription[Any]]:
-        return [sub for sub in self.subscriptions if sub._handler is not None]
-
-    def get_handler_subscription_by_id(
-        self, sub_id: HexStr
-    ) -> Optional[EthSubscription[Any]]:
-        sub = self.get_by_id(sub_id)
-        if sub and sub._handler:
-            return sub
-        return None
 
 
 class SubscriptionManager:

--- a/web3/providers/persistent/websocket.py
+++ b/web3/providers/persistent/websocket.py
@@ -59,8 +59,6 @@ class WebSocketProvider(PersistentConnectionProvider):
     logger = logging.getLogger("web3.providers.WebSocketProvider")
     is_async: bool = True
 
-    _ws: Optional[WebSocketClientProtocol] = None
-
     def __init__(
         self,
         endpoint_uri: Optional[Union[URI, str]] = None,
@@ -68,9 +66,12 @@ class WebSocketProvider(PersistentConnectionProvider):
         # `PersistentConnectionProvider` kwargs can be passed through
         **kwargs: Any,
     ) -> None:
+        # initialize the endpoint_uri before calling the super constructor
         self.endpoint_uri = (
             URI(endpoint_uri) if endpoint_uri is not None else get_default_endpoint()
         )
+        super().__init__(**kwargs)
+        self._ws: Optional[WebSocketClientProtocol] = None
 
         if not any(
             self.endpoint_uri.startswith(prefix)
@@ -92,8 +93,6 @@ class WebSocketProvider(PersistentConnectionProvider):
                 )
 
         self.websocket_kwargs = merge(DEFAULT_WEBSOCKET_KWARGS, websocket_kwargs or {})
-
-        super().__init__(**kwargs)
 
     def __str__(self) -> str:
         return f"WebSocket connection: {self.endpoint_uri}"

--- a/web3/providers/persistent/websocket.py
+++ b/web3/providers/persistent/websocket.py
@@ -132,6 +132,7 @@ class WebSocketProvider(PersistentConnectionProvider):
         self._ws = await connect(self.endpoint_uri, **self.websocket_kwargs)
 
     async def _provider_specific_disconnect(self) -> None:
+        # this should remain idempotent
         if self._ws is not None and not self._ws.closed:
             await self._ws.close()
             self._ws = None

--- a/web3/providers/rpc/rpc.py
+++ b/web3/providers/rpc/rpc.py
@@ -71,6 +71,7 @@ class HTTPProvider(JSONBaseProvider):
         ] = empty,
         **kwargs: Any,
     ) -> None:
+        super().__init__(**kwargs)
         self._request_session_manager = HTTPSessionManager()
 
         if endpoint_uri is None:
@@ -87,8 +88,6 @@ class HTTPProvider(JSONBaseProvider):
             self._request_session_manager.cache_and_return_session(
                 self.endpoint_uri, session
             )
-
-        super().__init__(**kwargs)
 
     def __str__(self) -> str:
         return f"RPC connection {self.endpoint_uri}"

--- a/web3/types.py
+++ b/web3/types.py
@@ -273,11 +273,19 @@ class RPCResponse(TypedDict, total=False):
     params: EthSubscriptionParams
 
 
+EthSubscriptionResult = Union[
+    BlockData,  # newHeads
+    TxData,  # newPendingTransactions, full_transactions=True
+    HexBytes,  # newPendingTransactions, full_transactions=False
+    LogReceipt,  # logs
+    SyncProgress,  # syncing
+    GethSyncingSubscriptionResult,  # geth syncing
+]
+
+
 class FormattedEthSubscriptionResponse(TypedDict):
     subscription: HexStr
-    result: Union[
-        BlockData, TxData, LogReceipt, SyncProgress, GethSyncingSubscriptionResult
-    ]
+    result: EthSubscriptionResult
 
 
 class CreateAccessListResponse(TypedDict):

--- a/web3/types.py
+++ b/web3/types.py
@@ -262,6 +262,13 @@ EthSubscriptionParams = Union[
 RPCId = Optional[Union[int, str]]
 
 
+class RPCRequest(TypedDict, total=False):
+    id: RPCId
+    jsonrpc: Literal["2.0"]
+    method: RPCEndpoint
+    params: Any
+
+
 class RPCResponse(TypedDict, total=False):
     error: RPCError
     id: RPCId

--- a/web3/utils/__init__.py
+++ b/web3/utils/__init__.py
@@ -42,6 +42,9 @@ from .caching import (
 from .exception_handling import (
     handle_offchain_lookup,
 )
+from .subscriptions import (
+    EthSubscription,
+)
 
 __all__ = [
     "abi_to_signature",
@@ -70,5 +73,6 @@ __all__ = [
     "async_handle_offchain_lookup",
     "RequestCacheValidationThreshold",
     "SimpleCache",
+    "EthSubscription",
     "handle_offchain_lookup",
 ]

--- a/web3/utils/subscriptions.py
+++ b/web3/utils/subscriptions.py
@@ -3,9 +3,11 @@ from typing import (
     Any,
     Callable,
     Coroutine,
+    Generic,
     List,
     Optional,
     Sequence,
+    TypeVar,
     Union,
 )
 
@@ -14,44 +16,125 @@ from eth_typing import (
     ChecksumAddress,
     HexStr,
 )
+from hexbytes import (
+    HexBytes,
+)
 
 from web3.exceptions import (
     Web3ValueError,
 )
+from web3.types import (
+    BlockData,
+    FilterParams,
+    LogReceipt,
+    SyncProgress,
+    TxData,
+)
 
 if TYPE_CHECKING:
-    from web3 import AsyncWeb3  # noqa: F401
+    from web3 import (
+        AsyncWeb3,
+    )
+    from web3.contract.async_contract import (
+        AsyncContractEvent,
+    )
     from web3.providers.persistent.subscription_manager import (
         SubscriptionManager,
     )
-    from web3.types import (
-        FilterParams,
-    )
+    from web3.types import EthSubscriptionResult  # noqa: F401
+
+
+TSubscriptionResult = TypeVar("TSubscriptionResult", bound="EthSubscriptionResult")
+TSubscription = TypeVar("TSubscription", bound="EthSubscription[Any]")
 
 EthSubscriptionHandler = Callable[
-    ["AsyncWeb3", "EthSubscription", Any], Coroutine[Any, Any, None]
+    ["AsyncWeb3", TSubscription, TSubscriptionResult], Coroutine[Any, Any, None]
 ]
 
 
-class EthSubscription:
-    """
-    A base class for all eth_subscription types.
-    """
+def handler_wrapper(
+    handler: Optional[EthSubscriptionHandler[TSubscription, TSubscriptionResult]]
+) -> Optional[EthSubscriptionHandler[TSubscription, TSubscriptionResult]]:
+    if handler is None:
+        return None
 
+    async def wrapped_handler(
+        async_w3: "AsyncWeb3",
+        sx: TSubscription,
+        result: TSubscriptionResult,
+    ) -> None:
+        sx.handler_call_count += 1
+        sx._manager.total_handler_calls += 1
+        sx._manager.logger.debug(
+            "Subscription handler called.\n"
+            f"    label: {sx.label}\n"
+            f"    call count: {sx.handler_call_count}\n"
+            f"    total handler calls: {sx._manager.total_handler_calls}"
+        )
+        await handler(async_w3, sx, result)
+
+    return wrapped_handler
+
+
+class EthSubscription(Generic[TSubscriptionResult]):
     _id: HexStr = None
     _manager: "SubscriptionManager" = None
 
     def __init__(
-        self,
+        self: TSubscription,
         subscription_params: Optional[Sequence[Any]] = None,
-        handler: Optional[EthSubscriptionHandler] = None,
+        handler: Optional[
+            EthSubscriptionHandler[
+                "EthSubscription[TSubscriptionResult]", TSubscriptionResult
+            ]
+        ] = None,
         label: Optional[str] = None,
     ) -> None:
-        self._handler = handler
         self._subscription_params = subscription_params
+        self._handler = handler_wrapper(handler)
         self._label = label
+        self.handler_call_count = 0
 
-    # -- properties -- #
+    @classmethod
+    def _create_type_aware_subscription(
+        cls,
+        subscription_params: Optional[Sequence[Any]],
+        handler: Optional[EthSubscriptionHandler["EthSubscription[Any]", Any]] = None,
+        event: Optional["AsyncContractEvent"] = None,
+        label: Optional[str] = None,
+    ) -> "EthSubscription[Any]":
+        subscription_type = subscription_params[0]
+        subscription_arg = subscription_params[1]
+
+        if event and subscription_type != "logs":
+            raise Web3ValueError(
+                "Event provided without logs subscription type. "
+                "Please provide a logs subscription type."
+            )
+
+        if subscription_type == "newHeads":
+            return NewHeadsSubscription(handler=handler, label=label)
+        elif subscription_type == "logs":
+            subscription_arg = subscription_arg or {}
+            return LogsSubscription(
+                **subscription_arg, handler=handler, event=event, label=label
+            )
+        elif subscription_type == "newPendingTransactions":
+            subscription_arg = subscription_arg or False
+            return PendingTxSubscription(
+                full_transactions=subscription_arg, handler=handler, label=label
+            )
+        elif subscription_type == "syncing":
+            return SyncingSubscription(handler=handler, label=label)
+        else:
+            # don't pass in the subscription_arg, if it's ``None``, to avoid
+            # client-side errors
+            params = (
+                (subscription_type, subscription_arg)
+                if subscription_arg
+                else (subscription_type,)
+            )
+            return cls(params, handler=handler, label=label)
 
     @property
     def subscription_params(self) -> Sequence[Any]:
@@ -75,32 +158,32 @@ class EthSubscription:
     def id(self) -> HexStr:
         if not self._id:
             raise Web3ValueError(
-                "No `id` found for subscription. Once you are subscribed to this "
-                "subscription, an `id` will be set by the server."
+                "No `id` found for subscription. Once you are subscribed, "
+                "an `id` will be set by the server."
             )
-
         return self._id
 
-    # -- methods -- #
-
     async def unsubscribe(self) -> bool:
-        """
-        Unsubscribes from the subscription using the underlying manager assigned at
-        subscription creation.
-        """
         return await self._manager.unsubscribe(self)
 
 
-class LogsSubscription(EthSubscription):
+LogsSubscriptionType = EthSubscription["LogReceipt"]
+
+
+class LogsSubscription(LogsSubscriptionType):
     def __init__(
         self,
         address: Optional[
             Union[Address, ChecksumAddress, List[Address], List[ChecksumAddress]]
         ] = None,
         topics: Optional[List[HexStr]] = None,
-        handler: Optional[EthSubscriptionHandler] = None,
+        event: "AsyncContractEvent" = None,
+        handler: Optional[
+            EthSubscriptionHandler[LogsSubscriptionType, "LogReceipt"]
+        ] = None,
         label: Optional[str] = None,
     ) -> None:
+        self.event = event
         self.address = address
         self.topics = topics
 
@@ -114,10 +197,15 @@ class LogsSubscription(EthSubscription):
         )
 
 
-class NewHeadsSubscription(EthSubscription):
+NewHeadsSubscriptionType = EthSubscription["BlockData"]
+
+
+class NewHeadsSubscription(NewHeadsSubscriptionType):
     def __init__(
         self,
-        handler: Optional[EthSubscriptionHandler] = None,
+        handler: Optional[
+            EthSubscriptionHandler[NewHeadsSubscriptionType, "BlockData"]
+        ] = None,
         label: Optional[str] = None,
     ) -> None:
         super().__init__(
@@ -125,25 +213,36 @@ class NewHeadsSubscription(EthSubscription):
         )
 
 
-class PendingTxSubscription(EthSubscription):
+PendingTxSubscriptionType = EthSubscription[Union[HexBytes, TxData]]
+
+
+class PendingTxSubscription(PendingTxSubscriptionType):
     def __init__(
         self,
         full_transactions: bool = False,
-        handler: Optional[EthSubscriptionHandler] = None,
+        handler: Optional[
+            EthSubscriptionHandler[
+                EthSubscription[Union[HexBytes, TxData]], Union[HexBytes, TxData]
+            ]
+        ] = None,
         label: Optional[str] = None,
     ) -> None:
         self.full_transactions = full_transactions
+        self.result_type = TxData if full_transactions else HexBytes
         super().__init__(
-            ("newPendingTransactions", full_transactions),
-            handler=handler,
-            label=label,
+            ("newPendingTransactions", full_transactions), handler=handler, label=label
         )
 
 
-class SyncingSubscription(EthSubscription):
+SyncingSubscriptionType = EthSubscription[SyncProgress]
+
+
+class SyncingSubscription(SyncingSubscriptionType):
     def __init__(
         self,
-        handler: Optional[EthSubscriptionHandler] = None,
+        handler: Optional[
+            EthSubscriptionHandler[SyncingSubscriptionType, SyncProgress]
+        ] = None,
         label: Optional[str] = None,
     ) -> None:
         super().__init__(subscription_params=("syncing",), handler=handler, label=label)

--- a/web3/utils/subscriptions.py
+++ b/web3/utils/subscriptions.py
@@ -83,14 +83,14 @@ def handler_wrapper(
     async def wrapped_handler(
         context: EthSubscriptionContext[TSubscription, TSubscriptionResult],
     ) -> None:
-        sx = context.subscription
-        sx.handler_call_count += 1
-        sx.manager.total_handler_calls += 1
-        sx.manager.logger.debug(
+        sub = context.subscription
+        sub.handler_call_count += 1
+        sub.manager.total_handler_calls += 1
+        sub.manager.logger.debug(
             f"Subscription handler called.\n"
-            f"    label: {sx.label}\n"
-            f"    call count: {sx.handler_call_count}\n"
-            f"    total handler calls: {sx.manager.total_handler_calls}"
+            f"    label: {sub.label}\n"
+            f"    call count: {sub.handler_call_count}\n"
+            f"    total handler calls: {sub.manager.total_handler_calls}"
         )
         await handler(context)
 

--- a/web3/utils/subscriptions.py
+++ b/web3/utils/subscriptions.py
@@ -1,0 +1,149 @@
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Coroutine,
+    List,
+    Optional,
+    Sequence,
+    Union,
+)
+
+from eth_typing import (
+    Address,
+    ChecksumAddress,
+    HexStr,
+)
+
+from web3.exceptions import (
+    Web3ValueError,
+)
+
+if TYPE_CHECKING:
+    from web3 import AsyncWeb3  # noqa: F401
+    from web3.providers.persistent.subscription_manager import (
+        SubscriptionManager,
+    )
+    from web3.types import (
+        FilterParams,
+    )
+
+EthSubscriptionHandler = Callable[
+    ["AsyncWeb3", "EthSubscription", Any], Coroutine[Any, Any, None]
+]
+
+
+class EthSubscription:
+    """
+    A base class for all eth_subscription types.
+    """
+
+    _id: HexStr = None
+    _manager: "SubscriptionManager" = None
+
+    def __init__(
+        self,
+        subscription_params: Optional[Sequence[Any]] = None,
+        handler: Optional[EthSubscriptionHandler] = None,
+        label: Optional[str] = None,
+    ) -> None:
+        self._handler = handler
+        self._subscription_params = subscription_params
+        self._label = label
+
+    # -- properties -- #
+
+    @property
+    def subscription_params(self) -> Sequence[Any]:
+        return self._subscription_params
+
+    @subscription_params.setter
+    def subscription_params(self, value: Optional[Sequence[Any]]) -> None:
+        self._subscription_params = value
+
+    @property
+    def label(self) -> str:
+        if not self._label:
+            self._label = f"{self.__class__.__name__}{self.subscription_params}"
+        return self._label
+
+    @label.setter
+    def label(self, value: str) -> None:
+        self._label = value
+
+    @property
+    def id(self) -> HexStr:
+        if not self._id:
+            raise Web3ValueError(
+                "No `id` found for subscription. Once you are subscribed to this "
+                "subscription, an `id` will be set by the server."
+            )
+
+        return self._id
+
+    # -- methods -- #
+
+    async def unsubscribe(self) -> bool:
+        """
+        Unsubscribes from the subscription using the underlying manager assigned at
+        subscription creation.
+        """
+        return await self._manager.unsubscribe(self)
+
+
+class LogsSubscription(EthSubscription):
+    def __init__(
+        self,
+        address: Optional[
+            Union[Address, ChecksumAddress, List[Address], List[ChecksumAddress]]
+        ] = None,
+        topics: Optional[List[HexStr]] = None,
+        handler: Optional[EthSubscriptionHandler] = None,
+        label: Optional[str] = None,
+    ) -> None:
+        self.address = address
+        self.topics = topics
+
+        logs_filter: "FilterParams" = {}
+        if self.address:
+            logs_filter["address"] = self.address
+        if self.topics:
+            logs_filter["topics"] = self.topics
+        super().__init__(
+            subscription_params=("logs", logs_filter), handler=handler, label=label
+        )
+
+
+class NewHeadsSubscription(EthSubscription):
+    def __init__(
+        self,
+        handler: Optional[EthSubscriptionHandler] = None,
+        label: Optional[str] = None,
+    ) -> None:
+        super().__init__(
+            subscription_params=("newHeads",), handler=handler, label=label
+        )
+
+
+class PendingTxSubscription(EthSubscription):
+    def __init__(
+        self,
+        full_transactions: bool = False,
+        handler: Optional[EthSubscriptionHandler] = None,
+        label: Optional[str] = None,
+    ) -> None:
+        self.full_transactions = full_transactions
+        super().__init__(
+            ("newPendingTransactions", full_transactions),
+            handler=handler,
+            label=label,
+        )
+
+
+class SyncingSubscription(EthSubscription):
+    def __init__(
+        self,
+        handler: Optional[EthSubscriptionHandler] = None,
+        label: Optional[str] = None,
+    ) -> None:
+        super().__init__(subscription_params=("syncing",), handler=handler, label=label)


### PR DESCRIPTION
### What was wrong?

Related to Issue #3397

Working with many subscriptions is not ideal at the moment. In web3.py v7, we added significant support for `eth_subscribe` via the new `PersistentConnectionProvider` implementation. Though we've added support with parity to how `websockets` works, this still only left us with a raw API to handle messages as they come through the socket. We have JSON-RPC specifications of how subscriptions should be formed and the client returns a unique `id` per subscription. Since `PersistentConenctionProvider` classes are fully asynchronous, as they should be, we should implement an API that can leverage all of this in order to handle subscriptions asynchronously as they come in.

### How was it fixed?

- Implement a subscription manager class to manage all subscriptions under-the-hood. This manager can be accessed directly to deal with subscriptions as objects, rather than free-floating ids that are tracked. Each `EthSubscription` class can, and should be encouraged to, have a `handler` function passed to it so that it can properly handle the subscription as it comes in, rather than having the burden of listening and parsing based on message `id` be on the user.
- `w3.eth.subscribe` can now also accept a `handler` kwarg since all subscriptions are managed by the manager under-the-hood. It can also accept an `event` for "logs" subscriptions so that it may be easily parsed by the handler.
- Subscriptions can have descriptive labels for clearer log messages, if desired, instead of relying on an abstract subscription `id` to parse logs.
- The manager counts how many total handler calls have been issued and each subscription counts how many times its handler has been called.

---

In a separate PR we should add a significant docs overhaul for clearer communication on `PersistentConnectionProvider` usage as well as subscription management usage

### Todo:

- [x] Clean up commit history
- [x] Early documentation before a significant docs overhaul to highlight this usage more appropriately
- [x] Add tests
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![1000029633](https://github.com/user-attachments/assets/3d8d09ae-14d6-46c6-8129-44607e0d51c8)

