### PR TITLE
Add Correct kwargs to AsyncHTTPProvider to allow graceful shutdown

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -214,6 +214,8 @@ AsyncHTTPProvider
         >>> # If you want to pass in your own session:
         >>> custom_session = ClientSession()
         >>> await w3.provider.cache_async_session(custom_session) # This method is an async method so it needs to be handled accordingly
+        >>> # when you're finished, disconnect:
+        >>> w3.provider.disconnect()
 
     Under the hood, the ``AsyncHTTPProvider`` uses the python
     `aiohttp <https://docs.aiohttp.org/en/stable/>`_ library for making requests.

--- a/newsfragments/3557.bugfix.rst
+++ b/newsfragments/3557.bugfix.rst
@@ -1,0 +1,1 @@
+Add a ``disconnect`` method to the AsyncHTTPProvider that closes all sessions and clears the cache

--- a/tests/integration/go_ethereum/test_goethereum_http.py
+++ b/tests/integration/go_ethereum/test_goethereum_http.py
@@ -160,7 +160,7 @@ class TestGoEthereumAsyncNetModuleTest(GoEthereumAsyncNetModuleTest):
 
 class TestGoEthereumAsyncEthModuleTest(GoEthereumAsyncEthModuleTest):
     @pytest.mark.asyncio
-    async def test_async_http_provider_disconnects_gracefully_reuses(
+    async def test_async_http_provider_disconnects_gracefully(
         self, async_w3, endpoint_uri
     ) -> None:
         w3_1 = async_w3

--- a/web3/_utils/http_session_manager.py
+++ b/web3/_utils/http_session_manager.py
@@ -18,6 +18,7 @@ from aiohttp import (
     ClientResponse,
     ClientSession,
     ClientTimeout,
+    TCPConnector,
 )
 from eth_typing import (
     URI,
@@ -174,7 +175,12 @@ class HTTPSessionManager:
         async with async_lock(self.session_pool, self._lock):
             if cache_key not in self.session_cache:
                 if session is None:
-                    session = ClientSession(raise_for_status=True)
+                    session = ClientSession(
+                        raise_for_status=True,
+                        connector=TCPConnector(
+                            force_close=True, enable_cleanup_closed=True
+                        ),
+                    )
 
                 cached_session, evicted_items = self.session_cache.cache(
                     cache_key, session
@@ -213,7 +219,12 @@ class HTTPSessionManager:
                     )
 
                     # replace stale session with a new session at the cache key
-                    _session = ClientSession(raise_for_status=True)
+                    _session = ClientSession(
+                        raise_for_status=True,
+                        connector=TCPConnector(
+                            force_close=True, enable_cleanup_closed=True
+                        ),
+                    )
                     cached_session, evicted_items = self.session_cache.cache(
                         cache_key, _session
                     )

--- a/web3/_utils/http_session_manager.py
+++ b/web3/_utils/http_session_manager.py
@@ -301,9 +301,3 @@ class HTTPSessionManager:
                 "Some evicted async sessions were not properly closed: "
                 f"{evicted_sessions}"
             )
-
-    async def close_all_sessions(self, session_cache: SimpleCache) -> None:
-        for _, session in session_cache.items():
-            await session.close()
-        # Give time for the socket to close so a ResourceWarning doesn't get emitted
-        await asyncio.sleep(0.1)

--- a/web3/_utils/http_session_manager.py
+++ b/web3/_utils/http_session_manager.py
@@ -301,3 +301,9 @@ class HTTPSessionManager:
                 "Some evicted async sessions were not properly closed: "
                 f"{evicted_sessions}"
             )
+
+    async def close_all_sessions(self, session_cache: SimpleCache) -> None:
+        for _, session in session_cache.items():
+            await session.close()
+        # Give time for the socket to close so a ResourceWarning doesn't get emitted
+        await asyncio.sleep(0.1)

--- a/web3/providers/rpc/async_rpc.py
+++ b/web3/providers/rpc/async_rpc.py
@@ -177,3 +177,10 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
         self.logger.debug("Received batch response HTTP.")
         responses_list = cast(List[RPCResponse], self.decode_rpc_response(raw_response))
         return sort_batch_response_by_response_ids(responses_list)
+
+    async def disconnect(self) -> None:
+        cache = self._request_session_manager.session_cache
+        await self._request_session_manager.close_all_sessions(cache)
+        cache.clear()
+
+        self.logger.info(f"Successfully disconnected from: {self.endpoint_uri}")

--- a/web3/providers/rpc/async_rpc.py
+++ b/web3/providers/rpc/async_rpc.py
@@ -181,14 +181,6 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
     async def disconnect(self) -> None:
         cache = self._request_session_manager.session_cache
         for _, session in cache.items():
-            # workaround for aiohttp issue:
-            connectors = [
-                conn[0] for conns in session.connector._conns.values() for conn in conns
-            ]
-            transports = [conn.transport for conn in connectors if conn.transport]
-            for transport in transports:
-                transport.get_extra_info("socket").shutdown(2)
-            # end workaround
             await session.close()
         cache.clear()
 


### PR DESCRIPTION
### What was wrong?
The session wasn't being properly closed in the AsyncHTTPProvider if there was more than one w3 instance, and warnings were being emitted.

Closes #3524 

### How was it fixed?

Added an async context manager where needed. 

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://www.zumalka.com/cdn/shop/articles/adorable_baby_raccoon_being_held.jpg?v=1720680175)
