### PR TITLE
fix: typos in documentation files

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -872,7 +872,7 @@ Improved Documentation
 
 - Add MEV blocking tutorial to Resources docs page (`#3072 <https://github.com/ethereum/web3.py/issues/3072>`__)
 - Fix documentation around current state of ``get_logs()`` usage and arguments. (`#3073 <https://github.com/ethereum/web3.py/issues/3073>`__)
-- Add an Ape hackathon kit to Resources documenation page (`#3082 <https://github.com/ethereum/web3.py/issues/3082>`__)
+- Add an Ape hackathon kit to Resources documentation page (`#3082 <https://github.com/ethereum/web3.py/issues/3082>`__)
 
 
 web3.py v6.8.0 (2023-08-02)

--- a/tests/core/contracts/test_contract_events_build_filter.py
+++ b/tests/core/contracts/test_contract_events_build_filter.py
@@ -26,7 +26,7 @@ def test_build_filter_topic_signature(w3, math_contract_abi):
 def test_build_filter_resetting_build_filter_properties(w3, math_contract_abi):
     contract = w3.eth.contract(abi=math_contract_abi)
     filter_builder = contract.events.Increased.build_filter()
-    # Address is setable from undeployed contract class
+    # Address is settable from undeployed contract class
     filter_builder.address = b"\x10" * 40
     filter_builder.from_block = 0
     filter_builder.to_block = "latest"


### PR DESCRIPTION
Corrected `documenation` to `documentation`
Corrected `setable` to `settable`
![cuteanim](https://github.com/user-attachments/assets/f55dffcb-a126-42e0-8df5-c6ecd660d9d1)

