### PR TITLE
Fix numerical formatting and byte encoding issues in test_utils_functions.py

### DIFF
--- a/tests/core/filtering/test_utils_functions.py
+++ b/tests/core/filtering/test_utils_functions.py
@@ -20,7 +20,7 @@ from web3.exceptions import (
     (
         (
             pytest.param(
-                (-12345, 000, 111, Decimal(2) + Decimal(1) / Decimal(10)),
+                (-12345, 0, 111, Decimal(2) + Decimal(1) / Decimal(10)),
                 False,
                 (
                     ("int", (-12345,)),
@@ -33,7 +33,7 @@ from web3.exceptions import (
         ),
         (
             pytest.param(
-                (-12345, 000, 111, Decimal(2) + Decimal(1) / Decimal(10)),
+                (-12345, 0, 111, Decimal(2) + Decimal(1) / Decimal(10)),
                 True,
                 (
                     ("int", (-12345,)),
@@ -65,7 +65,7 @@ from web3.exceptions import (
                     ("string", ("aye",)),
                     ("string", ("bee",)),
                     ("string", ("sea",)),
-                    ("bytes", (b"\x124",)),
+                    ("bytes", (b"\x12\x34",)),
                 ),
                 id="tuple with valid string and hex values",
             )
@@ -147,7 +147,7 @@ def test_match_fn_with_various_data_types(w3, data, expected, match_data_and_abi
             pytest.param(
                 (("0x12343434",)),
                 True,
-                (("bytes4", (b"\x12444",)),),
+                (("bytes4", (b"\x12\x34\x34\x34",)),),
                 id="tuple with valid hex string",
             )
         ),
@@ -171,7 +171,7 @@ def test_match_fn_with_various_data_types(w3, data, expected, match_data_and_abi
             pytest.param(
                 (("0x1212", b"34"),),
                 False,
-                (("bytes2[]", ((b"12", b"34"),)),),
+                (("bytes2[]", ((b"\x12", b"34"),)),),
                 id="list with incorrect hexstring and byte return values",
             )
         ),


### PR DESCRIPTION
- Incorrect numerical formatting: `000` was used instead of `0`, which is unnecessary and could lead to confusion.  

- Incorrect byte encoding in test cases:  
  - `b"\x124"` was used instead of the correct representation `b"\x12\x34"`.  
  - `b"\x12444"` was corrected to `b"\x12\x34\x34\x34"`.  
  - `b"12"` was replaced with `b"\x12"` for consistency in hex representation.  

### **Todo:**  
- [ ] Clean up commit history  
- [ ] Add or update documentation related to these changes  
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)  

### **Cute Animal Picture** 🐶🐱  
![Cute Puppy](https://s0.rbk.ru/v6_top_pics/media/img/9/72/347283057054729.webp)


