### PR TITLE
Allow setting the request information cache size:

### DIFF
--- a/docs/providers.rst
+++ b/docs/providers.rst
@@ -233,7 +233,9 @@ Persistent Connection Base Class
 .. py:class:: web3.providers.persistent.PersistentConnectionProvider(\
         request_timeout: float = 50.0, \
         subscription_response_queue_size: int = 500, \
-        silence_listener_task_exceptions: bool = False\
+        silence_listener_task_exceptions: bool = False \
+        max_connection_retries: int = 5, \
+        request_information_cache_size: int = 500, \
     )
 
     This is a base provider class, inherited by the following providers:
@@ -261,6 +263,13 @@ Persistent Connection Base Class
     * ``silence_listener_task_exceptions`` is a boolean that determines whether
       exceptions raised by the listener task are silenced. Defaults to ``False``,
       raising any exceptions that occur in the listener task.
+
+    * ``max_connection_retries`` is the maximum number of times to retry a connection
+      to the provider when initializing the provider. Defaults to ``5``.
+
+    * ``request_information_cache_size`` specifies the size of the transient cache for
+      storing request details, enabling the provider to process responses based on the
+      original request information. Defaults to ``500``.
 
 AsyncIPCProvider
 ++++++++++++++++

--- a/newsfragments/3662.feature.rst
+++ b/newsfragments/3662.feature.rst
@@ -1,0 +1,1 @@
+Allow setting the ``request_information_cache_size`` for ``PersistentConnectionProvider`` implementations.

--- a/web3/providers/persistent/persistent.py
+++ b/web3/providers/persistent/persistent.py
@@ -87,12 +87,14 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
         subscription_response_queue_size: int = 500,
         silence_listener_task_exceptions: bool = False,
         max_connection_retries: int = 5,
+        request_information_cache_size: int = 500,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self._request_processor = RequestProcessor(
             self,
             subscription_response_queue_size=subscription_response_queue_size,
+            request_information_cache_size=request_information_cache_size,
         )
         self._message_listener_task: Optional["asyncio.Task[None]"] = None
         self._batch_request_counter: Optional[int] = None

--- a/web3/providers/persistent/request_processor.py
+++ b/web3/providers/persistent/request_processor.py
@@ -85,9 +85,12 @@ class RequestProcessor:
         self,
         provider: "PersistentConnectionProvider",
         subscription_response_queue_size: int = 500,
+        request_information_cache_size: int = 500,
     ) -> None:
         self._provider = provider
-        self._request_information_cache: SimpleCache = SimpleCache(500)
+        self._request_information_cache: SimpleCache = SimpleCache(
+            request_information_cache_size
+        )
         self._request_response_cache: SimpleCache = SimpleCache(500)
         self._subscription_response_queue: TaskReliantQueue[
             Union[RPCResponse, TaskNotRunning]
@@ -152,6 +155,12 @@ class RequestProcessor:
             cache_key,
             request_info,
         )
+        if self._request_information_cache.is_full():
+            self._provider.logger.warning(
+                "Request information cache is full. This may result in unexpected "
+                "behavior. Consider increasing the ``request_information_cache_size`` "
+                "on the provider."
+            )
         return cache_key
 
     def pop_cached_request_information(

--- a/web3/utils/caching.py
+++ b/web3/utils/caching.py
@@ -25,6 +25,12 @@ class SimpleCache:
         self._size = size
         self._data: OrderedDict[str, Any] = OrderedDict()
 
+    def __contains__(self, key: str) -> bool:
+        return key in self._data
+
+    def __len__(self) -> int:
+        return len(self._data)
+
     def cache(self, key: str, value: Any) -> Tuple[Any, Dict[str, Any]]:
         evicted_items = {}
         # If the key is already in the OrderedDict just update it
@@ -59,11 +65,8 @@ class SimpleCache:
     def popitem(self, last: bool = True) -> Tuple[str, Any]:
         return self._data.popitem(last=last)
 
-    def __contains__(self, key: str) -> bool:
-        return key in self._data
-
-    def __len__(self) -> int:
-        return len(self._data)
+    def is_full(self) -> bool:
+        return len(self._data) >= self._size
 
     # -- async utility methods -- #
 


### PR DESCRIPTION
### What was wrong?

- This was a feature that had been requested while the WebsocketProviderV2 was being developed, in beta. We did not forward-port this to the WebSocketProvider in ``v7``. relevant ``v6`` PR: https://github.com/ethereum/web3.py/pull/3226

Closes #3660

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="475" alt="Screenshot 2025-04-14 at 15 42 59" src="https://github.com/user-attachments/assets/8631d6b6-f826-45d6-abda-8a8a4dd50560" />
