### PR TITLE
Add Hardware Security Module to accounts documentation

### DIFF
--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -503,6 +503,6 @@ Example code for using Google Cloud HSM:
   print(f"Transaction hash: {receipt['transactionHash'].hex()}")
   print(f"From: {receipt['from']}")
   print(f"To: {receipt['to']}")
-  print(f"Gas used: {receipt['gasUsed']}")  
+  print(f"Gas used: {receipt['gasUsed']}")
 
 Note that HSM does not protect against supply chain attacks, as any software running on the cloud having access to the HSM module can still sign arbitrary transactions. You still need to secure your server access e.g. with two-factor authentication and have audit logs of the software deployments.

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -460,18 +460,16 @@ Generally, HSM refers to techniques in which a cloud service provider offers a s
 
 - HSM should always be used if you need to have a private key available on a server, so-called "hot wallet"
 - HSMs are for a general use case, not just for Ethereum or cryptocurrencies, encrypting files being the most popular one
-- HSM value promise is that private key cannot be copied and thus leaked, or exported
+- HSM value promise is that private key cannot be copied and thus leaked or exported
 - HSM services often provide audit records to see what has been signed and by who
 
-Note that HSM does not protect against supply chain attacks, as any software running on the cloud having access to the HSM module can still sign arbitrary transactions. You still need to secure your server access e.g. with two-factor authentication and have audit logs of the software deployments.
-
-HSM services are available from [Google Cloud](https://cloud.google.com/kms/docs/hsm), AWS and others.
+HSM services are available from [Google Cloud](https://cloud.google.com/kms/docs/hsm), Amazon AWS and others.
 
 To use HSM private keys in Web3.py, see
 
 - [web3-google-hsm](https://github.com/Ankvik-Tech-Labs/web3-google-hsm) - Google cloud HSM signing for Web3.py and Ethereum
 
-Example:
+Example code for using Google Cloud HSM:
 
 .. code-block:: python
 
@@ -507,3 +505,4 @@ Example:
   print(f"To: {receipt['to']}")
   print(f"Gas used: {receipt['gasUsed']}")  
 
+Note that HSM does not protect against supply chain attacks, as any software running on the cloud having access to the HSM module can still sign arbitrary transactions. You still need to secure your server access e.g. with two-factor authentication and have audit logs of the software deployments.

--- a/docs/web3.eth.account.rst
+++ b/docs/web3.eth.account.rst
@@ -474,12 +474,12 @@ Example code for using Google Cloud HSM:
 .. code-block:: python
 
   from web3_google_hsm.accounts.gcp_kms_account import GCPKmsAccount
-  
+
   account = GCPKmsAccount()
-  
+
   # Get the Ethereum address derived from your GCP KMS key
   print(f"GCP KMS Account address: {account.address}")
-  
+
   tx = {
       "from": account.address,
       "chain_id": w3.eth.chain_id,
@@ -491,15 +491,15 @@ Example code for using Google Cloud HSM:
       "gas_limit": 1000000,
       "gas_price": 300000000000,
   }
-  
+
   # Convert dict to Transaction object and sign
   signed_tx = account.sign_transaction(Transaction.from_dict(tx))
 
   tx_hash = w3.eth.send_raw_transaction(signed_tx)
-  
+
   # Wait for transaction receipt
   receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
-  
+
   print(f"Transaction hash: {receipt['transactionHash'].hex()}")
   print(f"From: {receipt['from']}")
   print(f"To: {receipt['to']}")


### PR DESCRIPTION
Explain HSM, add an example how to use

### What was wrong?

There was no information how to use hardware security module keys with Web3.py.

### How was it fixed?

Added documentation bit to accounts, refer to Google Cloud HSM example.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

```
                                       /;    ;\
                                   __  \\____//
                                  /{_\_/   `'\____
                                  \___   (o)  (o  }
       _____________________________/          :--'
   ,-,'`@@@@@@@@       @@@@@@         \_    `__\
  ;:(  @@@@@@@@@        @@@             \___(o'o)
  :: )  @@@@          @@@@@@        ,'@@(  `===='
  :: : @@@@@:          @@@@         `@@@:
  :: \  @@@@@:       @@@@@@@)    (  '@@@'
  ;; /\      /`,    @@@@@@@@@\   :@@@@@)
  ::/  )    {_----------------:  :~`,~~;
 ;;'`; :   )                  :  / `; ;   
;;;; : :   ;                  :  ;  ; :
`'`' / :  :                   :  :  : :
    )_ \__;      ";"          :_ ;  \_\       `,','
    :__\  \    * `,'*         \  \  :  \   *  8`;'*  *
        `^'     \ :/           `^'  `-^-'   \v/ :  \/
----------  Targon (Ed Wisniewski)
```
