### PR TITLE
fix: correct type annotation for nullable values

### DIFF
--- a/ens/base_ens.py
+++ b/ens/base_ens.py
@@ -6,6 +6,7 @@ from typing import (
     Any,
     Type,
     Union,
+    Optional,
 )
 
 from eth_typing import (
@@ -38,10 +39,10 @@ if TYPE_CHECKING:
 
 
 class BaseENS:
-    w3: Union["AsyncWeb3", "Web3"] = None
-    ens: Union["Contract", "AsyncContract"] = None
-    _resolver_contract: Union[Type["Contract"], Type["AsyncContract"]] = None
-    _reverse_resolver_contract: Union[Type["Contract"], Type["AsyncContract"]] = None
+    w3: Optional[Union["AsyncWeb3", "Web3"]] = None
+    ens: Optional[Union["Contract", "AsyncContract"]] = None
+    _resolver_contract: Optional[Type[Union["Contract", "AsyncContract"]]] = None
+    _reverse_resolver_contract: Optional[Type[Union["Contract", "AsyncContract"]]] = None
 
     @property
     def strict_bytes_type_checking(self) -> bool:


### PR DESCRIPTION
### What was wrong?

Found a small type hinting mistake — `Union` was used where `Optional` would be more appropriate.

### How was it fixed?

Swapped `Union` with `Optional` to better describe that the value can be `None`.

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [[release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Cute cheetah cub](https://wildlifesafari.net/cdn/shop/products/IMG_E6270.jpg?v=1689277556)
