### PR TITLE
``eth_simulateV1`` support

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -947,6 +947,76 @@ The following methods are available on the ``web3.eth`` namespace.
     can be accessed via the ``data`` attribute on ``ContractLogicError``.
 
 
+.. py:method:: Eth.simulateV1(payload, block_identifier)
+
+    * Delegates to ``eth_simulateV1`` RPC Method
+
+    Executes a simulation for the given payload at the given block. Returns the simulation results.
+
+    .. code-block:: python
+
+        >>> w3.eth.simulateV1(
+        ...   {
+        ...     "blockStateCalls": [
+        ...       {
+        ...         "blockOverrides": {
+        ...           "baseFeePerGas": Wei(10),
+        ...         },
+        ...         "stateOverrides": {
+        ...           "0xc100000000000000000000000000000000000000": {
+        ...             "balance": Wei(500000000),
+        ...           }
+        ...         },
+        ...         "calls": [
+        ...           {
+        ...             "from": "0xc100000000000000000000000000000000000000",
+        ...             "to": "0xc100000000000000000000000000000000000000",
+        ...             "maxFeePerGas": Wei(10),
+        ...             "maxPriorityFeePerGas": Wei(10),
+        ...           }
+        ...         ],
+        ...       }
+        ...     ],
+        ...     "validation": True,
+        ...     "traceTransfers": True,
+        ...   },
+        ...   "latest",
+        ... )
+        [AttributeDict({
+          'baseFeePerGas': 10,
+          'blobGasUsed': 0,
+          'calls': [AttributeDict({
+            'returnData': HexBytes('0x'),
+            'logs': [],
+            'gasUsed': 21000,
+            'status': 1
+          })],
+          'difficulty': 0,
+          'excessBlobGas': 0,
+          'extraData': HexBytes('0x'),
+          'gasLimit': 983527531,
+          'gasUsed': 21000,
+          'hash': HexBytes('0xb2dba64c905dea42e940d67b8e0f44019f4a61c4833a9cba99c426b748d9e1a4'),
+          'logsBloom': HexBytes('0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'),
+          'miner': '0x0000000000000000000000000000000000000000',
+          'mixHash': HexBytes('0x0000000000000000000000000000000000000000000000000000000000000000'),
+          'nonce': HexBytes('0x0000000000000000'),
+          'number': 18,
+          'parentBeaconBlockRoot': HexBytes('0x0000000000000000000000000000000000000000000000000000000000000000'),
+          'parentHash': HexBytes('0x71d32db179a1291de86b5f7fa15224292ef9ee6ebb3fa62484896601d9f20d5f'),
+          'receiptsRoot': HexBytes('0xf78dfb743fbd92ade140711c8bbc542b5e307f0ab7984eff35d751969fe57efa'),
+          'sha3Uncles': HexBytes('0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347'),
+          'size': 626,
+          'stateRoot': HexBytes('0xbbbe846b616911d13780f58f500f8948e0878ba6f55cae7432da915cab3ba2b6'),
+          'timestamp': 1739921487,
+          'transactions': [HexBytes('0xfd801060af398c615f1ffb61586604aaf4fc688615cb1ff088531638a9b9e8e6')],
+          'transactionsRoot': HexBytes('0xa6bc01d7707e94b62dccb8d097df1db25d6b44fad35463ecc99c9e5822e7aa5f'),
+          'uncles': [],
+          'withdrawals': [],
+          'withdrawalsRoot': HexBytes('0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421')
+        })]
+
+
 .. py:method:: Eth.create_access_list(transaction, block_identifier=web3.eth.default_block)
 
     * Delegates to ``eth_createAccessList`` RPC Method

--- a/newsfragments/3622.feature.rst
+++ b/newsfragments/3622.feature.rst
@@ -1,0 +1,1 @@
+Sync and async support for ``eth_simulateV1`` RPC method.

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -338,8 +338,8 @@ class TestEthereumTesterEthModule(EthModuleTest):
         EthModuleTest.test_eth_getBlockReceipts_finalized,
         MethodUnavailable,
     )
-    test_eth_simulateV1 = not_implemented(
-        EthModuleTest.test_eth_simulateV1,
+    test_eth_simulate_v1 = not_implemented(
+        EthModuleTest.test_eth_simulate_v1,
         MethodUnavailable,
     )
 

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -338,6 +338,10 @@ class TestEthereumTesterEthModule(EthModuleTest):
         EthModuleTest.test_eth_getBlockReceipts_finalized,
         MethodUnavailable,
     )
+    test_eth_simulateV1 = not_implemented(
+        EthModuleTest.test_eth_simulateV1,
+        MethodUnavailable,
+    )
 
     def test_eth_getBlockByHash_pending(self, w3: "Web3") -> None:
         block = w3.eth.get_block("pending")

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -1691,8 +1691,8 @@ class AsyncEthModuleTest:
             await async_offchain_lookup_contract.caller().continuousOffchainLookup()  # noqa: E501 type: ignore
 
     @pytest.mark.asyncio
-    async def test_eth_simulateV1(self, async_w3: "AsyncWeb3") -> None:
-        simulate_result = await async_w3.eth.simulateV1(
+    async def test_eth_simulate_v1(self, async_w3: "AsyncWeb3") -> None:
+        simulate_result = await async_w3.eth.simulate_v1(
             {
                 "blockStateCalls": [
                     {
@@ -3960,8 +3960,8 @@ class EthModuleTest:
             w3.eth.call(txn_params)
         assert excinfo.value.data == data
 
-    def test_eth_simulateV1(self, w3: "Web3") -> None:
-        simulate_result = w3.eth.simulateV1(
+    def test_eth_simulate_v1(self, w3: "Web3") -> None:
+        simulate_result = w3.eth.simulate_v1(
             {
                 "blockStateCalls": [
                     {

--- a/web3/_utils/rpc_abi.py
+++ b/web3/_utils/rpc_abi.py
@@ -51,6 +51,7 @@ class RPC:
     eth_blobBaseFee = RPCEndpoint("eth_blobBaseFee")
     eth_blockNumber = RPCEndpoint("eth_blockNumber")
     eth_call = RPCEndpoint("eth_call")
+    eth_simulateV1 = RPCEndpoint("eth_simulateV1")
     eth_createAccessList = RPCEndpoint("eth_createAccessList")
     eth_chainId = RPCEndpoint("eth_chainId")
     eth_estimateGas = RPCEndpoint("eth_estimateGas")

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -300,7 +300,7 @@ class AsyncEth(BaseEth):
         ]
     ] = Method(RPC.eth_simulateV1)
 
-    async def simulateV1(
+    async def simulate_v1(
         self,
         payload: SimulateV1Payload,
         block_identifier: BlockIdentifier,

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -7,6 +7,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Sequence,
     Tuple,
     Type,
     Union,
@@ -89,6 +90,8 @@ from web3.types import (
     LogsSubscriptionArg,
     Nonce,
     SignedTx,
+    SimulateV1Payload,
+    SimulateV1Result,
     StateOverride,
     SubscriptionType,
     SyncStatus,
@@ -287,6 +290,22 @@ class AsyncEth(BaseEth):
                 transaction["data"] = durin_calldata
 
         raise TooManyRequests("Too many CCIP read redirects")
+
+    # eth_simulateV1
+
+    _simulateV1: Method[
+        Callable[
+            [SimulateV1Payload, BlockIdentifier],
+            Awaitable[Sequence[SimulateV1Result]],
+        ]
+    ] = Method(RPC.eth_simulateV1)
+
+    async def simulateV1(
+        self,
+        payload: SimulateV1Payload,
+        block_identifier: BlockIdentifier,
+    ) -> Sequence[SimulateV1Result]:
+        return await self._simulateV1(payload, block_identifier)
 
     # eth_createAccessList
 

--- a/web3/eth/eth.py
+++ b/web3/eth/eth.py
@@ -85,6 +85,8 @@ from web3.types import (
     MerkleProof,
     Nonce,
     SignedTx,
+    SimulateV1Payload,
+    SimulateV1Result,
     StateOverride,
     SyncStatus,
     TxData,
@@ -269,6 +271,19 @@ class Eth(BaseEth):
                 transaction["data"] = durin_calldata
 
         raise TooManyRequests("Too many CCIP read redirects")
+
+    # eth_simulateV1
+
+    _simulateV1: Method[
+        Callable[[SimulateV1Payload, BlockIdentifier], Sequence[SimulateV1Result]]
+    ] = Method(RPC.eth_simulateV1)
+
+    def simulateV1(
+        self,
+        payload: SimulateV1Payload,
+        block_identifier: BlockIdentifier,
+    ) -> Sequence[SimulateV1Result]:
+        return self._simulateV1(payload, block_identifier)
 
     # eth_createAccessList
 

--- a/web3/eth/eth.py
+++ b/web3/eth/eth.py
@@ -278,7 +278,7 @@ class Eth(BaseEth):
         Callable[[SimulateV1Payload, BlockIdentifier], Sequence[SimulateV1Result]]
     ] = Method(RPC.eth_simulateV1)
 
-    def simulateV1(
+    def simulate_v1(
         self,
         payload: SimulateV1Payload,
         block_identifier: BlockIdentifier,

--- a/web3/types.py
+++ b/web3/types.py
@@ -197,10 +197,10 @@ class LogReceipt(TypedDict):
     blockNumber: BlockNumber
     data: HexBytes
     logIndex: int
+    removed: bool
     topics: Sequence[HexBytes]
     transactionHash: HexBytes
     transactionIndex: int
-    removed: bool
 
 
 class SubscriptionResponse(TypedDict):
@@ -336,7 +336,7 @@ class StateOverrideParams(TypedDict, total=False):
     stateDiff: Optional[Dict[HexStr, HexStr]]
 
 
-StateOverride = Dict[ChecksumAddress, StateOverrideParams]
+StateOverride = Dict[Union[str, Address, ChecksumAddress], StateOverrideParams]
 
 
 GasPriceStrategy = Union[
@@ -565,6 +565,30 @@ class OpcodeTrace(TypedDict, total=False):
     failed: bool
     returnValue: str
     structLogs: List[StructLog]
+
+
+class BlockStateCallV1(TypedDict):
+    blockOverrides: NotRequired[BlockData]
+    stateOverrides: NotRequired[StateOverride]
+    calls: Sequence[TxParams]
+
+
+class SimulateV1Payload(TypedDict):
+    blockStateCalls: Sequence[BlockStateCallV1]
+    validation: NotRequired[bool]
+    traceTransfers: NotRequired[bool]
+
+
+class SimulateV1CallResult(TypedDict):
+    returnData: HexBytes
+    logs: Sequence[LogReceipt]
+    gasUsed: int
+    status: int
+    error: NotRequired[RPCError]
+
+
+class SimulateV1Result(BlockData):
+    calls: Sequence[SimulateV1CallResult]
 
 
 #


### PR DESCRIPTION
### What was wrong?

Though [ethereum/execution-apis#484](https://github.com/ethereum/execution-apis/pull/484) has not yet been merged, many clients have already implemented `eth_simulateV1`. This PR adds support for `eth_simulateV1` RPC endpoint requests with formatters and expected types.

Closes #3494

### How was it fixed?

- Add `eth_simulateV1` support for `eth` and `async_eth`
- Add related formatters and types
- Add integration tests
- [unrelated] Open up the typing for `StateOverride` type keys to better match `TxParams`: accepts `str` and `Address` in addition to `ChecksumAddress`. We already use formatters that turn these values into the checksum address.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="1107" alt="Screenshot 2025-02-18 at 16 23 26" src="https://github.com/user-attachments/assets/d668f14b-4691-4b59-9dca-64ef2a24dac1" />

