### PR TITLE
check _request_information_cache value is a dict before .get-ing from it

### DIFF
--- a/newsfragments/3642.bugfix.rst
+++ b/newsfragments/3642.bugfix.rst
@@ -1,1 +1,1 @@
-Checks that ``PersistentConnectionProvider`` response cache value is a dict before attempting to access it like one.
+Checks that ``PersistentConnectionProvider`` response cache value is a dict before attempting to access it like one. Also adds checks to ``make_batch_request`` to make sure it is in batching mode before being called and is not after.

--- a/newsfragments/3642.bugfix.rst
+++ b/newsfragments/3642.bugfix.rst
@@ -1,0 +1,1 @@
+Checks that ``PersistentConnectionProvider`` response cache value is a dict before attempting to access it like one.

--- a/tests/core/providers/test_http_provider.py
+++ b/tests/core/providers/test_http_provider.py
@@ -132,3 +132,21 @@ def test_http_empty_batch_response(mock_post):
 
     # assert that even though there was an error, we have reset the batching state
     assert not w3.provider._is_batching
+
+
+@patch(
+    "web3._utils.http_session_manager.HTTPSessionManager.make_post_request",
+    new_callable=Mock,
+)
+def test_sync_provider_is_batching_when_make_batch_request(mock_post):
+    def assert_is_batching_and_return_response(*_args, **_kwargs) -> bytes:
+        assert provider._is_batching
+        return b'{"jsonrpc":"2.0","id":1,"result":["0x1"]}'
+
+    provider = HTTPProvider()
+    assert not provider._is_batching
+
+    mock_post.side_effect = assert_is_batching_and_return_response
+
+    provider.make_batch_request([("eth_blockNumber", [])])
+    assert not provider._is_batching

--- a/tests/core/providers/test_websocket_provider.py
+++ b/tests/core/providers/test_websocket_provider.py
@@ -534,3 +534,19 @@ async def test_req_info_cache_size_can_be_set_and_warns_when_full(caplog):
             "behavior. Consider increasing the ``request_information_cache_size`` "
             "on the provider."
         ) in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_raise_stray_errors_from_cache_handles_list_response():
+    provider = WebSocketProvider("ws://mocked")
+    _mock_ws(provider)
+
+    bad_response = [
+        {"id": None, "jsonrpc": "2.0", "error": {"code": 21, "message": "oops"}}
+    ]
+    provider._request_processor._request_response_cache._data["bad_key"] = bad_response
+
+    try:
+        provider._raise_stray_errors_from_cache()
+    except Exception as e:
+        pytest.fail(f"{e}")

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -30,6 +30,7 @@ from web3.types import (
 )
 
 from .._utils.batching import (
+    batching_context,
     sort_batch_response_by_response_ids,
 )
 from .._utils.caching import (
@@ -201,6 +202,7 @@ class IPCProvider(JSONBaseProvider):
         request = self.encode_rpc_request(method, params)
         return self._make_request(request)
 
+    @batching_context
     def make_batch_request(
         self, requests: List[Tuple[RPCEndpoint, Any]]
     ) -> List[RPCResponse]:

--- a/web3/providers/legacy_websocket.py
+++ b/web3/providers/legacy_websocket.py
@@ -27,6 +27,7 @@ from websockets.legacy.client import (
 )
 
 from web3._utils.batching import (
+    batching_context,
     sort_batch_response_by_response_ids,
 )
 from web3._utils.caching import (
@@ -143,6 +144,7 @@ class LegacyWebSocketProvider(JSONBaseProvider):
         )
         return future.result()
 
+    @batching_context
     def make_batch_request(
         self, requests: List[Tuple[RPCEndpoint, Any]]
     ) -> List[RPCResponse]:

--- a/web3/providers/persistent/persistent.py
+++ b/web3/providers/persistent/persistent.py
@@ -24,6 +24,7 @@ from websockets import (
 
 from web3._utils.batching import (
     BATCH_REQUEST_ID,
+    async_batching_context,
     sort_batch_response_by_response_ids,
 )
 from web3._utils.caching import (
@@ -237,14 +238,17 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
         rpc_request = await self.send_request(method, params)
         return await self.recv_for_request(rpc_request)
 
+    @async_batching_context
     async def make_batch_request(
         self, requests: List[Tuple[RPCEndpoint, Any]]
     ) -> List[RPCResponse]:
         request_data = self.encode_batch_rpc_request(requests)
         await self.socket_send(request_data)
 
+        # breakpoint()
         response = cast(
-            List[RPCResponse], await self._get_response_for_request_id(BATCH_REQUEST_ID)
+            List[RPCResponse],
+            await self._get_response_for_request_id(BATCH_REQUEST_ID),
         )
         return response
 

--- a/web3/providers/persistent/persistent.py
+++ b/web3/providers/persistent/persistent.py
@@ -320,17 +320,16 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
             for (
                 response
             ) in self._request_processor._request_response_cache._data.values():
-                request = (
-                    self._request_processor._request_information_cache.get_cache_entry(
+                if isinstance(response, dict):
+                    request = self._request_processor._request_information_cache.get_cache_entry(  # noqa: E501
                         generate_cache_key(response["id"])
                     )
-                )
-                if "error" in response and request is None:
-                    # if we find an error response in the cache without a corresponding
-                    # request, raise the error
-                    validate_rpc_response_and_raise_if_error(
-                        response, None, logger=self.logger
-                    )
+                    if "error" in response and request is None:
+                        # if we find an error response in the cache without a
+                        # corresponding request, raise the error
+                        validate_rpc_response_and_raise_if_error(
+                            cast(RPCResponse, response), None, logger=self.logger
+                        )
 
     async def _message_listener(self) -> None:
         self.logger.info(

--- a/web3/providers/rpc/async_rpc.py
+++ b/web3/providers/rpc/async_rpc.py
@@ -36,6 +36,7 @@ from web3.types import (
 )
 
 from ..._utils.batching import (
+    async_batching_context,
     sort_batch_response_by_response_ids,
 )
 from ..._utils.caching import (
@@ -166,6 +167,7 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
         )
         return response
 
+    @async_batching_context
     async def make_batch_request(
         self, batch_requests: List[Tuple[RPCEndpoint, Any]]
     ) -> Union[List[RPCResponse], RPCResponse]:

--- a/web3/providers/rpc/rpc.py
+++ b/web3/providers/rpc/rpc.py
@@ -34,6 +34,7 @@ from web3.types import (
 )
 
 from ..._utils.batching import (
+    batching_context,
     sort_batch_response_by_response_ids,
 )
 from ..._utils.caching import (
@@ -174,6 +175,7 @@ class HTTPProvider(JSONBaseProvider):
         )
         return response
 
+    @batching_context
     def make_batch_request(
         self, batch_requests: List[Tuple[RPCEndpoint, Any]]
     ) -> Union[List[RPCResponse], RPCResponse]:


### PR DESCRIPTION
### What was wrong?
Mixing batching and non-batching calls causing issues.

Closes #3642 

### How was it fixed?
 - Check that the value from cache is a `dict` before `get`ting from it.
 - Add `try/finally` blocks (via a decorator) to all `make_batch_request` functions to make sure `_is_batching` is `True` when called and reset to `False` afterwards.

### Todo:

- [x] Clean up commit history
- [ ] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/8c7ab5cf-df2e-4fc0-9007-15efcc2e2b86)
