### PR TITLE
Auto Provider batch requests

### DIFF
--- a/docs/web3.main.rst
+++ b/docs/web3.main.rst
@@ -72,6 +72,12 @@ Batch Requests
             responses = batch.execute()
             assert len(responses) == 3
 
+    .. note::
+
+       Within the batching context above, calls are suspended until
+       ``batch.execute()`` is called. Calling a method without
+       passing it to ``batch.add`` might result in unexpected behavior.
+
     Using the batch object directly:
 
     .. code-block:: python

--- a/newsfragments/3607.bugfix.rst
+++ b/newsfragments/3607.bugfix.rst
@@ -1,0 +1,1 @@
+Batching can now be used with the AutoProvider

--- a/tests/integration/go_ethereum/test_goethereum_http.py
+++ b/tests/integration/go_ethereum/test_goethereum_http.py
@@ -76,6 +76,17 @@ def w3(geth_process, endpoint_uri):
     return Web3(Web3.HTTPProvider(endpoint_uri, request_kwargs={"timeout": 10}))
 
 
+@pytest.fixture(scope="module")
+def auto_w3(geth_process, endpoint_uri):
+    wait_for_http(endpoint_uri)
+
+    from web3.auto import (
+        w3,
+    )
+
+    return w3
+
+
 class TestGoEthereumWeb3ModuleTest(GoEthereumWeb3ModuleTest):
     pass
 
@@ -105,7 +116,15 @@ class TestGoEthereumDebugModuleTest(GoEthereumDebugModuleTest):
 
 
 class TestGoEthereumEthModuleTest(GoEthereumEthModuleTest):
-    pass
+    def test_auto_provider_batching(
+        self,
+        auto_w3: "Web3",
+        monkeypatch,
+        endpoint_uri,
+    ) -> None:
+        monkeypatch.setenv("WEB3_PROVIDER_URI", endpoint_uri)
+        # test that batch_requests doesn't error out when using the auto provider
+        auto_w3.batch_requests()
 
 
 class TestGoEthereumNetModuleTest(GoEthereumNetModuleTest):

--- a/tests/integration/go_ethereum/test_goethereum_ipc.py
+++ b/tests/integration/go_ethereum/test_goethereum_ipc.py
@@ -54,6 +54,17 @@ def geth_ipc_path(datadir):
 
 
 @pytest.fixture(scope="module")
+def auto_w3(geth_process, geth_ipc_path):
+    wait_for_socket(geth_ipc_path)
+
+    from web3.auto import (
+        w3,
+    )
+
+    return w3
+
+
+@pytest.fixture(scope="module")
 def w3(geth_process, geth_ipc_path):
     wait_for_socket(geth_ipc_path)
     return Web3(Web3.IPCProvider(geth_ipc_path, timeout=10))
@@ -68,7 +79,15 @@ class TestGoEthereumDebugModuleTest(GoEthereumDebugModuleTest):
 
 
 class TestGoEthereumEthModuleTest(GoEthereumEthModuleTest):
-    pass
+    def test_auto_provider_batching(
+        self,
+        auto_w3: "Web3",
+        monkeypatch,
+        geth_ipc_path,
+    ) -> None:
+        monkeypatch.setenv("WEB3_PROVIDER_URI", f"file:///{geth_ipc_path}")
+        # test that batch_requests doesn't error out when using the auto provider
+        auto_w3.batch_requests()
 
 
 class TestGoEthereumNetModuleTest(GoEthereumNetModuleTest):

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -447,6 +447,8 @@ class RequestManager:
         """
         Context manager for making batch requests
         """
+        if isinstance(self.provider, AutoProvider):
+            self.provider = self.provider._get_active_provider(use_cache=True)
         if not isinstance(self.provider, (AsyncJSONBaseProvider, JSONBaseProvider)):
             raise Web3TypeError("Batch requests are not supported by this provider.")
         return RequestBatcher(self.w3)


### PR DESCRIPTION
### What was wrong?

- Batching wasn't working with the AutoProvider.
- Quick clarification in the batching docs

Closes #3599 

### How was it fixed?

Check if provider isinstance of AutoProvider, and then find the active provider. 

Tests aren't great - lemme know if you see something else I should check other than "doesn't error"

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://t3.ftcdn.net/jpg/01/04/40/06/360_F_104400672_zCaPIFbYT1dXdzN85jso7NV8M6uwpKtf.jpg)
