### PR TITLE
Fix dependency typo (pyunormalize -> unidecode)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         "typing-extensions>=4.0.1",
         "types-requests>=2.0.0",
         "websockets>=10.0.0,<14.0.0",
-        "pyunormalize>=15.0.0",
+        "unidecode>=15.0.0",
     ],
     python_requires=">=3.8, <4",
     extras_require=extras_require,


### PR DESCRIPTION
Fix dependency typo in setup.py:
- "pyunormalize" was a misspelling.
- Replaced with "unidecode", the correct package name.
