### PR TITLE
Allow async ens tests to run

### DIFF
--- a/newsfragments/3675.internal.rst
+++ b/newsfragments/3675.internal.rst
@@ -1,0 +1,1 @@
+AsyncENS tests were xfailing for the wrong reason.

--- a/web3/_utils/ens.py
+++ b/web3/_utils/ens.py
@@ -65,13 +65,21 @@ class StaticENS:
         return self.registry.get(name, None)
 
 
+class AsyncStaticENS:
+    def __init__(self, name_addr_pairs: Dict[str, ChecksumAddress]) -> None:
+        self.registry = dict(name_addr_pairs)
+
+    async def address(self, name: str) -> ChecksumAddress:
+        return self.registry.get(name, None)
+
+
 @contextmanager
 def ens_addresses(
     w3: Union["Web3", "AsyncWeb3"], name_addr_pairs: Dict[str, ChecksumAddress]
 ) -> Iterator[None]:
     original_ens = w3.ens
     if w3.provider.is_async:
-        w3.ens = cast(AsyncENS, StaticENS(name_addr_pairs))
+        w3.ens = cast(AsyncENS, AsyncStaticENS(name_addr_pairs))
     else:
         w3.ens = cast(ENS, StaticENS(name_addr_pairs))
     yield

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -454,9 +454,6 @@ class AsyncEthModuleTest:
         assert result["tx"]["nonce"] == txn_params["nonce"]
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="async name_to_address_middleware has not been implemented yet"
-    )
     async def test_async_eth_sign_transaction_ens_names(
         self, async_w3: "AsyncWeb3", async_keyfile_account_address: ChecksumAddress
     ) -> None:
@@ -2086,7 +2083,6 @@ class AsyncEthModuleTest:
         assert bytes(slot_4[:4]) == b"four"
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail
     async def test_async_eth_get_storage_at_ens_name(
         self, async_w3: "AsyncWeb3", async_storage_contract: "AsyncContract"
     ) -> None:
@@ -2238,9 +2234,6 @@ class AsyncEthModuleTest:
         assert new_signature != signature
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="Async middleware to convert ENS names to addresses is missing"
-    )
     async def test_async_eth_sign_ens_names(
         self,
         async_w3: "AsyncWeb3",


### PR DESCRIPTION
### What was wrong?
Tests were xfailing but should have been passing. Highlights the need to specify which exception tests expect. 

### How was it fixed?
Added a new AsyncStaticENS class for tests instead of using StaticENS which had a sync `address` method.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://media.istockphoto.com/id/466395505/photo/red-squirrel-looking-around-a-tree.jpg?s=612x612&w=0&k=20&c=xqKMBPgN9zbsyqat2Q9ubnA7bzIjOw8XnZ-Ze_BcUiI=)
