### PR TITLE
Refactor ens and async_ens to call resolver only if coin_type is specified

### DIFF
--- a/ens/async_ens.py
+++ b/ens/async_ens.py
@@ -152,12 +152,12 @@ class AsyncENS(BaseENS):
         :param int coin_type: if provided, look up the address for this coin type
         :raises InvalidName: if `name` has invalid syntax
         """
-        r = await self.resolver(name)
         if coin_type is None:
             # don't validate `addr(bytes32)` interface id since extended resolvers
             # can implement a "resolve" function as of ENSIP-10
             return cast(ChecksumAddress, await self._resolve(name, "addr"))
         else:
+            r = await self.resolver(name)
             await _async_validate_resolver_and_interface_id(
                 name, r, ENS_MULTICHAIN_ADDRESS_INTERFACE_ID, "addr(bytes32,uint256)"
             )

--- a/ens/ens.py
+++ b/ens/ens.py
@@ -154,12 +154,12 @@ class ENS(BaseENS):
         :raises UnsupportedFunction: if the resolver does not support the ``addr()``
                 function
         """
-        r = self.resolver(name)
         if coin_type is None:
             # don't validate `addr(bytes32)` interface id since extended resolvers
             # can implement a "resolve" function as of ENSIP-10
             return cast(ChecksumAddress, self._resolve(name, "addr"))
         else:
+            r = self.resolver(name)
             _validate_resolver_and_interface_id(
                 name, r, ENS_MULTICHAIN_ADDRESS_INTERFACE_ID, "addr(bytes32,uint256)"
             )

--- a/newsfragments/3584.performance.rst
+++ b/newsfragments/3584.performance.rst
@@ -1,0 +1,1 @@
+Avoid unnecessary extra call to resolver when resolving an ENS address with no ``coin_type`` specified (default).


### PR DESCRIPTION
### What was wrong?

Previously, in `ens.py` and `async_ens.py`, the method `address()` always called `self.resolver(name)` even when `coin_type` was `None`. This meant an unnecessary call in scenarios where the resolver wasn’t actually used.

Related to Issue #3582

Closes #3582

### How was it fixed?

Moved the `self.resolver(name)` call inside the `else` block. Now it’s only triggered if `coin_type` is not `None`. This prevents an extra network call when `coin_type` is absent.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<https://camo.githubusercontent.com/8d65c4b3dda4b4cc4843e770bffb29350a972dc33fc1eb0bdb79c67186228c67/68747470733a2f2f73706f747065742e636f6d2f5f6e6578742f696d6167653f75726c3d6874747073253341253246253246696d616765732e6374666173736574732e6e65742532466d3565686e3373357437656325324677702d696d6167652d32303030303625324634353730376433393261363133383738636533633262303966666139366635372532464d616c746573655f426573745f4879706f616c6c657267656e69635f446f672e7765627026773d3338343026713d3735>)
