### PR TITLE
Fix typo in integration tests documentation

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -31,7 +31,7 @@ A block as returned by `web3.eth.get_block` that has a single transaction.
 
 #### `math_contract`
 
-An deployed Contract instance of the *Math* contract found in
+A deployed Contract instance of the *Math* contract found in
 `web3._utils.contract_sources.MathContract.sol`.
 
 #### `keyfile_account_address`


### PR DESCRIPTION
This pull request corrects a minor typographical error in the `README.md` file located in the `tests/integration` directory. The change improves clarity in the documentation for deployed contract instances.

### What was wrong?

The documentation contained a grammatical error: "An deployed Contract" instead of "A deployed Contract."
![scale_1200](https://github.com/user-attachments/assets/9586b522-ea24-4b00-aff9-5d54cc9d2f6e)
