### PR TITLE
chore: fix correction 

### DIFF
--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -59,7 +59,7 @@ def get_ipc_socket(ipc_path: str, timeout: float = 2.0) -> socket.socket:
         return sock
 
 
-class PersistantSocket:
+class PersistentSocket:
     sock = None
 
     def __init__(self, ipc_path: str) -> None:

--- a/web3/providers/persistent/persistent_connection.py
+++ b/web3/providers/persistent/persistent_connection.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 class PersistentConnection:
     """
     A class that houses the public API for interacting with the persistent connection
-    via a `AsyncWeb3` instance instantiated with a `PersistentConnectionProvider` class.
+    via an `AsyncWeb3` instance instantiated with a `PersistentConnectionProvider` class.
     """
 
     def __init__(self, w3: "AsyncWeb3"):

--- a/web3/utils/abi.py
+++ b/web3/utils/abi.py
@@ -172,7 +172,7 @@ def _get_any_abi_signature_with_name(
     Find an ABI identifier signature by element name. A signature identifier is
     returned, "name(arg1Type,arg2Type,...)".
 
-    If multiple ABIs match the name and every one contain arguments, the first
+    If multiple ABIs match the name and every one contains arguments, the first
     result is returned. Otherwise the signature without arguments is returned.
     Returns None if no ABI exists with the provided name.
     """


### PR DESCRIPTION
web3/providers/ipc.py
typo fix PersistantSocket --> PersistentSocket

web3/providers/persistent/persistent_connection.py
correction a `AsyncWeb3` -  an `AsyncWeb3`

web3/utils/abi.py
contain - contains