### PR TITLE
fix: correct examples in `providers.rst` documentation

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -419,7 +419,7 @@ shown below.
     ...     await w3.provider.disconnect()
 
     # run the example
-    >>> asyncio.run(await_instantiation_example)
+    >>> asyncio.run(await_instantiation_example())
 
 .. code-block:: python
 
@@ -434,7 +434,7 @@ shown below.
     ...     await w3.provider.disconnect()
 
     # run the example
-    >>> asyncio.run(await_provider_connect_example)
+    >>> asyncio.run(await_provider_connect_example())
 
 :class:`~web3.providers.persistent.PersistentConnectionProvider` classes use the
 :class:`~web3.providers.persistent.request_processor.RequestProcessor` class under the


### PR DESCRIPTION
**Description:**
This pull request updates the `docs/providers.rst` file by correcting examples in the following ways:

- Fixed missing parentheses in `asyncio.run()` calls to ensure code examples are syntactically correct and executable.
- Improved consistency in the documentation examples for better readability and accuracy.

These changes ensure that the provided examples align with proper Python syntax and improve the developer experience.