### PR TITLE
Get current loop from within extended signal handler

### DIFF
--- a/web3/main.py
+++ b/web3/main.py
@@ -540,7 +540,10 @@ class AsyncWeb3(BaseWeb3):
     )
     def __await__(self) -> Generator[Any, None, Self]:
         async def __async_init__() -> Self:
-            await self.provider.connect()
+            provider = cast("PersistentConnectionProvider", self.provider)
+            await provider.connect()
+            # set signal handlers since not within a context manager
+            provider._set_signal_handlers()
             return self
 
         return __async_init__().__await__()

--- a/web3/providers/persistent/persistent.py
+++ b/web3/providers/persistent/persistent.py
@@ -270,14 +270,13 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
         raise NotImplementedError("Must be implemented by subclasses")
 
     def _set_signal_handlers(self) -> None:
-        loop = asyncio.get_event_loop()
-
         def extended_handler(sig: int, frame: Any, existing_handler: Any) -> None:
-            loop.create_task(self.disconnect())
+            loop = asyncio.get_event_loop()
 
             # invoke the existing handler, if callable
             if callable(existing_handler):
                 existing_handler(sig, frame)
+            loop.create_task(self.disconnect())
 
         existing_sigint_handler = signal.getsignal(signal.SIGINT)
         existing_sigterm_handler = signal.getsignal(signal.SIGTERM)

--- a/web3/providers/persistent/persistent.py
+++ b/web3/providers/persistent/persistent.py
@@ -177,7 +177,6 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
                 self.logger.info(
                     f"Successfully connected to: {self.get_endpoint_uri_or_ipc_path()}"
                 )
-                self._set_signal_handlers()
                 break
             except (WebSocketException, OSError) as e:
                 if _connection_attempts == self._max_connection_retries:


### PR DESCRIPTION
### What was wrong?

- Extending signal handlers to properly disconnect persistent connection providers, instead of waiting a long time for a connection timeout, was introduced in the recent subscription management PR ([commit](https://github.com/ethereum/web3.py/pull/3554/commits/49bb60d9d847aba1f99ed5b8cf68487439b4e0c1)). This would happen when not inside a context manager, `e.g. w3 = await AsyncWeb3(WebSocketProvider(...))`, if for example a `KeyboardInterrupt` was triggered by the user.

- This had some side effects when running `pytest`, since they have their own signal handler. If persistent connection provider tests were run along with any other tests, the disconnect task would interfere with pytest's handler.

### How was it fixed?

- Only add these signal handlers when instantiation and provider lifecycle is not being managed by a context manager i.e. `await AsyncWeb3(Provider(...))`.
- If we get the current loop when the extended handler is called (call it from within the handler), the issue is no longer present.

### Testing

Compare the command below with and without these changes:

- `control` + `c` (KeyboardInterrupt) during `pytest tests/core/providers`

### Todo:

- [x] Clean up commit history
- There has been no release since the sub manager changes, so I don't believe this needs a release note if this change is included in the next release.

#### Cute Animal Picture

<img width="688" alt="Screenshot 2025-01-13 at 14 57 30" src="https://github.com/user-attachments/assets/d060d877-a7dd-469f-afa2-b1268a904d98" />
