### PR TITLE
 Update type annotations in persistent provider and fix error in validation error message

### DIFF
--- a/web3/_utils/validation.py
+++ b/web3/_utils/validation.py
@@ -131,7 +131,7 @@ def validate_abi_value(abi_type: TypeStr, value: Any) -> None:
                 )
             if specified_length != len(value):
                 raise Web3TypeError(
-                    "The following array length does not the length specified"
+                    "The following array length does not match the length specified "
                     f"by the abi-type, {abi_type}: {value}"
                 )
 

--- a/web3/providers/persistent/persistent.py
+++ b/web3/providers/persistent/persistent.py
@@ -68,11 +68,15 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
     logger = logging.getLogger("web3.providers.PersistentConnectionProvider")
     has_persistent_connection = True
 
-    _send_func_cache: Tuple[Optional[int], Optional[Callable[..., Coroutine[Any, Any, RPCRequest]]]] = (
+    _send_func_cache: Tuple[
+        Optional[int], Optional[Callable[..., Coroutine[Any, Any, RPCRequest]]]
+    ] = (
         None,
         None,
     )
-    _recv_func_cache: Tuple[Optional[int], Optional[Callable[..., Coroutine[Any, Any, RPCResponse]]]] = (
+    _recv_func_cache: Tuple[
+        Optional[int], Optional[Callable[..., Coroutine[Any, Any, RPCResponse]]]
+    ] = (
         None,
         None,
     )

--- a/web3/providers/persistent/persistent.py
+++ b/web3/providers/persistent/persistent.py
@@ -68,11 +68,11 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
     logger = logging.getLogger("web3.providers.PersistentConnectionProvider")
     has_persistent_connection = True
 
-    _send_func_cache: Tuple[int, Callable[..., Coroutine[Any, Any, RPCRequest]]] = (
+    _send_func_cache: Tuple[Optional[int], Optional[Callable[..., Coroutine[Any, Any, RPCRequest]]]] = (
         None,
         None,
     )
-    _recv_func_cache: Tuple[int, Callable[..., Coroutine[Any, Any, RPCResponse]]] = (
+    _recv_func_cache: Tuple[Optional[int], Optional[Callable[..., Coroutine[Any, Any, RPCResponse]]]] = (
         None,
         None,
     )


### PR DESCRIPTION
- The error message incorrectly stated:  
    `"The following array length does not the length specified"`  
  - It was missing the word **"match"**, leading to unclear error messaging.
  
- Incorrect Type Annotations:  
  - `_send_func_cache` and `_recv_func_cache` were annotated as `Tuple[int, Callable[..., Coroutine[Any, Any, RPCRequest]]]`, but were initialized with `(None, None)`, causing type inconsistency.  
  - This could lead to type-checking errors when using `mypy` or similar tools.