### PR TITLE
comparing `isinstance(...)` to `True` is an anti-pattern

### DIFF
--- a/web3/_utils/events.py
+++ b/web3/_utils/events.py
@@ -325,7 +325,7 @@ normalize_topic_list = compose(
 
 
 def is_indexed(arg: Any) -> bool:
-    if isinstance(arg, TopicArgumentFilter) is True:
+    if isinstance(arg, TopicArgumentFilter):
         return True
     return False
 


### PR DESCRIPTION
Because `isinstance(...)` already returns a boolean, comparing it to `True` with `is` is unnecessary and considered an anti-pattern. 