### PR TITLE
Use ``-U`` for geth steps to install `py-geth`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ geth_steps: &geth_steps
               sudo apt-get install -y build-essential
               pygeth_version=$(python web3/scripts/parse_pygeth_version.py)
               echo "installing py-geth$pygeth_version"
-              pip install --user "py-geth$pygeth_version"
+              pip install -U --user "py-geth$pygeth_version"
               python -m geth.install v<< pipeline.parameters.geth_version >>
             fi
             sudo ln -s /home/circleci/.py-geth/geth-v<< pipeline.parameters.geth_version >>/bin/geth /usr/local/bin/geth

--- a/newsfragments/3637.internal.rst
+++ b/newsfragments/3637.internal.rst
@@ -1,0 +1,1 @@
+Use ``-U`` to install latest `py-geth` version for CI geth steps. This is usually a requirement if we're missing the binary for the newly-generated fixture geth version.


### PR DESCRIPTION
### What was wrong?

- Issues with CI on main after pushing an update to the geth test fixture.

### How was it fixed?

- ``-U`` will update the version to the latest even if a *py-geth* version is already installed. This is required if we have just updated the test fixture and need to install the new geth version from the latest *py-geth* version.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fs-i.huffpost.com%2Fgen%2F3311140%2Fimages%2Fo-FENNEC-FOX-facebook.jpg&f=1&nofb=1&ipt=5c53d6562fea52de507491245f4c8a8f1db60a36183961b1ca9fed79dbfb5e48&ipo=images)
