### PR TITLE
Refactor for duplicate code in contract internal implementations

### DIFF
--- a/newsfragments/3579.internal.rst
+++ b/newsfragments/3579.internal.rst
@@ -1,0 +1,1 @@
+Move duplicate code into base class in (1) ContractFunction and AsyncContractFunction, (2) ContractEvents and AsyncContractEvents, and (3) ContractFunctions and AsyncContractFunctions.

--- a/newsfragments/3579.internal.rst
+++ b/newsfragments/3579.internal.rst
@@ -1,1 +1,1 @@
-Move duplicate code into base class in (1) ContractFunction and AsyncContractFunction, (2) ContractEvents and AsyncContractEvents, and (3) ContractFunctions and AsyncContractFunctions.
+Move duplicate code into ``BaseContract`` class from ``Contract`` and ``AsyncContract``. (1) ``ContractFunction`` and ``AsyncContractFunction`` (2) ``ContractFunctions`` and ``AsyncContractFunctions``, (3) ``ContractEvent`` and ``AsyncContractEvent``, and (4) ``ContractEvents`` and ``AsyncContractEvents``.

--- a/web3/contract/async_contract.py
+++ b/web3/contract/async_contract.py
@@ -46,7 +46,6 @@ from web3._utils.compat import (
 )
 from web3._utils.contracts import (
     async_parse_block_identifier,
-    copy_contract_event,
 )
 from web3._utils.datatypes import (
     PropertyCheckingFactory,
@@ -105,9 +104,6 @@ if TYPE_CHECKING:
 class AsyncContractEvent(BaseContractEvent):
     # mypy types
     w3: "AsyncWeb3"
-
-    def __call__(self, *args: Any, **kwargs: Any) -> Self:
-        return copy_contract_event(self, *args, **kwargs)
 
     @combomethod
     async def get_logs(

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -58,7 +58,11 @@ from web3._utils.abi_element_identifiers import (
     FallbackFn,
     ReceiveFn,
 )
+from web3._utils.compat import (
+    Self,
+)
 from web3._utils.contracts import (
+    copy_contract_function,
     decode_transaction_data,
     encode_abi,
     prepare_transaction,
@@ -118,12 +122,15 @@ from web3.types import (
     EventData,
     FilterParams,
     LogReceipt,
+    StateOverride,
     TContractFn,
     TxParams,
     TxReceipt,
 )
 from web3.utils.abi import (
+    _filter_by_argument_count,
     _get_any_abi_signature_with_name,
+    _mismatched_abi_error_diagnosis,
     check_if_arguments_can_be_encoded,
     get_abi_element,
     get_abi_element_info,
@@ -721,11 +728,121 @@ class BaseContractFunction:
             return _repr + ">"
         return f"<Function {get_abi_element_signature(self.abi_element_identifier)}>"
 
+    def __call__(self, *args: Any, **kwargs: Any) -> Self:
+        # When a function is called, check arguments to obtain the correct function
+        # in the contract. self will be used if all args and kwargs are
+        # encodable to self.abi, otherwise the correct function is obtained from
+        # the contract.
+        if (
+            self.abi_element_identifier in [FallbackFn, ReceiveFn]
+            or self.abi_element_identifier == "constructor"
+        ):
+            return copy_contract_function(self, *args, **kwargs)
+
+        all_functions = cast(
+            List[ABIFunction],
+            filter_abi_by_type(
+                "function",
+                self.contract_abi,
+            ),
+        )
+        # Filter functions by name to obtain function signatures
+        function_name = get_name_from_abi_element_identifier(
+            self.abi_element_identifier
+        )
+        function_abis = [
+            function for function in all_functions if function["name"] == function_name
+        ]
+        num_args = len(args) + len(kwargs)
+        function_abis_with_arg_count = cast(
+            List[ABIFunction],
+            _filter_by_argument_count(
+                num_args,
+                function_abis,
+            ),
+        )
+
+        if not len(function_abis_with_arg_count):
+            # Build an ABI without arguments to determine if one exists
+            function_abis_with_arg_count = [
+                ABIFunction({"type": "function", "name": function_name})
+            ]
+
+        # Check that arguments in call match a function ABI
+        num_attempts = 0
+        function_abi_matches = []
+        contract_function = None
+        for abi in function_abis_with_arg_count:
+            try:
+                num_attempts += 1
+
+                # Search for a function ABI that matches the arguments used
+                function_abi_matches.append(
+                    cast(
+                        ABIFunction,
+                        get_abi_element(
+                            function_abis,
+                            abi_to_signature(abi),
+                            *args,
+                            abi_codec=self.w3.codec,
+                            **kwargs,
+                        ),
+                    )
+                )
+            except MismatchedABI:
+                # ignore exceptions
+                continue
+
+        if len(function_abi_matches) == 1:
+            function_abi = function_abi_matches[0]
+            if abi_to_signature(self.abi) == abi_to_signature(function_abi):
+                contract_function = self
+            else:
+                # Found a match that is not self
+                contract_function = self.__class__.factory(
+                    abi_to_signature(function_abi),
+                    w3=self.w3,
+                    contract_abi=self.contract_abi,
+                    address=self.address,
+                    abi_element_identifier=abi_to_signature(function_abi),
+                    abi=function_abi,
+                )
+        else:
+            for abi in function_abi_matches:
+                if abi_to_signature(self.abi) == abi_to_signature(abi):
+                    contract_function = self
+                    break
+            else:
+                # Raise exception if multiple found
+                raise MismatchedABI(
+                    _mismatched_abi_error_diagnosis(
+                        function_name,
+                        self.contract_abi,
+                        len(function_abi_matches),
+                        num_args,
+                        *args,
+                        abi_codec=self.w3.codec,
+                        **kwargs,
+                    )
+                )
+
+        return copy_contract_function(contract_function, *args, **kwargs)
+
     @classmethod
-    def factory(
-        cls, class_name: str, **kwargs: Any
-    ) -> Union["ContractFunction", "AsyncContractFunction"]:
+    def factory(cls, class_name: str, **kwargs: Any) -> Self:
         return PropertyCheckingFactory(class_name, (cls,), kwargs)()
+
+    def call(
+        self,
+        transaction: Optional[TxParams] = None,
+        block_identifier: Optional[BlockIdentifier] = None,
+        state_override: Optional[StateOverride] = None,
+        ccip_read_enabled: Optional[bool] = None,
+    ) -> Any:
+        """
+        Should be implemented by child class.
+        """
+        raise NotImplementedError("This method should be implemented by child class")
 
 
 class BaseContractFunctions:

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -806,13 +806,11 @@ class BaseContractFunction:
                 ABIFunction({"type": "function", "name": function_name})
             ]
 
-        # Check that arguments in call match a function ABI
-        num_attempts = 0
         function_abi_matches = []
         contract_function = None
         for abi in function_abis_with_arg_count:
             try:
-                num_attempts += 1
+                pass
 
                 # Search for a function ABI that matches the arguments used
                 function_abi_matches.append(
@@ -878,9 +876,12 @@ class BaseContractFunction:
         ccip_read_enabled: Optional[bool] = None,
     ) -> Any:
         """
-        Should be implemented by child class.
+        Implementation of ``call`` should create a callable contract function
+        and execute it using the `eth_call` interface.
         """
-        raise NotImplementedError("This method should be implemented in the inherited class")
+        raise NotImplementedError(
+            "This method should be implemented in the inherited class"
+        )
 
 
 class BaseContractFunctions(Generic[TContractFn]):

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -880,7 +880,7 @@ class BaseContractFunction:
         """
         Should be implemented by child class.
         """
-        raise NotImplementedError("This method should be implemented by child class")
+        raise NotImplementedError("This method should be implemented in the inherited class")
 
 
 class BaseContractFunctions(Generic[TContractFn]):

--- a/web3/contract/base_contract.py
+++ b/web3/contract/base_contract.py
@@ -63,6 +63,7 @@ from web3._utils.compat import (
     Self,
 )
 from web3._utils.contracts import (
+    copy_contract_event,
     copy_contract_function,
     decode_transaction_data,
     encode_abi,
@@ -198,6 +199,9 @@ class BaseContractEvent:
         if self.abi:
             return f"<Event {abi_to_signature(self.abi)}>"
         return f"<Event {get_abi_element_signature(self.abi_element_identifier)}>"
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Self:
+        return copy_contract_event(self, *args, **kwargs)
 
     @property
     def topic(self) -> HexStr:
@@ -810,8 +814,6 @@ class BaseContractFunction:
         contract_function = None
         for abi in function_abis_with_arg_count:
             try:
-                pass
-
                 # Search for a function ABI that matches the arguments used
                 function_abi_matches.append(
                     cast(

--- a/web3/contract/contract.py
+++ b/web3/contract/contract.py
@@ -30,7 +30,6 @@ from hexbytes import (
 
 from web3._utils.abi import (
     fallback_func_abi_exists,
-    get_name_from_abi_element_identifier,
     receive_func_abi_exists,
 )
 from web3._utils.abi_element_identifiers import (
@@ -84,9 +83,6 @@ from web3.contract.utils import (
     transact_with_contract_function,
 )
 from web3.exceptions import (
-    ABIFunctionNotFound,
-    NoABIFound,
-    NoABIFunctionsFound,
     Web3AttributeError,
     Web3TypeError,
     Web3ValidationError,
@@ -97,9 +93,6 @@ from web3.types import (
     EventData,
     StateOverride,
     TxParams,
-)
-from web3.utils.abi import (
-    _get_any_abi_signature_with_name,
 )
 
 if TYPE_CHECKING:
@@ -412,46 +405,6 @@ class ContractFunctions(BaseContractFunctions[ContractFunction]):
         decode_tuples: Optional[bool] = False,
     ) -> None:
         super().__init__(abi, w3, ContractFunction, address, decode_tuples)
-
-    def __iter__(self) -> Iterable["ContractFunction"]:
-        if not hasattr(self, "_functions") or not self._functions:
-            return
-
-        for func in self._functions:
-            yield self[abi_to_signature(func)]
-
-    def __getattr__(self, function_name: str) -> "ContractFunction":
-        if super().__getattribute__("abi") is None:
-            raise NoABIFound(
-                "There is no ABI found for this contract.",
-            )
-        elif "_functions" not in self.__dict__ or len(self._functions) == 0:
-            raise NoABIFunctionsFound(
-                "The abi for this contract contains no function definitions. ",
-                "Are you sure you provided the correct contract abi?",
-            )
-        elif get_name_from_abi_element_identifier(function_name) not in [
-            get_name_from_abi_element_identifier(function["name"])
-            for function in self._functions
-        ]:
-            raise ABIFunctionNotFound(
-                f"The function '{function_name}' was not found in this ",
-                "contract's abi.",
-            )
-
-        if "(" not in function_name:
-            function_name = _get_any_abi_signature_with_name(
-                function_name, self._functions
-            )
-        else:
-            function_name = f"_{function_name}"
-
-        return super().__getattribute__(
-            function_name,
-        )
-
-    def __getitem__(self, function_name: str) -> "ContractFunction":
-        return getattr(self, function_name)
 
 
 class Contract(BaseContract):

--- a/web3/contract/contract.py
+++ b/web3/contract/contract.py
@@ -13,7 +13,6 @@ from typing import (
 
 from eth_typing import (
     ABI,
-    ABIFunction,
     ChecksumAddress,
 )
 from eth_utils import (
@@ -43,7 +42,6 @@ from web3._utils.compat import (
 )
 from web3._utils.contracts import (
     copy_contract_event,
-    copy_contract_function,
     parse_block_identifier,
 )
 from web3._utils.datatypes import (
@@ -88,7 +86,6 @@ from web3.contract.utils import (
 from web3.exceptions import (
     ABIEventNotFound,
     ABIFunctionNotFound,
-    MismatchedABI,
     NoABIEventsFound,
     NoABIFound,
     NoABIFunctionsFound,
@@ -104,10 +101,7 @@ from web3.types import (
     TxParams,
 )
 from web3.utils.abi import (
-    _filter_by_argument_count,
     _get_any_abi_signature_with_name,
-    _mismatched_abi_error_diagnosis,
-    get_abi_element,
 )
 
 if TYPE_CHECKING:
@@ -306,110 +300,6 @@ class ContractEvents(BaseContractEvents):
 class ContractFunction(BaseContractFunction):
     # mypy types
     w3: "Web3"
-
-    def __call__(self, *args: Any, **kwargs: Any) -> "ContractFunction":
-        # When a function is called, check arguments to obtain the correct function
-        # in the contract. self will be used if all args and kwargs are
-        # encodable to self.abi, otherwise the correct function is obtained from
-        # the contract.
-        if (
-            self.abi_element_identifier in [FallbackFn, ReceiveFn]
-            or self.abi_element_identifier == "constructor"
-        ):
-            return copy_contract_function(self, *args, **kwargs)
-
-        all_functions = cast(
-            List[ABIFunction],
-            filter_abi_by_type(
-                "function",
-                self.contract_abi,
-            ),
-        )
-        # Filter functions by name to obtain function signatures
-        function_name = get_name_from_abi_element_identifier(
-            self.abi_element_identifier
-        )
-        function_abis = [
-            function for function in all_functions if function["name"] == function_name
-        ]
-        num_args = len(args) + len(kwargs)
-        function_abis_with_arg_count = cast(
-            List[ABIFunction],
-            _filter_by_argument_count(
-                num_args,
-                function_abis,
-            ),
-        )
-
-        if not len(function_abis_with_arg_count):
-            # Build an ABI without arguments to determine if one exists
-            function_abis_with_arg_count = [
-                ABIFunction({"type": "function", "name": function_name})
-            ]
-
-        # Check that arguments in call match a function ABI
-        num_attempts = 0
-        function_abi_matches = []
-        contract_function = None
-        for abi in function_abis_with_arg_count:
-            try:
-                num_attempts += 1
-
-                # Search for a function ABI that matches the arguments used
-                function_abi_matches.append(
-                    cast(
-                        ABIFunction,
-                        get_abi_element(
-                            function_abis,
-                            abi_to_signature(abi),
-                            *args,
-                            abi_codec=self.w3.codec,
-                            **kwargs,
-                        ),
-                    )
-                )
-            except MismatchedABI:
-                # ignore exceptions
-                continue
-
-        if len(function_abi_matches) == 1:
-            function_abi = function_abi_matches[0]
-            if abi_to_signature(self.abi) == abi_to_signature(function_abi):
-                contract_function = self
-            else:
-                # Found a match that is not self
-                contract_function = ContractFunction.factory(
-                    abi_to_signature(function_abi),
-                    w3=self.w3,
-                    contract_abi=self.contract_abi,
-                    address=self.address,
-                    abi_element_identifier=abi_to_signature(function_abi),
-                    abi=function_abi,
-                )
-        else:
-            for abi in function_abi_matches:
-                if abi_to_signature(self.abi) == abi_to_signature(abi):
-                    contract_function = self
-                    break
-            else:
-                # Raise exception if multiple found
-                raise MismatchedABI(
-                    _mismatched_abi_error_diagnosis(
-                        function_name,
-                        self.contract_abi,
-                        len(function_abi_matches),
-                        num_args,
-                        *args,
-                        abi_codec=self.w3.codec,
-                        **kwargs,
-                    )
-                )
-
-        return copy_contract_function(contract_function, *args, **kwargs)
-
-    @classmethod
-    def factory(cls, class_name: str, **kwargs: Any) -> Self:
-        return PropertyCheckingFactory(class_name, (cls,), kwargs)()
 
     def call(
         self,

--- a/web3/contract/contract.py
+++ b/web3/contract/contract.py
@@ -40,7 +40,6 @@ from web3._utils.compat import (
     Self,
 )
 from web3._utils.contracts import (
-    copy_contract_event,
     parse_block_identifier,
 )
 from web3._utils.datatypes import (
@@ -103,9 +102,6 @@ if TYPE_CHECKING:
 class ContractEvent(BaseContractEvent):
     # mypy types
     w3: "Web3"
-
-    def __call__(self, *args: Any, **kwargs: Any) -> "ContractEvent":
-        return copy_contract_event(self, *args, **kwargs)
 
     @combomethod
     def get_logs(

--- a/web3/types.py
+++ b/web3/types.py
@@ -36,14 +36,9 @@ from web3._utils.compat import (
 )
 
 if TYPE_CHECKING:
-    from web3.contract.async_contract import (  # noqa: F401
-        AsyncContractEvent,
-    )
     from web3.contract.base_contract import (
+        BaseContractEvent,
         BaseContractFunction,
-    )
-    from web3.contract.contract import (  # noqa: F401
-        ContractEvent,
     )
     from web3.main import (  # noqa: F401
         AsyncWeb3,
@@ -583,7 +578,7 @@ class GethWallet(TypedDict):
 # Contract types
 
 TContractFn = TypeVar("TContractFn", bound="BaseContractFunction")
-TContractEvent = TypeVar("TContractEvent", "ContractEvent", "AsyncContractEvent")
+TContractEvent = TypeVar("TContractEvent", bound="BaseContractEvent")
 
 
 # Tracing types

--- a/web3/types.py
+++ b/web3/types.py
@@ -38,11 +38,12 @@ from web3._utils.compat import (
 if TYPE_CHECKING:
     from web3.contract.async_contract import (  # noqa: F401
         AsyncContractEvent,
-        AsyncContractFunction,
+    )
+    from web3.contract.base_contract import (
+        BaseContractFunction,
     )
     from web3.contract.contract import (  # noqa: F401
         ContractEvent,
-        ContractFunction,
     )
     from web3.main import (  # noqa: F401
         AsyncWeb3,
@@ -581,7 +582,7 @@ class GethWallet(TypedDict):
 
 # Contract types
 
-TContractFn = TypeVar("TContractFn", "ContractFunction", "AsyncContractFunction")
+TContractFn = TypeVar("TContractFn", bound="BaseContractFunction")
 TContractEvent = TypeVar("TContractEvent", "ContractEvent", "AsyncContractEvent")
 
 


### PR DESCRIPTION
### What was wrong?

Closes #3561 

In internal contract implementations, there might be duplicate implementations repeating same code for async and non-async functions, for example, `ContractFunctions` and `AsyncContractFunctions`. 

### How was it fixed?

This case is because of:
- hardcoded class name
- type hint requirements

As for previous one, they can be resolved using self.__class__ to other techiniques to dynamically get the right class.
As for latter one, `Self` combined with `Generic` would help solve the issue

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="296" alt="image" src="https://github.com/user-attachments/assets/39219060-8933-4610-aff4-4ed1f0e81b63" />
