### PR TITLE
 Grammar Fixes in Event Scanner Documentation

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -555,7 +555,7 @@ The script can be run with: ``python ./eventscanner.py <your JSON-RPC API URL>``
             # # (slow down scan after starting to get hits)
             self.chunk_size_decrease = 0.5
 
-            # Factor how fast we increase chunk size if no results found
+            # Factor how fast we increase chunk size if no results are found
             self.chunk_size_increase = 2.0
 
         @property
@@ -681,7 +681,7 @@ The script can be run with: ``python ./eventscanner.py <your JSON-RPC API URL>``
             """
 
             if event_found_count > 0:
-                # When we encounter first events, reset the chunk size window
+                # When we encountered first events, reset the chunk size window
                 current_chuck_size = self.min_scan_chunk_size
             else:
                 current_chuck_size *= self.chunk_size_increase


### PR DESCRIPTION

1. Added missing "are":
- Factor how fast we increase chunk size if no results found
+ Factor how fast we increase chunk size if no results are found

2. Fixed verb tense for consistency:
- When we encounter first events, reset the chunk size window
+ When we encountered first events, reset the chunk size window

Reason: Improved grammar and tense consistency in documentation comments for better readability. Documentation-only changes, no functional impact.
