### PR TITLE
Flaky test help

### DIFF
--- a/newsfragments/3583.internal.rst
+++ b/newsfragments/3583.internal.rst
@@ -1,0 +1,1 @@
+Address flaky tests in CI runs.

--- a/tests/core/contracts/test_contract_init.py
+++ b/tests/core/contracts/test_contract_init.py
@@ -85,7 +85,7 @@ def test_init_multiple_contracts_performance(w3, emitter_contract_data):
             abi=emitter_contract_data["abi"], bytecode=emitter_contract_data["bytecode"]
         )
     # assert initializing 500 contracts is within a conservative / reasonable time
-    assert (time.time() - start_time) < 1.5
+    assert (time.time() - start_time) < 1.75
 
 
 # -- async -- #
@@ -98,4 +98,4 @@ def test_async_init_multiple_contracts_performance(async_w3, emitter_contract_da
             abi=emitter_contract_data["abi"], bytecode=emitter_contract_data["bytecode"]
         )
     # assert initializing 500 contracts is within a conservative / reasonable time
-    assert (time.time() - start_time) < 1.5
+    assert (time.time() - start_time) < 1.75

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -2388,6 +2388,7 @@ class AsyncEthModuleTest:
         with pytest.raises(Web3ValueError):
             await async_w3.eth.replace_transaction(txn_hash, txn_params)
 
+    @flaky_geth_dev_mining
     @pytest.mark.asyncio
     async def test_async_eth_replace_transaction_gas_price_defaulting_minimum(
         self, async_w3: "AsyncWeb3", async_keyfile_account_address: ChecksumAddress
@@ -2411,6 +2412,7 @@ class AsyncEthModuleTest:
             gas_price * 1.125
         )  # minimum gas price
 
+    @flaky_geth_dev_mining
     @pytest.mark.asyncio
     async def test_async_eth_replace_transaction_gas_price_defaulting_strategy_higher(
         self, async_w3: "AsyncWeb3", async_keyfile_account_address: ChecksumAddress
@@ -2439,6 +2441,7 @@ class AsyncEthModuleTest:
         )  # Strategy provides higher gas price
         async_w3.eth.set_gas_price_strategy(None)  # reset strategy
 
+    @flaky_geth_dev_mining
     @pytest.mark.asyncio
     async def test_async_eth_replace_transaction_gas_price_defaulting_strategy_lower(
         self, async_w3: "AsyncWeb3", async_keyfile_account_address: ChecksumAddress

--- a/web3/_utils/module_testing/module_testing_utils.py
+++ b/web3/_utils/module_testing/module_testing_utils.py
@@ -1,17 +1,12 @@
 import asyncio
-import functools
-import pytest
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     Collection,
     Dict,
     Generator,
     Literal,
     Sequence,
-    Tuple,
-    Type,
     Union,
 )
 
@@ -61,43 +56,6 @@ for the duration of the test. This behavior can be flaky
 due to timing of the test running as a block is mined.
 """
 flaky_geth_dev_mining = flaky(max_runs=3, min_passes=1)
-
-
-def flaky_with_xfail_on_exception(
-    reason: str,
-    exception: Union[Type[Exception], Tuple[Type[Exception], ...]],
-    max_runs: int = 3,
-    min_passes: int = 1,
-) -> Callable[[Any], Any]:
-    """
-    Some tests inconsistently fail hard with a particular exception and retrying
-    these tests often times does not get them "unstuck". If we've exhausted all flaky
-    retries and this expected exception is raised, `xfail` the test with the given
-    reason.
-    """
-    runs = max_runs
-
-    def decorator(func: Any) -> Any:
-        @flaky(max_runs=max_runs, min_passes=min_passes)
-        @functools.wraps(func)
-        async def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
-            nonlocal runs
-            try:
-                return await func(self, *args, **kwargs)
-            except exception:
-                # xfail the test only if the exception is raised and we have exhausted
-                # all flaky retries
-                if runs == 1:
-                    pytest.xfail(reason)
-                runs -= 1
-                pytest.fail(f"xfailed but {runs} run(s) remaining with flaky...")
-            except Exception as e:
-                # let flaky handle it
-                raise e
-
-        return wrapper
-
-    return decorator
 
 
 def assert_contains_log(


### PR DESCRIPTION
### What was wrong?

- We recently removed the specific flaky xfail markers from some replace transaction tests. They now sometimes fail with "nonce too low", which is better than the previous timeout issues. We should add the flaky_geth_dev_mining decorator to these so they can run again and ideally pass 1 out of 3 times.

- We also sometimes get performance issues with older Python versions on the multiple contract init core tests. Let's keep this a more conservative number for now. `1.5` -> `1.75` should do I think.

### Todo:

- [x] Clean up commit history
- [x] Re-run the CI multiple times to see if we get consistent results

#### Cute Animal Picture

`0_o`
