### PR TITLE
docs: rename osx to macos

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -59,7 +59,7 @@ body:
     attributes:
       label: Operating System
       description: Which operating system are you using?
-      placeholder: osx/linux/win
+      placeholder: macos/linux/win
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
### What was wrong?

OSX renamed to macOS in 2016!
