### PR TITLE
feat: optimize with iterators

### DIFF
--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -7,6 +7,7 @@ from typing import (
     Collection,
     Dict,
     Iterable,
+    Iterator,
     NoReturn,
     Tuple,
     TypeVar,
@@ -35,7 +36,6 @@ from eth_utils.curried import (
     is_string,
     to_checksum_address,
     to_list,
-    to_tuple,
 )
 from eth_utils.toolz import (
     complement,
@@ -1094,11 +1094,10 @@ ERROR_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
 }
 
 
-@to_tuple
 def combine_formatters(
     formatter_maps: Collection[Dict[RPCEndpoint, Callable[..., TReturn]]],
     method_name: RPCEndpoint,
-) -> Iterable[Callable[..., TReturn]]:
+) -> Iterator[Callable[..., TReturn]]:
     for formatter_map in formatter_maps:
         if method_name in formatter_map:
             yield formatter_map[method_name]
@@ -1234,12 +1233,11 @@ FILTER_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
 }
 
 
-@to_tuple
 def apply_module_to_formatters(
     formatters: Iterable[Callable[..., TReturn]],
     module: "Module",
     method_name: Union[RPCEndpoint, Callable[..., RPCEndpoint]],
-) -> Iterable[Callable[..., TReturn]]:
+) -> Iterator[Callable[..., TReturn]]:
     for f in formatters:
         yield partial(f, module, method_name)
 

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -139,7 +139,9 @@ TFilter = TypeVar(
     LogFilter,
 )
 
-FilterResultFormatter = Callable[[Union["AsyncEth", "Eth"], RPCEndpoint, TValue], TFilter]
+FilterResultFormatter = Callable[
+    [Union["AsyncEth", "Eth"], RPCEndpoint, TValue], TFilter
+]
 
 
 def bytes_to_ascii(value: bytes) -> str:
@@ -1240,7 +1242,9 @@ def filter_wrapper(
         )
 
 
-FILTER_RESULT_FORMATTERS: Dict[RPCEndpoint, FilterResultFormatter[HexStr, AnyFilter]] = {
+FILTER_RESULT_FORMATTERS: Dict[
+    RPCEndpoint, FilterResultFormatter[HexStr, AnyFilter]
+] = {
     RPC.eth_newPendingTransactionFilter: filter_wrapper,
     RPC.eth_newBlockFilter: filter_wrapper,
     RPC.eth_newFilter: filter_wrapper,

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -1230,7 +1230,7 @@ def filter_wrapper(
         )
 
 
-FILTER_RESULT_FORMATTERS: Dict[RPCEndpoint, FilterResultFormatter[HexStr, Filter]] = {
+FILTER_RESULT_FORMATTERS: Dict[RPCEndpoint, FilterResultFormatter[HexStr, AnyFilter]] = {
     RPC.eth_newPendingTransactionFilter: filter_wrapper,
     RPC.eth_newBlockFilter: filter_wrapper,
     RPC.eth_newFilter: filter_wrapper,

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -129,7 +129,9 @@ AnyFilter = Union[
     LogFilter,
 ]
 
-FilterResultFormatter = Callable[[Union["AsyncEth", "Eth"], RPCEndpoint, TValue], TReturn]
+TFilter = TypeVar("TFilter", bound=AnyFilter)
+
+FilterResultFormatter = Callable[[Union["AsyncEth", "Eth"], RPCEndpoint, TValue], TFilter]
 
 
 def bytes_to_ascii(value: bytes) -> str:
@@ -1238,10 +1240,10 @@ FILTER_RESULT_FORMATTERS: Dict[RPCEndpoint, FilterResultFormatter[HexStr, AnyFil
 
 
 def apply_module_to_formatters(
-    formatters: Iterable[FilterResultFormatter[TValue, TReturn]],
+    formatters: Iterable[FilterResultFormatter[TValue, TFilter]],
     module: "Module",
     method_name: RPCEndpoint,
-) -> Iterator[Callable[[TValue], TReturn]]:
+) -> Iterator[Callable[[TValue], TFilter]]:
     for f in formatters:
         yield partial(f, module, method_name)
 

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -129,7 +129,7 @@ Filter = Union[
     LogFilter,
 ]
 
-FilterResultFormatter = Callable[["Module", RPCEndpoint, TValue], TReturn]
+FilterResultFormatter = Callable[[Union["AsyncEth", "Eth"], RPCEndpoint, TValue], TReturn]
 
 
 def bytes_to_ascii(value: bytes) -> str:

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -129,7 +129,15 @@ AnyFilter = Union[
     LogFilter,
 ]
 
-TFilter = TypeVar("TFilter", bound=AnyFilter)
+TFilter = TypeVar(
+    "TFilter",
+    AsyncBlockFilter,
+    AsyncTransactionFilter,
+    AsyncLogFilter,
+    BlockFilter,
+    TransactionFilter,
+    LogFilter,
+)
 
 FilterResultFormatter = Callable[[Union["AsyncEth", "Eth"], RPCEndpoint, TValue], TFilter]
 

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -1234,10 +1234,10 @@ FILTER_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
 
 
 def apply_module_to_formatters(
-    formatters: Iterable[Callable[..., TReturn]],
+    formatters: Iterable[Callable[["Module", RPCEndpoint, TValue], TReturn]],
     module: "Module",
     method_name: RPCEndpoint,
-) -> Iterator[Callable[..., TReturn]]:
+) -> Iterator[Callable[[TValue], TReturn]]:
     for f in formatters:
         yield partial(f, module, method_name)
 

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -1236,7 +1236,7 @@ FILTER_RESULT_FORMATTERS: Dict[RPCEndpoint, Callable[..., Any]] = {
 def apply_module_to_formatters(
     formatters: Iterable[Callable[..., TReturn]],
     module: "Module",
-    method_name: Union[RPCEndpoint, Callable[..., RPCEndpoint]],
+    method_name: RPCEndpoint,
 ) -> Iterator[Callable[..., TReturn]]:
     for f in formatters:
         yield partial(f, module, method_name)

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -119,7 +119,6 @@ if TYPE_CHECKING:
     from web3.module import Module  # noqa: F401
 
 TValue = TypeVar("TValue")
-TReturn = TypeVar("TReturn")
 
 Filter = Union[
     AsyncBlockFilter,

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -120,7 +120,7 @@ if TYPE_CHECKING:
 
 TValue = TypeVar("TValue")
 
-Filter = Union[
+AnyFilter = Union[
     AsyncBlockFilter,
     AsyncTransactionFilter,
     AsyncLogFilter,
@@ -1204,7 +1204,7 @@ def filter_wrapper(
     module: Union["AsyncEth", "Eth"],
     method: RPCEndpoint,
     filter_id: HexStr,
-) -> Filter:
+) -> AnyFilter:
     if method == RPC.eth_newBlockFilter:
         if module.is_async:
             return AsyncBlockFilter(filter_id, eth_module=cast("AsyncEth", module))


### PR DESCRIPTION
### What was wrong?

The formatters init quite a few lists each run, and can be made much more efficient using iterators. This PR does so.

I figured this was more important than the logger stuff in my last PR so finished this one up first.


Related to Issue # N/A
Closes # N/A

### How was it fixed?
creation of an IteratorProxy class that allows `map` objects to be passed thru the formatters instead of fully materializing a list every step of the way

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](
![image](https://github.com/user-attachments/assets/1ea49fa5-c0b6-4381-ab97-4b19b7b5e1ce)
)
