### PR TITLE
updated the broken link to the decentralized apps article in index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,7 +39,7 @@ Getting Started
 .. include:: toc.rst
 
 
-.. _decentralized apps (dapps): https://ethereum.org/dapps/
+.. _decentralized apps (dapps): https://ethereum.org/en/dapps/
 .. _@EthereumPython: https://twitter.com/EthereumPython
 .. _blog: https://snakecharmers.ethereum.org/
 .. _blog post series: https://snakecharmers.ethereum.org/a-developers-guide-to-ethereum-pt-1


### PR DESCRIPTION
### What was wrong?

The /dapps/ page without /en/ is missing and shows a 404 (Page Not Found).

### How was it fixed?

Replaced with a new one link 

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![photo_2025-02-22_01-55-56](https://github.com/user-attachments/assets/b5891230-053d-4c01-8005-636a7a62792a)

