### PR TITLE
bugfix: Fix gethdev ipc path for auto.gethdev

### DIFF
--- a/newsfragments/3576.bugfix.rst
+++ b/newsfragments/3576.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug related to building the ipc path for connecting to a geth ``--dev`` instance via ``web3.auto.gethdev``.

--- a/tests/core/providers/test_auto_provider.py
+++ b/tests/core/providers/test_auto_provider.py
@@ -55,7 +55,19 @@ def test_load_provider_from_env(monkeypatch, uri, expected_type, expected_attrs)
 
 
 def test_get_dev_ipc_path(monkeypatch, tmp_path):
-    uri = str(tmp_path)
+    # test default path
+    path = get_dev_ipc_path()
+    assert path == "/tmp/geth.ipc"
+
+    uri = str(tmp_path) + "/geth.ipc"
+
+    # test setting the "TMPDIR" environment variable
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    path = get_dev_ipc_path()
+    assert path == uri
+    monkeypatch.delenv("TMPDIR")  # reset
+
+    # test with WEB3_PROVIDER_URI set
     monkeypatch.setenv("WEB3_PROVIDER_URI", uri)
     path = get_dev_ipc_path()
     assert path == uri

--- a/tests/core/providers/test_ipc_provider.py
+++ b/tests/core/providers/test_ipc_provider.py
@@ -97,7 +97,7 @@ def test_get_default_ipc_path(platform, expected_result, expected_error):
     "platform, expected_result, expected_error",
     [
         ("darwin", "/var/path/to/tmp/T/geth.ipc", None),
-        ("linux", "/tmp/geth.ipc", None),
+        ("linux", "/var/path/to/tmp/T/geth.ipc", None),
         ("freebsd", "/tmp/geth.ipc", None),
         ("win32", r"\\.\pipe\geth.ipc", None),
         (
@@ -119,7 +119,7 @@ def test_get_dev_ipc_path_(provider_env_uri, platform, expected_result, expected
             os.environ,
             {
                 "TMPDIR": "/var/path/to/tmp/T/",
-                "WEB3_PROVIDER_URI": provider_env_uri,
+                "WEB3_PROVIDER_URI": provider_env_uri or "",
             },
         ):
             if provider_env_uri:
@@ -130,7 +130,7 @@ def test_get_dev_ipc_path_(provider_env_uri, platform, expected_result, expected
                 ):
                     get_dev_ipc_path()
             else:
-                assert get_dev_ipc_path().endswith(expected_result)
+                assert get_dev_ipc_path() == expected_result
 
 
 @pytest.fixture

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -116,14 +116,15 @@ def get_default_ipc_path() -> str:
 
 
 def get_dev_ipc_path() -> str:
-    if os.environ.get("WEB3_PROVIDER_URI", ""):
-        return os.environ.get("WEB3_PROVIDER_URI")
+    web3_provider_uri = os.environ.get("WEB3_PROVIDER_URI", "")
+    if web3_provider_uri and "geth.ipc" in web3_provider_uri:
+        return web3_provider_uri
 
-    elif sys.platform == "darwin":
-        tmpdir = os.environ.get("TMPDIR", "")
+    elif sys.platform == "darwin" or sys.platform.startswith("linux"):
+        tmpdir = os.environ.get("TMPDIR", "/tmp")
         return os.path.expanduser(os.path.join(tmpdir, "geth.ipc"))
 
-    elif sys.platform.startswith("linux") or sys.platform.startswith("freebsd"):
+    elif sys.platform.endswith("freebsd"):
         return os.path.expanduser(os.path.join("/tmp", "geth.ipc"))
 
     elif sys.platform == "win32":


### PR DESCRIPTION
### What was wrong?

There were some minor hiccups in establishing a connection to geth dev using `web3.auto.gethdev`. If the `WEB3_PROVIDER_URI` environment variable was set, it would automatically override the ipc path.

### How was it fixed?

- Check to make sure it points to a `geth.ipc`
- Else, build the path from the `TMPDIR` environment variable, defaulting to `/tmp/geth.ipc`.

`TMPDIR` is a unix and linux [convention](https://www.ibm.com/docs/en/idr/10.2.1?topic=windows-setting-tmpdir-environment-variable-linux-unix), so this was extended for linux in this PR. I think this is technically still a bugfix rather than a breaking change, given the intended purpose, but open to another interpretation as well.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

`0_o`
