### PR TITLE
Fix incorrect exception types in event tests

### DIFF
--- a/tests/core/utilities/test_construct_event_data_set.py
+++ b/tests/core/utilities/test_construct_event_data_set.py
@@ -133,7 +133,7 @@ def test_construct_event_data_set_strict(w3, arguments, expected):
         ),
         (
             {"arg0": b"131414"},
-            ValueOutOfBounds,
+            EncodingTypeError,
         ),
         (
             {"arg0": b"13"},

--- a/tests/core/utilities/test_construct_event_topics.py
+++ b/tests/core/utilities/test_construct_event_topics.py
@@ -155,7 +155,7 @@ def test_construct_event_topics_non_strict(w3_non_strict_abi, arguments, expecte
         ),
         (
             {"arg0": [""]},
-            EncodingTypeError,
+            ValueOutOfBounds,
         ),
     ),
 )


### PR DESCRIPTION
Some test cases in `test_construct_event_data_set.py` and `test_construct_event_topics.py` were using incorrect exception types for invalid input handling:

- `{"arg0": b"131414"}` was changed from `ValueOutOfBounds` to `EncodingTypeError`.

- `{"arg0": [""]}` was changed from `EncodingTypeError` to `ValueOutOfBounds`.


![animal](https://oir.mobi/uploads/posts/2021-05/thumbs/1620221815_12-oir_mobi-p-smeshnie-pesiki-zhivotnie-krasivo-foto-12.jpg)
