### PR TITLE
Raise only for non-unique provided sub labels; create unique default labels

### DIFF
--- a/newsfragments/3594.bugfix.rst
+++ b/newsfragments/3594.bugfix.rst
@@ -1,0 +1,1 @@
+Don't raise on non-unique default subscription labels (no label provided). Only raise if a non-unique custom label is explicitly set for a subscription.

--- a/web3/utils/subscriptions.py
+++ b/web3/utils/subscriptions.py
@@ -114,6 +114,10 @@ class EthSubscription(Generic[TSubscriptionResult]):
         self._label = label
         self.handler_call_count = 0
 
+    @property
+    def _default_label(self) -> str:
+        return f"{self.__class__.__name__}{self.subscription_params}"
+
     @classmethod
     def _create_type_aware_subscription(
         cls,
@@ -170,7 +174,7 @@ class EthSubscription(Generic[TSubscriptionResult]):
     @property
     def label(self) -> str:
         if not self._label:
-            self._label = f"{self.__class__.__name__}{self.subscription_params}"
+            self._label = self._default_label
         return self._label
 
     @property


### PR DESCRIPTION
### What was wrong?

Some users may want to treat observers of the same event as separate subscriptions. If no labels are provided, create unique default labels. The user likely doesn't care about tracking via a label. However, if a user passes in the same explicit label for two separate subscriptions, raise an exception (this was already in place).

Closes #3593

### How was it fixed?

- If a user does not provide a subscription label, they likely don't care about tracking via a label. Create unique default labels for each subscription.
- If a user provides a subscription label, but it is not unique, raise an error.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="731" alt="Screenshot 2025-01-28 at 08 50 23" src="https://github.com/user-attachments/assets/de4a0b93-b82b-4367-b805-ef47354fc9ce" />
