### PR TITLE
Add event topic and fix sub manager docs

### DIFF
--- a/newsfragments/3578.feature.rst
+++ b/newsfragments/3578.feature.rst
@@ -1,0 +1,1 @@
+Implement a ``topic`` property for contract events to retrieve the topic for the event.

--- a/tests/core/contracts/conftest.py
+++ b/tests/core/contracts/conftest.py
@@ -804,6 +804,26 @@ async def async_nested_tuple_contract_with_decode_tuples(
 
 
 @pytest_asyncio.fixture
+async def async_event_contract(
+    async_w3, async_wait_for_transaction, async_wait_for_block, address_conversion_func
+):
+    async_event_contract_factory = async_w3.eth.contract(**EVENT_CONTRACT_DATA)
+
+    await async_wait_for_block(async_w3)
+    deploy_txn_hash = await async_event_contract_factory.constructor().transact(
+        {"gas": 1000000}
+    )
+    deploy_receipt = await async_wait_for_transaction(async_w3, deploy_txn_hash)
+    contract_address = address_conversion_func(deploy_receipt["contractAddress"])
+
+    bytecode = await async_w3.eth.get_code(contract_address)
+    assert bytecode == async_event_contract_factory.bytecode_runtime
+    event_contract = async_event_contract_factory(address=contract_address)
+    assert event_contract.address == contract_address
+    return event_contract
+
+
+@pytest_asyncio.fixture
 async def async_ambiguous_event_contract(async_w3, address_conversion_func):
     async_ambiguous_event_contract_factory = async_w3.eth.contract(
         **AMBIGUOUS_EVENT_NAME_CONTRACT_DATA

--- a/web3/_utils/module_testing/persistent_connection_provider.py
+++ b/web3/_utils/module_testing/persistent_connection_provider.py
@@ -542,14 +542,13 @@ class PersistentConnectionProviderTest:
         sub_manager = async_w3.subscription_manager
 
         event = async_emitter_contract.events.LogIndexedAndNotIndexed
-        event_topic = async_w3.keccak(text=event.abi_element_identifier).to_0x_hex()
 
         logs_handler_test = SubscriptionHandlerTest()
         sub_id = await async_w3.eth.subscribe(
             "logs",
             {
                 "address": async_emitter_contract.address,
-                "topics": [HexStr(event_topic)],
+                "topics": [event.topic],
             },
             handler=logs_handler,
             handler_context={

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -175,6 +175,7 @@ class BaseContractEvent:
             self.abi = abi
 
         self.signature = abi_to_signature(self.abi)
+        self.topic = encode_hex(keccak(text=self.signature))
 
         if argument_names:
             self.argument_names = argument_names
@@ -204,6 +205,7 @@ class BaseContractEvent:
 
     def _set_event_info(self) -> None:
         self.abi = self._get_event_abi()
+        self.topic = encode_hex(keccak(text=self.signature))
 
     @combomethod
     def process_receipt(

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -165,6 +165,7 @@ class BaseContractEvent:
     argument_types: Tuple[str, ...] = tuple()
     args: Any = None
     kwargs: Any = None
+    _topic: HexStr = None
 
     def __init__(self, *argument_names: str, abi: Optional[ABIEvent] = None) -> None:
         self.abi_element_identifier = type(self).__name__
@@ -175,7 +176,6 @@ class BaseContractEvent:
             self.abi = abi
 
         self.signature = abi_to_signature(self.abi)
-        self.topic = encode_hex(keccak(text=self.signature))
 
         if argument_names:
             self.argument_names = argument_names
@@ -188,6 +188,12 @@ class BaseContractEvent:
         if self.abi:
             return f"<Event {abi_to_signature(self.abi)}>"
         return f"<Event {get_abi_element_signature(self.abi_element_identifier)}>"
+
+    @property
+    def topic(self) -> HexStr:
+        if self._topic is None:
+            self._topic = encode_hex(keccak(text=self.signature))
+        return self._topic
 
     @combomethod
     def _get_event_abi(cls) -> ABIEvent:
@@ -205,7 +211,6 @@ class BaseContractEvent:
 
     def _set_event_info(self) -> None:
         self.abi = self._get_event_abi()
-        self.topic = encode_hex(keccak(text=self.signature))
 
     @combomethod
     def process_receipt(


### PR DESCRIPTION
### What was wrong?

- The code block was not correct for subscription manager docs.
- Getting the contract event's topic was much too difficult.

### How was it fixed?

- Fix subscription manager docs.
- Add `topic` property to `BaseContractEvent`.
- Add topic tests.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="724" alt="Screenshot 2025-01-15 at 11 40 56" src="https://github.com/user-attachments/assets/10b3de8d-6def-4540-83c7-4a6a697d5321" />
