### PR TITLE
fix: correctly combine address and contract address list in event filter param construction

### DIFF
--- a/newsfragments/3618.bugfix.rst
+++ b/newsfragments/3618.bugfix.rst
@@ -1,0 +1,1 @@
+Fix contract event ``FilterParams`` to validate and normalize ``address`` parameters.

--- a/tests/core/utilities/test_construct_event_filter_params.py
+++ b/tests/core/utilities/test_construct_event_filter_params.py
@@ -106,6 +106,32 @@ def event_abi():
             id="address-string",
         ),
         pytest.param(
+            {"address": b"\xf2\xe2F\xbbv\xdf\x87l\xef\x8b8\xae\x84\x13\x0fOU\xde9["},
+            {
+                "topics": [
+                    "0xb470a829ed7792f06947f0ca3730a570cb378329ddcf09f2b4efabd6326f51f6"
+                ],
+                "address": b"\xf2\xe2F\xbbv\xdf\x87l\xef\x8b8\xae\x84\x13\x0fOU\xde9[",
+            },
+            id="address-bytes",
+        ),
+        pytest.param(
+            {
+                "contract_address": b"\xf2\xe2F\xbbv\xdf\x87l\xef\x8b8\xae\x84\x13\x0fOU\xde9[",  # noqa: E501
+                "address": [
+                    b"\xf2\xe2F\xbbv\xdf\x87l\xef\x8b8\xae\x84\x13\x0fOU\xde9[",
+                    b"\xf2\xe2F\xbbv\xdf\x87l\xef\x8b8\xae\x84\x13\x0fOU\xde9[",
+                ],
+            },
+            {
+                "topics": [
+                    "0xb470a829ed7792f06947f0ca3730a570cb378329ddcf09f2b4efabd6326f51f6"
+                ],
+                "address": b"\xf2\xe2F\xbbv\xdf\x87l\xef\x8b8\xae\x84\x13\x0fOU\xde9[",
+            },
+            id="address-bytes-list",
+        ),
+        pytest.param(
             {"address": ["0xd3CdA913deB6f67967B99D67aCDFa1712C293601"]},
             {
                 "topics": [

--- a/tests/core/utilities/test_construct_event_filter_params.py
+++ b/tests/core/utilities/test_construct_event_filter_params.py
@@ -18,7 +18,7 @@ EVENT_1_ABI = {
 @pytest.mark.parametrize(
     "event_abi,fn_kwargs,expected",
     (
-        (
+        pytest.param(
             EVENT_1_ABI,
             {},
             {
@@ -26,13 +26,15 @@ EVENT_1_ABI = {
                     "0xb470a829ed7792f06947f0ca3730a570cb378329ddcf09f2b4efabd6326f51f6"
                 ],
             },
+            id="no-args",
         ),
-        (
+        pytest.param(
             EVENT_1_ABI,
             {"topics": ["should-overwrite-topics"]},
             {"topics": ["should-overwrite-topics"]},
+            id="overwrite-topics",
         ),
-        (
+        pytest.param(
             EVENT_1_ABI,
             {"contract_address": "0xd3CdA913deB6f67967B99D67aCDFa1712C293601"},
             {
@@ -41,8 +43,9 @@ EVENT_1_ABI = {
                 ],
                 "address": "0xd3CdA913deB6f67967B99D67aCDFa1712C293601",
             },
+            id="contract_address-string",
         ),
-        (
+        pytest.param(
             EVENT_1_ABI,
             {
                 "contract_address": "0xd3CdA913deB6f67967B99D67aCDFa1712C293601",
@@ -57,8 +60,9 @@ EVENT_1_ABI = {
                     "0xd3CdA913deB6f67967B99D67aCDFa1712C293601",
                 ],
             },
+            id="address-with-contract_address",
         ),
-        (
+        pytest.param(
             EVENT_1_ABI,
             {"address": "0xd3CdA913deB6f67967B99D67aCDFa1712C293601"},
             {
@@ -67,6 +71,75 @@ EVENT_1_ABI = {
                 ],
                 "address": "0xd3CdA913deB6f67967B99D67aCDFa1712C293601",
             },
+            id="address-string",
+        ),
+        pytest.param(
+            EVENT_1_ABI,
+            {"address": ["0xd3CdA913deB6f67967B99D67aCDFa1712C293601"]},
+            {
+                "topics": [
+                    "0xb470a829ed7792f06947f0ca3730a570cb378329ddcf09f2b4efabd6326f51f6"
+                ],
+                "address": ["0xd3CdA913deB6f67967B99D67aCDFa1712C293601"],
+            },
+            id="address-list",
+        ),
+        pytest.param(
+            EVENT_1_ABI,
+            {
+                "address": [
+                    "0xd3CdA913deB6f67967B99D67aCDFa1712C293601",
+                    "0x1234567890123456789012345678901234567890",
+                ]
+            },
+            {
+                "topics": [
+                    "0xb470a829ed7792f06947f0ca3730a570cb378329ddcf09f2b4efabd6326f51f6"
+                ],
+                "address": [
+                    "0xd3CdA913deB6f67967B99D67aCDFa1712C293601",
+                    "0x1234567890123456789012345678901234567890",
+                ],
+            },
+            id="multiple-address",
+        ),
+        pytest.param(
+            EVENT_1_ABI,
+            {
+                "address": "0xd3CdA913deB6f67967B99D67aCDFa1712C293601",
+                "contract_address": ["0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413"],
+            },
+            {
+                "topics": [
+                    "0xb470a829ed7792f06947f0ca3730a570cb378329ddcf09f2b4efabd6326f51f6"
+                ],
+                "address": [
+                    "0xd3CdA913deB6f67967B99D67aCDFa1712C293601",
+                    "0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413",
+                ],
+            },
+            id="one-address-with-multiple-contract_address",
+        ),
+        pytest.param(
+            EVENT_1_ABI,
+            {
+                "address": [
+                    "0xd3CdA913deB6f67967B99D67aCDFa1712C293601",
+                    "0x1234567890123456789012345678901234567890",
+                ],
+                "contract_address": "0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413",
+            },
+            {
+                "topics": [
+                    "0xb470a829ed7792f06947f0ca3730a570cb378329ddcf09f2b4efabd6326f51f6"
+                ],
+                "address": [
+                    "0xd3CdA913deB6f67967B99D67aCDFa1712C293601",
+                    "0x1234567890123456789012345678901234567890",
+                    "0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413",
+                ],
+            },
+            id="multiple-address-with-one-contract_address",
         ),
     ),
 )

--- a/web3/_utils/filters.py
+++ b/web3/_utils/filters.py
@@ -95,10 +95,11 @@ def construct_event_filter_params(
     if address and contract_address:
         if is_list_like(address):
             filter_params["address"] = address
-            if is_list_like(contract_address):
-                filter_params["address"] += contract_address
-            else:
-                filter_params["address"] += [contract_address]
+            if address != contract_address:
+                if is_list_like(contract_address):
+                    filter_params["address"] += contract_address
+                else:
+                    filter_params["address"] += [contract_address]
         elif is_string(address):
             filter_params["address"] = (
                 [address, contract_address]

--- a/web3/_utils/filters.py
+++ b/web3/_utils/filters.py
@@ -82,7 +82,7 @@ def _sanitize_addresses(
     for arg in address:
         if not arg:
             continue
-        elif isinstance(arg, str):
+        elif isinstance(arg, str) or isinstance(arg, bytes):
             address_set.add(arg)
         elif isinstance(arg, list):
             address_set.update(arg)

--- a/web3/_utils/filters.py
+++ b/web3/_utils/filters.py
@@ -94,7 +94,7 @@ def construct_event_filter_params(
 
     if address and contract_address:
         if is_list_like(address):
-            filter_params["address"] = [address] + [contract_address]
+            filter_params["address"] = list(set(address + contract_address))
         elif is_string(address):
             filter_params["address"] = (
                 [address, contract_address]

--- a/web3/_utils/filters.py
+++ b/web3/_utils/filters.py
@@ -70,12 +70,12 @@ if TYPE_CHECKING:
 def construct_event_filter_params(
     event_abi: ABIEvent,
     abi_codec: ABICodec,
-    contract_address: Optional[ChecksumAddress] = None,
+    contract_address: Optional[ChecksumAddress | Sequence[ChecksumAddress]] = None,
     argument_filters: Optional[Dict[str, Any]] = None,
     topics: Optional[Sequence[HexStr]] = None,
     from_block: Optional[BlockIdentifier] = None,
     to_block: Optional[BlockIdentifier] = None,
-    address: Optional[ChecksumAddress] = None,
+    address: Optional[ChecksumAddress | Sequence[ChecksumAddress]] = None,
 ) -> Tuple[List[List[Optional[HexStr]]], FilterParams]:
     filter_params: FilterParams = {}
     topic_set: Sequence[HexStr] = construct_event_topic_set(
@@ -94,7 +94,11 @@ def construct_event_filter_params(
 
     if address and contract_address:
         if is_list_like(address):
-            filter_params["address"] = list(set(address + contract_address))
+            filter_params["address"] = address
+            if is_list_like(contract_address):
+                filter_params["address"] += contract_address
+            else:
+                filter_params["address"] += [contract_address]
         elif is_string(address):
             filter_params["address"] = (
                 [address, contract_address]
@@ -108,7 +112,7 @@ def construct_event_filter_params(
     elif address:
         filter_params["address"] = address
     elif contract_address:
-        filter_params["address"] = contract_address
+        filter_params["address"] = [contract_address]
 
     if "address" not in filter_params:
         pass


### PR DESCRIPTION
### What was wrong?

Related to Issue #3617 
Closes #3617 

### How was it fixed?
See description of #3617 

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://github.com/user-attachments/assets/7ed5e4a0-48b4-408a-aca1-a37e0d2a3f98)
