### PR TITLE
 Fix list numbering in Windows setup instructions

### DIFF
--- a/docs/README-windows.md
+++ b/docs/README-windows.md
@@ -4,4 +4,4 @@
 
 1. Install all of the package dependencies (TODO)
 
-1. Install `leveldb` (TODO)
+2. Install `leveldb` (TODO)


### PR DESCRIPTION
### What was wrong?
Change second step label from `1.` to `2.` for correct sequence