### PR TITLE
chore: remove old fixtures when generating test fixture

### DIFF
--- a/newsfragments/3693.internal.rst
+++ b/newsfragments/3693.internal.rst
@@ -1,0 +1,1 @@
+Remove old test fixtures when generating a new test fixture.

--- a/tests/integration/generate_fixtures/go_ethereum.py
+++ b/tests/integration/generate_fixtures/go_ethereum.py
@@ -438,6 +438,20 @@ def update_circleci_geth_version(new_version):
     update_geth_version_string(changes, new_version, change_next_line=True)
 
 
+def remove_old_fixtures(current_geth_version):
+    """
+    Remove any geth fixture files that are not for the current version.
+    """
+    for file in os.listdir("./tests/integration"):
+        if (
+            file.startswith("geth-")
+            and file.endswith("-fixture.zip")
+            and current_geth_version not in file
+        ):
+            os.remove(os.path.join("./tests/integration", file))
+            print(f"Removed old fixture: {file}")
+
+
 if __name__ == "__main__":
     geth_binary = os.environ.get("GETH_BINARY", None)
     if not geth_binary:
@@ -445,6 +459,7 @@ if __name__ == "__main__":
 
     geth_version = re.search(r"geth-v([\d.]+)/", geth_binary).group(1)
     generate_go_ethereum_fixture(f"./tests/integration/geth-{geth_version}-fixture")
+    remove_old_fixtures(geth_version)
     update_circleci_geth_version(geth_version)
     update_fixture_generation_version(geth_version)
     update_doc_version(geth_version)


### PR DESCRIPTION
### What was wrong?

- Small addition to clean old test fixtures when generating a new test fixture

### Todo:

- [x] Clean up commit history

#### Cute Animal Picture

<img width="489" alt="Screenshot 2025-05-07 at 13 30 26" src="https://github.com/user-attachments/assets/a9833958-24a9-4958-918f-3ff5bdeda9bf" />
