### PR TITLE
Subscription manager bugfixes:

### DIFF
--- a/newsfragments/3585.breaking.rst
+++ b/newsfragments/3585.breaking.rst
@@ -1,0 +1,1 @@
+The bugfix to match ``unsubscribe`` to ``subscribe`` for multiple subscriptions breaks the function signature for ``unsubscribe``, changing the ``subscription`` argument to ``subscriptions``.

--- a/newsfragments/3595.bugfix.rst
+++ b/newsfragments/3595.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bugs related to subscription manager: ``run_forever`` can start with ``0`` subscriptions and remains alive, ``unsubscribe`` accepts single or multiple subs as objects or hexstrs, ``subscribe`` for many subs returns a list of hexstr ids.

--- a/tests/core/subscriptions/test_subscription_manager.py
+++ b/tests/core/subscriptions/test_subscription_manager.py
@@ -46,7 +46,8 @@ async def test_subscription_default_labels_are_unique(subscription_manager):
     sub3 = NewHeadsSubscription()
     sub4 = NewHeadsSubscription()
 
-    await subscription_manager.subscribe([sub1, sub2, sub3, sub4])
+    sub_ids = await subscription_manager.subscribe([sub1, sub2, sub3, sub4])
+    assert sub_ids == ["0x0", "0x1", "0x2", "0x3"]
 
     assert sub1.label != sub2.label != sub3.label != sub4.label
     assert sub1.label == "NewHeadsSubscription('newHeads',)"
@@ -133,3 +134,23 @@ async def test_unsubscribe_all_clears_all_subscriptions(subscription_manager):
     assert sub_container.subscriptions == []
     assert sub_container.subscriptions_by_id == {}
     assert sub_container.subscriptions_by_label == {}
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_with_hex_ids(subscription_manager):
+    sub1 = NewHeadsSubscription()
+    sub2 = PendingTxSubscription()
+    sub3 = NewHeadsSubscription()
+    sub4 = LogsSubscription()
+
+    sub_id1, sub_id2, sub_id3, sub_id4 = await subscription_manager.subscribe(
+        [sub1, sub2, sub3, sub4]
+    )
+
+    assert subscription_manager.subscriptions == [sub1, sub2, sub3, sub4]
+
+    assert await subscription_manager.unsubscribe(sub_id1) is True
+    assert subscription_manager.subscriptions == [sub2, sub3, sub4]
+
+    assert await subscription_manager.unsubscribe([sub_id2, sub_id3]) is True
+    assert subscription_manager.subscriptions == [sub4]


### PR DESCRIPTION
### What was wrong?

Some bugs shared via Discord conversation with @fubuloubu.

### How was it fixed?

- Fix ``run_forever`` logic so that it doesn't require subscriptions to start and doesn't end when no subscriptions are present.
- Fix the ``unsubscribe`` method so that it can accept subscription ids.
- Fix the ``unsubscribe`` method so it behaves like the ``subscribe`` method, accepting both single or multiple subscriptions or subscription ids. **Note this does change the signature from ``subscription`` to ``subscriptions``, but I think this can be a bugfix since the ``subscribe`` method accepts multiple subscriptions and ``unsubscribe`` should behave similarly.** Happy to revert back and change this in v8 if we don't want to break it here.

- Fix ``subscribe`` so that it returns a list of subscription ids when a list of subscriptions is provided.

Add tests:

- Add a test for ``run_forever`` to make sure it can start without subscriptions and that the task does not stop when no subscriptions are present.
- Add a test for ``unsubscribe`` to make sure it can accept multiple subscriptions as hexstr ids or as subscription objects.
- Update subscriptions tests to check that a list of ids is returned when multiple subscriptions are provided to the ``subscribe`` method.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="239" alt="Screenshot 2025-01-30 at 11 17 58" src="https://github.com/user-attachments/assets/8081c05a-0893-41ae-a7fa-345bcc961371" />
