### PR TITLE
fix: missing quotation mark in citation line

### DIFF
--- a/ens/exceptions.py
+++ b/ens/exceptions.py
@@ -32,7 +32,7 @@ class AddressMismatch(ENSException):
 class InvalidName(idna.IDNAError, ENSException):
     """
     Raised if the provided name does not meet the normalization
-    standards specified in `ENSIP-15
+    standards specified in `ENSIP-15`
     <https://docs.ens.domains/ens-improvement-proposals/ensip-15-normalization-standard>`_.
     """
 


### PR DESCRIPTION
### What was wrong?
the citation line ending at "ENSIP-15" was missing a closing quotation mark, which caused formatting issues

### How was it fixed?
added the missing closing quotation mark to the citation, ensuring proper formatting and compliance with the expected syntax

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [[release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![So cute for you](https://smv.org/media/images/2021.03.10_AnimalCuteness_Getty.width-1000.jpg)