### PR TITLE
feat: optimize reject_recursive_repeats

### DIFF
--- a/newsfragments/3668.performance.rst
+++ b/newsfragments/3668.performance.rst
@@ -1,0 +1,1 @@
+Optimize web3._utils.decorators.reject_recursive_repeats


### PR DESCRIPTION
### What was wrong?
Nothing was wrong, but reject_recursive_repeats was ripe for optimization since it is used frequently throughout the codebase

Related to Issue #N/A
Closes #N/A

### How was it fixed?
I optimized the decorator by refactoring out unnecessary variables and repetitive attr lookups

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://github.com/user-attachments/assets/5999e72c-45fd-46dc-b867-10584614a472)
