### PR TITLE
fix: middleware values keyerror fix

### DIFF
--- a/newsfragments/3596.bugfix.rst
+++ b/newsfragments/3596.bugfix.rst
@@ -1,0 +1,1 @@
+Fix issue where ``.values()`` raised a ``KeyError`` in ``NamedTupledOnion``

--- a/tests/core/datastructures/test_datastructures.py
+++ b/tests/core/datastructures/test_datastructures.py
@@ -4,7 +4,11 @@ import re
 
 from web3.datastructures import (
     AttributeDict,
+    NamedElementOnion,
     tupleize_lists_nested,
+)
+from web3.middleware import (
+    GasPriceStrategyMiddleware,
 )
 
 
@@ -207,3 +211,11 @@ def test_AttributeDict_hashing_backwards_compatibility(input, error):
             assert hash(tuple(sorted(input.items()))) == hash(input)
     else:
         assert hash(tuple(sorted(input.items()))) == hash(input)
+
+
+def test_NamedElementOnion_values():
+    middleware = GasPriceStrategyMiddleware(None)
+    initial_items = [(middleware, "gas_price_strategy")]
+    named_element_onion = NamedElementOnion(initial_items)
+    actual = [x for x in named_element_onion.values()]
+    assert actual == [middleware]

--- a/web3/datastructures.py
+++ b/web3/datastructures.py
@@ -17,6 +17,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    ValuesView,
     cast,
 )
 
@@ -337,3 +338,6 @@ class NamedElementOnion(Mapping[TKey, TValue]):
         # This leads to typing issues, so it's better to use
         # ``as_tuple_of_middleware()`` to achieve the same result.
         return iter(self._reversed_middleware())  # type: ignore
+
+    def values(self) -> ValuesView[TValue]:
+        return ValuesView(self._queue)


### PR DESCRIPTION
### What was wrong?

Related to Issue #3596
Closes #3596 

### How was it fixed?

Override `.values()`

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

`0_o`
