### PR TITLE
bugfix: subscription manager break on `PersistentConnectionClosedOK`

### DIFF
--- a/newsfragments/3690.bugfix.rst
+++ b/newsfragments/3690.bugfix.rst
@@ -1,0 +1,1 @@
+Properly handle ``PersistentConnectionClosedOK`` for ``subscription_manager.handle_subscriptions()``.

--- a/tests/core/providers/test_websocket_provider.py
+++ b/tests/core/providers/test_websocket_provider.py
@@ -397,7 +397,7 @@ async def test_async_iterator_pattern_exception_handling_for_subscriptions():
 
 
 @pytest.mark.asyncio
-async def test_connection_closed_ok_breaks_message_iteration():
+async def test_connection_closed_ok_breaks_process_subscriptions_iteration():
     with patch(
         "web3.providers.persistent.websocket.connect",
         new=lambda *_1, **_2: WebSocketMessageStreamMock(
@@ -407,6 +407,22 @@ async def test_connection_closed_ok_breaks_message_iteration():
         w3 = await AsyncWeb3(WebSocketProvider("ws://mocked"))
         async for _ in w3.socket.process_subscriptions():
             pytest.fail("Should not reach this point.")
+
+
+@pytest.mark.asyncio
+async def test_connection_closed_ok_breaks_handle_subscriptions_iteration():
+    with patch(
+        "web3.providers.persistent.websocket.connect",
+        new=lambda *_1, **_2: WebSocketMessageStreamMock(
+            raise_exception=ConnectionClosedOK(None, None)
+        ),
+    ):
+        w3 = await AsyncWeb3(WebSocketProvider("ws://mocked"))
+        # would fail with a ``TimeoutError`` if the iteration did not break properly
+        # on ``ConnectionClosedOK``
+        await asyncio.wait_for(
+            w3.subscription_manager.handle_subscriptions(run_forever=True), timeout=1
+        )
 
 
 @pytest.mark.asyncio

--- a/web3/providers/persistent/async_ipc.py
+++ b/web3/providers/persistent/async_ipc.py
@@ -110,7 +110,9 @@ class AsyncIPCProvider(PersistentConnectionProvider):
             raise
 
         if not data:
-            raise PersistentConnectionClosedOK("Socket reader received end of stream.")
+            raise PersistentConnectionClosedOK(
+                user_message="Socket reader received end of stream."
+            )
         return self.decode_rpc_response(data)
 
     # -- private methods -- #

--- a/web3/providers/persistent/subscription_manager.py
+++ b/web3/providers/persistent/subscription_manager.py
@@ -298,6 +298,7 @@ class SubscriptionManager:
                     "Message listener background task for the provider has stopped "
                     "unexpectedly. Stopping subscription handling."
                 )
+                break
 
         # no active handler subscriptions, clear the handler subscription queue
         self._provider._request_processor._reset_handler_subscription_queue()


### PR DESCRIPTION
### What was wrong?

Closes #3689

### How was it fixed?

- Properly `break` on `PersistentConnectionClosedOK` for `subscription_manager.handle_subscriptions()`

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="721" alt="Screenshot 2025-05-06 at 15 16 34" src="https://github.com/user-attachments/assets/9504e7ef-f3ec-4f29-9ff7-bd337af8bb14" />

