### PR TITLE
Remove backwards-compatibility for ENS mainnet requirement, let NameNotFound raise

### DIFF
--- a/tests/core/middleware/test_name_to_address_middleware.py
+++ b/tests/core/middleware/test_name_to_address_middleware.py
@@ -7,7 +7,6 @@ from web3 import (
     Web3,
 )
 from web3.exceptions import (
-    InvalidAddress,
     NameNotFound,
 )
 from web3.middleware import (
@@ -95,7 +94,7 @@ def test_pass_name_resolver_send_transaction_dict_args(
 
 
 def test_fail_name_resolver(w3):
-    with pytest.raises(InvalidAddress, match=r".*ethereum\.eth.*"):
+    with pytest.raises(NameNotFound, match=r".*ethereum\.eth.*"):
         w3.eth.get_balance("ethereum.eth")
 
 

--- a/web3/_utils/normalizers.py
+++ b/web3/_utils/normalizers.py
@@ -49,7 +49,6 @@ from web3._utils.encoding import (
     text_if_str,
 )
 from web3._utils.ens import (
-    StaticENS,
     async_validate_name_has_address,
     is_ens_name,
     validate_name_has_address,
@@ -60,7 +59,6 @@ from web3._utils.validation import (
 )
 from web3.exceptions import (
     InvalidAddress,
-    NameNotFound,
     Web3ValueError,
 )
 
@@ -224,15 +222,7 @@ def abi_ens_resolver(
                 f"Could not look up name {val!r} because ENS is set to None"
             )
         else:
-            try:
-                return type_str, validate_name_has_address(_ens, val)
-            except NameNotFound as e:
-                # TODO: This try/except is to keep backwards compatibility when we
-                #  removed the mainnet requirement. Remove this in web3.py v7 and allow
-                #  NameNotFound to raise.
-                if not isinstance(_ens, StaticENS):
-                    raise InvalidAddress(f"{e}")
-                raise e
+            return type_str, validate_name_has_address(_ens, val)
     else:
         return type_str, val
 


### PR DESCRIPTION
### What was wrong?

* The code still contained a backward compatibility try/except block related to ENS name resolution, which was scheduled to be removed in Web3.py v7.
* This block prevented NameNotFound from being raised directly, instead converting it into InvalidAddress under certain conditions.

Related to Issue #
3580

Closes #
3580

### How was it fixed?

* Removed the try/except NameNotFound block so that NameNotFound raises naturally.
* Updated the relevant test to ensure the new behavior.

### Todo:

- [x] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<https://encrypted-tbn1.gstatic.com/images?q=tbn:ANd9GcT52_770s3MZ9UAVJultKdp95zQE-fNGAq8JWpfsmdO1IIWyxwff1JMYUuOchy4Fwb-gza8rzKikD1iqAYQ11v_aw>)
