### PR TITLE
Limit hypothesis integers in contract data and topic tests to a max value of MAX_UINT_256

### DIFF
--- a/newsfragments/3666.internal.rst
+++ b/newsfragments/3666.internal.rst
@@ -1,0 +1,1 @@
+Fix test failures on v6 from hypothesis upgrade

--- a/tests/core/filtering/test_contract_data_filters.py
+++ b/tests/core/filtering/test_contract_data_filters.py
@@ -9,6 +9,7 @@ from hypothesis import (
 import pytest_asyncio
 
 from tests.core.filtering.utils import (
+    MAX_UINT_256,
     _async_emitter_fixture_logic,
     _async_w3_fixture_logic,
     _emitter_fixture_logic,
@@ -39,14 +40,16 @@ def dynamic_values(draw):
 
 @st.composite
 def fixed_values(draw):
-    non_matching_1 = draw(st.integers(min_value=0))
-    non_matching_2 = draw(st.integers(min_value=0))
-    non_matching_3 = draw(st.integers(min_value=0))
-    non_matching_4 = draw(st.integers(min_value=0))
+    non_matching_1 = draw(st.integers(min_value=0, max_value=MAX_UINT_256))
+    non_matching_2 = draw(st.integers(min_value=0, max_value=MAX_UINT_256))
+    non_matching_3 = draw(st.integers(min_value=0, max_value=MAX_UINT_256))
+    non_matching_4 = draw(st.integers(min_value=0, max_value=MAX_UINT_256))
     exclusions = (non_matching_1, non_matching_2, non_matching_3, non_matching_4)
     matching_values = draw(
         st.lists(
-            elements=st.integers(min_value=0).filter(lambda x: x not in exclusions),
+            elements=st.integers(min_value=0, max_value=MAX_UINT_256).filter(
+                lambda x: x not in exclusions
+            ),
             min_size=4,
             max_size=4,
         )

--- a/tests/core/filtering/test_contract_topic_filters.py
+++ b/tests/core/filtering/test_contract_topic_filters.py
@@ -9,6 +9,7 @@ from hypothesis import (
 import pytest_asyncio
 
 from tests.core.filtering.utils import (
+    MAX_UINT_256,
     _async_emitter_fixture_logic,
     _async_w3_fixture_logic,
     _emitter_fixture_logic,
@@ -39,14 +40,16 @@ def dynamic_values(draw):
 
 @st.composite
 def fixed_values(draw):
-    non_matching_1 = draw(st.integers(min_value=0))
-    non_matching_2 = draw(st.integers(min_value=0))
-    non_matching_3 = draw(st.integers(min_value=0))
-    non_matching_4 = draw(st.integers(min_value=0))
+    non_matching_1 = draw(st.integers(min_value=0, max_value=MAX_UINT_256))
+    non_matching_2 = draw(st.integers(min_value=0, max_value=MAX_UINT_256))
+    non_matching_3 = draw(st.integers(min_value=0, max_value=MAX_UINT_256))
+    non_matching_4 = draw(st.integers(min_value=0, max_value=MAX_UINT_256))
     exclusions = (non_matching_1, non_matching_2, non_matching_3, non_matching_4)
     matching_values = draw(
         st.lists(
-            elements=st.integers(min_value=0).filter(lambda x: x not in exclusions),
+            elements=st.integers(min_value=0, max_value=MAX_UINT_256).filter(
+                lambda x: x not in exclusions
+            ),
             min_size=4,
             max_size=4,
         )

--- a/tests/core/filtering/utils.py
+++ b/tests/core/filtering/utils.py
@@ -14,6 +14,8 @@ from web3.providers.eth_tester import (
     EthereumTesterProvider,
 )
 
+MAX_UINT_256 = 2**256 - 1
+
 
 def _w3_fixture_logic(request):
     use_filter_middleware = request.param


### PR DESCRIPTION
### What was wrong?

Tests on v6 were failing due to a hypothesis upgrade. 

### How was it fixed?

Added a max_value for hypothesis integers in filtering tests.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cf-img-a-in.tosshub.com/sites/visualstory/wp/2023/10/wp2883597.jpg?size=*:900)

