### PR TITLE
docs: typo fix Update code_of_conduct.rst

### DIFF
--- a/docs/code_of_conduct.rst
+++ b/docs/code_of_conduct.rst
@@ -5,7 +5,7 @@ Our Pledge
 ~~~~~~~~~~
 
 In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
+contributors and maintainers pledge to make participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, gender identity and expression, level of experience,
 education, socio-economic status, nationality, personal appearance, race,


### PR DESCRIPTION
### What was wrong?

The phrase "pledge to making" should be "pledge to make" for correct grammar.

Corrected.

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![It's for you!](https://www.stuff.co.nz/media/images/9Tzi8ywRz924XE3uHaD6DS7nc5socMXiw3+FeqnKLTdkdtXvegWcf9ODvVUZVsb6kjkTT9nhVAF17Ivgr8wTeWukiUcYTQjAz8ndFfa8JJw=?resolution=620x350)

