### PR TITLE
fix(types): update type hints in web3._utils.method_formatters.py

### DIFF
--- a/newsfragments/3669.internal.rst
+++ b/newsfragments/3669.internal.rst
@@ -1,0 +1,1 @@
+Update some types in ``web3._utils.method_formatters``

--- a/web3/method.py
+++ b/web3/method.py
@@ -182,7 +182,7 @@ class Method(Generic[TFunc]):
     @property
     def method_selector_fn(
         self,
-    ) -> Callable[..., Union[RPCEndpoint, Callable[..., RPCEndpoint]]]:
+    ) -> Callable[..., RPCEndpoint]:
         """Gets the method selector from the config."""
         if callable(self.json_rpc_method):
             return self.json_rpc_method


### PR DESCRIPTION
### What was wrong?
`get_result_formatters` had return type `Dict[str, Callable[..., Any]]` which is incorrect because the function returns a callable `toolz.compose` object

`get_error_formatters`, and `get_null_result_formatters` both had return type `Callable[..., Any]` which is techincally correct but could be made more specific for clarity for contributors.

Related to Issue #N/A
Closes #N/A

### How was it fixed?
I've changed the return type for all 3 functions to `Callable[[RPCResponse], Any]`.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes

I did not add an entry to [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md) as this change is not relevant for users.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://github.com/user-attachments/assets/980c555c-ae55-4c49-acf6-f03c1630f0f9)
