### PR TITLE
bugfix: prevent mutating susbcriptions when unsubscribing

### DIFF
--- a/newsfragments/3604.bugfix.rst
+++ b/newsfragments/3604.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent mutating list of subscriptions when unsubscribing via the ``subscription_manager`` by iterating over a copy of the provided list.

--- a/tests/core/subscriptions/test_subscription_manager.py
+++ b/tests/core/subscriptions/test_subscription_manager.py
@@ -188,3 +188,28 @@ async def test_unsubscribe_with_one_or_multiple(subscription_manager):
     # unsubscribe non-existent subscription object
     with pytest.raises(Web3ValueError, match=f"Subscription not found|{sub5.id}"):
         await subscription_manager.unsubscribe(sub5)
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_with_subscriptions_reference_does_not_mutate_the_list(
+    subscription_manager,
+):
+    sub1 = NewHeadsSubscription()
+    sub2 = LogsSubscription()
+    sub3 = PendingTxSubscription()
+    sub4 = NewHeadsSubscription()
+
+    await subscription_manager.subscribe([sub1, sub2, sub3, sub4])
+    assert subscription_manager.subscriptions == [sub1, sub2, sub3, sub4]
+
+    # assert not mutating in place
+    await subscription_manager.unsubscribe(subscription_manager.subscriptions)
+    assert subscription_manager.subscriptions == []
+
+    # via unsubscribe all
+
+    await subscription_manager.subscribe([sub1, sub2, sub3, sub4])
+    assert subscription_manager.subscriptions == [sub1, sub2, sub3, sub4]
+
+    await subscription_manager.unsubscribe_all()
+    assert subscription_manager.subscriptions == []

--- a/web3/providers/persistent/subscription_manager.py
+++ b/web3/providers/persistent/subscription_manager.py
@@ -206,7 +206,10 @@ class SubscriptionManager:
                 raise Web3ValueError("No subscriptions provided.")
 
             unsubscribed: List[bool] = []
-            for sub in subscriptions:
+            # re-create the subscription list to prevent modifying the original list
+            # in case ``subscription_manager.subscriptions`` was passed in directly
+            subs = [sub for sub in subscriptions]
+            for sub in subs:
                 if isinstance(sub, str):
                     sub = HexStr(sub)
                 unsubscribed.append(await self.unsubscribe(sub))
@@ -226,7 +229,9 @@ class SubscriptionManager:
         :rtype: bool
         """
         unsubscribed = [
-            await self.unsubscribe(sub) for sub in self.subscriptions.copy()
+            await self.unsubscribe(sub)
+            # use copy to prevent modifying the list while iterating over it
+            for sub in self.subscriptions.copy()
         ]
         if all(unsubscribed):
             self.logger.info("Successfully unsubscribed from all subscriptions.")


### PR DESCRIPTION
### What was wrong?

Closes #3602 

### How was it fixed?

- If the reference to the subscriptions list is passed in directly, prevent ``unsubscribe`` from mutating the list by re-creating the list before iterating over it to unsubscribe.

- Add a test to verify that the bug is fixed.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Screenshot 2025-02-04 at 11 46 31](https://github.com/user-attachments/assets/8ed8cad5-4b60-44e3-a82d-4e5e3464208e)

