### PR TITLE
Fix typos in documentation files

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -571,7 +571,7 @@ when it comes in.
 The ``process_subscriptions()`` method on the
 :class:`~web3.providers.persistent.PersistentConnection` class, the public API for
 interacting with the active persistent socket connection, is also set up to receive
-``eth_subscription`` responses over an asynchronous interator pattern. You can use this
+``eth_subscription`` responses over an asynchronous iterator pattern. You can use this
 method to listen for raw messages and process them as they come in.
 
 .. code-block:: python

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -323,7 +323,7 @@ Miscellaneous Changes
   than the function names.
 - ``BaseContractFunction`` class attribute ``function_identifier`` has been removed in
   favor of the ``abi_element_identifier`` attribute.
-- ``web3.contract.utils.call_contract_function()`` no longers uses ``fn_abi`` as a
+- ``web3.contract.utils.call_contract_function()`` no longer uses ``fn_abi`` as a
   parameter. Instead, the ``abi_callable`` parameter of type ``ABICallable`` is used.
 - Beacon API filename change: ``beacon/main.py`` -> ``beacon/beacon.py``.
 - The asynchronous version of ``w3.eth.wait_for_transaction_receipt()`` changes its

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -299,7 +299,7 @@ types have been introduced in the ``eth_typing`` ``v5`` package for ABIs. Improv
 been made to make required types more explicit and to offer better semantics.
 
 The following types from ``web3.types`` have been removed:
-- ``ABIEventParams`` is no longer avaiable. Use ``ABIComponentIndexed`` from
+- ``ABIEventParams`` is no longer available. Use ``ABIComponentIndexed`` from
 ``eth_typing`` to represent event input components.
 - ``ABIEvent`` now resides in ``eth_typing``. ``ABIEvent.type`` and ``ABIEvent.name``
 are now required fields.


### PR DESCRIPTION
- Corrected "interator" to "iterator" in `internals.rst`.
- Fixed "avaiable" to "available" and "longers" to "longer" in `migration.rst`.

### What was wrong?

The errors involved incorrect spelling in the documentation that could cause confusion for users or developers reading the files.

### How was it fixed?

The typos were corrected to their proper forms to ensure accuracy and clarity in the documentation.

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)