### PR TITLE
feat: optimize utility_methods.py

### DIFF
--- a/newsfragments/3667.performance.rst
+++ b/newsfragments/3667.performance.rst
@@ -1,0 +1,4 @@
+Optimize performance for:
+web3._utils.utility_methods.all_in_dict
+web3._utils.utility_methods.any_in_dict
+web3._utils.utility_methods.none_in_dict

--- a/web3/_utils/utility_methods.py
+++ b/web3/_utils/utility_methods.py
@@ -1,7 +1,7 @@
 from typing import (
     Any,
-    Dict,
     Iterable,
+    Mapping,
     Set,
     Union,
 )
@@ -13,7 +13,7 @@ from web3.types import (
 
 
 def all_in_dict(
-    values: Iterable[Any], d: Union[Dict[Any, Any], TxData, TxParams]
+    values: Iterable[Any], d: Union[Mapping[Any, Any], TxData, TxParams]
 ) -> bool:
     """
     Returns a bool based on whether ALL of the provided values exist
@@ -24,11 +24,12 @@ def all_in_dict(
     :return:       True if ALL values exist in keys;
                    False if NOT ALL values exist in keys
     """
-    return all(_ in dict(d) for _ in values)
+    d = dict(d)
+    return all(_ in d for _ in values)
 
 
 def any_in_dict(
-    values: Iterable[Any], d: Union[Dict[Any, Any], TxData, TxParams]
+    values: Iterable[Any], d: Union[Mapping[Any, Any], TxData, TxParams]
 ) -> bool:
     """
     Returns a bool based on whether ANY of the provided values exist
@@ -39,11 +40,12 @@ def any_in_dict(
     :return:       True if ANY value exists in keys;
                    False if NONE of the values exist in keys
     """
-    return any(_ in dict(d) for _ in values)
+    d = dict(d)
+    return any(_ in d for _ in values)
 
 
 def none_in_dict(
-    values: Iterable[Any], d: Union[Dict[Any, Any], TxData, TxParams]
+    values: Iterable[Any], d: Union[Mapping[Any, Any], TxData, TxParams]
 ) -> bool:
     """
     Returns a bool based on whether NONE of the provided values exist


### PR DESCRIPTION
This was originally part of my other PR but that is becoming quite cluttered and hard to review so I separated this one out. 

### What was wrong?
Previously, the code would create a new dict from `d` one time for each item in the checked iterable. Now the code creates just one new dict from `d` at the beginning and uses that same dict to check membership for each item.

Related to Issue #N/A
Closes #N/A

### How was it fixed?
Call `dict` one time prior to entering the genexp, instead of calling it repeatedly inside.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://github.com/user-attachments/assets/a1698265-1f91-4cca-b931-7253677c8efa)
