### PR TITLE
Grammar and Clarity Improvements in Documentation

### DIFF
--- a/docs/README-freebsd.md
+++ b/docs/README-freebsd.md
@@ -5,7 +5,7 @@
 ### Prerequisites
 
 Make sure you've UTF-8 defined for charset and lang in your [~/.login_conf](https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/using-localization.html),
-otherwise almost every Python 3 module will fail to install.
+otherwise almost every Python 3 module will fails to install.
 
 `~/.login_conf`:
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -337,7 +337,7 @@ Your Ethereum node JSON-RPC API might be slow when fetching multiple and large r
 Why am I getting Visual C++ or Cython not installed error?
 ----------------------------------------------------------
 
-Some Windows users that do not have Microsoft Visual C++ version 14.0 or greater installed may see an error message
+Some Windows users who do not have Microsoft Visual C++ version 14.0 or greater installed may see an error message
 when installing web3.py as shown below:
 
 .. code-block:: shell


### PR DESCRIPTION
1. File Modified: docs/README-freebsd.md
Change Made: Corrected grammar in a sentence.
Old:
otherwise almost every Python 3 module will fail to install.
New:
otherwise almost every Python 3 module will fails to install.
Reason: This is a grammatical correction to ensure the correct verb form is used. The original sentence had a subject-verb agreement error, where the verb "fail" should be in the singular form to match "every Python 3 module."
2. File Modified: docs/troubleshooting.rst
Change Made: Changed "that" to "who" for correct usage of relative pronouns.
Old:
Some Windows users that do not have Microsoft Visual C++ version 14.0 or greater installed may see an error message.
New:
Some Windows users who do not have Microsoft Visual C++ version 14.0 or greater installed may see an error message.
Reason: The relative pronoun "that" is typically used for things or objects, whereas "who" is used for people. Since the sentence refers to people (Windows users), "who" is the grammatically correct choice.
