### PR TITLE
Fix Grammar and Formatting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 parameters:
-  # NOTE: Do not update the `geth_version` manually. It is updated during the
+  # NOTE: Do not update the `geth_version` manually. It is updated during
   # integration test fixture generation.
   geth_version:
     default: "1.15.5"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,4 +13,4 @@ Closes #
 
 #### Cute Animal Picture
 
-![Put a link to a cute animal picture inside the parenthesis-->](<>)
+![Put a link to a cute animal picture inside the parentheses-->](<>)


### PR DESCRIPTION
Fixed grammar in .circleci/config.yml

Change: Removed unnecessary "the" at the end of a sentence.
Reason: Improved sentence clarity.

Corrected plural form in .github/pull_request_template.md

Change: "parenthesis" → "parentheses"
Reason: "Parentheses" is the correct plural form.