### PR TITLE
somewhat fixed Batching thread safety

### DIFF
--- a/newsfragments/3661.bugfix.rst
+++ b/newsfragments/3661.bugfix.rst
@@ -1,0 +1,1 @@
+Moves base providers' ``_is_batching`` and ``_batch_request_func_cache`` from class to instance attrs to help with thread safety.

--- a/web3/providers/async_base.py
+++ b/web3/providers/async_base.py
@@ -75,12 +75,6 @@ class AsyncBaseProvider:
         Tuple[Middleware, ...], Callable[..., Coroutine[Any, Any, RPCResponse]]
     ] = (None, None)
 
-    _is_batching: bool = False
-    _batch_request_func_cache: Tuple[
-        Tuple[Middleware, ...],
-        Callable[..., Coroutine[Any, Any, Union[List[RPCResponse], RPCResponse]]],
-    ] = (None, None)
-
     is_async = True
     has_persistent_connection = False
     global_ccip_read_enabled: bool = True
@@ -100,6 +94,11 @@ class AsyncBaseProvider:
         self.cache_allowed_requests = cache_allowed_requests
         self.cacheable_requests = cacheable_requests or CACHEABLE_REQUESTS
         self.request_cache_validation_threshold = request_cache_validation_threshold
+        self._is_batching: bool = False
+        self._batch_request_func_cache: Tuple[
+            Tuple[Middleware, ...],
+            Callable[..., Coroutine[Any, Any, Union[List[RPCResponse], RPCResponse]]],
+        ] = (None, None)
 
     async def request_func(
         self, async_w3: "AsyncWeb3", middleware_onion: MiddlewareOnion

--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -116,14 +116,14 @@ class BaseProvider:
 class JSONBaseProvider(BaseProvider):
     logger = logging.getLogger("web3.providers.base.JSONBaseProvider")
 
-    _is_batching: bool = False
-    _batch_request_func_cache: Tuple[
-        Tuple[Middleware, ...], Callable[..., Union[List[RPCResponse], RPCResponse]]
-    ] = (None, None)
-
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.request_counter = itertools.count()
+
+        self._is_batching: bool = False
+        self._batch_request_func_cache: Tuple[
+            Tuple[Middleware, ...], Callable[..., Union[List[RPCResponse], RPCResponse]]
+        ] = (None, None)
 
     def encode_rpc_request(self, method: RPCEndpoint, params: Any) -> bytes:
         rpc_dict = {


### PR DESCRIPTION
The batching flag is set on the class, instead of likely as intended as an instance attribute. The style in which the attribute was set is common for other programming languages, but in Python this results in class level attributes, which are shared across all instances of that class. In this case the result was that everything breaks once web3.py was used in an concurrent (multi threaded) set up while using the new batching functionality. Even creating multiple w3 instances did not solve the issue as the batching flag was shared across all instances of JSONBaseProvider. There still is work required to make the batching feature thread save, but with this fix it should at least be possible to create multiple w3 instances to use each in it's own thread.
This is a step towards fixing #3613
Also the Async provider likely needs similar modifications.