### PR TITLE
fix: change minimum pin to functioning version of `eth-tester` in `tester` extras install

### DIFF
--- a/newsfragments/3555.bugfix.rst
+++ b/newsfragments/3555.bugfix.rst
@@ -1,0 +1,1 @@
+Bump the eth-tester version to one that works in the tester dependency extras

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ extras_require = {
     "tester": [
         # Note: ethereum-maintained libraries in this list should be added to the
         # `install_pre_releases.py` script.
-        "eth-tester[py-evm]>=0.11.0b1,<0.13.0b1",
+        "eth-tester[py-evm]>=0.12.0b1,<0.13.0b1",
         "py-geth>=5.1.0",
     ],
     "dev": [


### PR DESCRIPTION
### What was wrong?

 I am not sure that 0.11.0b1 works with the latest web3 environment. I got an import error from `eth-account` in the eth-tester stuff, re: typed_transactions

### How was it fixed?

bumpity bumped

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
