### PR TITLE
fix: docs and test name typos

### DIFF
--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -555,7 +555,7 @@ The script can be run with: ``python ./eventscanner.py <your JSON-RPC API URL>``
             # # (slow down scan after starting to get hits)
             self.chunk_size_decrease = 0.5
 
-            # Factor how fast we increase chunk size if no results found
+            # Factor how fast we increase chunk size if no results are found
             self.chunk_size_increase = 2.0
 
         @property

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -31,7 +31,7 @@ legacy ``WebsocketProvider``. The ``LegacyWebSocketProvider`` has been deprecate
 If migrating from ``WebSocketProviderV2`` to ``WebSocketProvider``, you can expect the
 following changes:
 
-- Instantiation no longer requires the ``persistant_websocket`` method:
+- Instantiation no longer requires the ``persistent_websocket`` method:
 
   .. code-block:: python
 

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -42,7 +42,7 @@ Tutorials
 - `Decode a signed transaction <https://snakecharmers.ethereum.org/web3-py-patterns-decoding-signed-transactions/>`__
 - Find a historical contract `revert reason <https://snakecharmers.ethereum.org/web3py-revert-reason-parsing/>`__
 - Generate a `vanity address <https://snakecharmers.ethereum.org/web3-py-patterns-mining-addresses/>`__
-- Similate transactions with `call state overrides <https://snakecharmers.ethereum.org/web3-py-patterns-eth_call-overrides/>`__
+- Simulate transactions with `call state overrides <https://snakecharmers.ethereum.org/web3-py-patterns-eth_call-overrides/>`__
 - Configure web3 for `JSON-RPC fallback and MEV blocker providers <https://web3-ethereum-defi.readthedocs.io/tutorials/multi-rpc-configuration.html>`__
 
 

--- a/tests/core/providers/test_tester_provider.py
+++ b/tests/core/providers/test_tester_provider.py
@@ -77,7 +77,7 @@ def test_eth_tester_provider_properly_handles_eth_tester_key_error_messages():
     assert response["error"]["message"] == "Unknown RPC Endpoint: eth_blockNumber"
 
 
-def test_eth_tester_provider_properly_handles_eth_tester_not_implmented_error_messages(
+def test_eth_tester_provider_properly_handles_eth_tester_not_implemented_error_messages(
     mocker,
 ):
     mocker.patch(


### PR DESCRIPTION
### What was wrong?

typos

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/0b1b3106-2c81-42bd-85d9-ef3afe16b870)
