### PR TITLE
Address flaky tests for now

### DIFF
--- a/newsfragments/3695.internal.rst
+++ b/newsfragments/3695.internal.rst
@@ -1,0 +1,1 @@
+Address some flaky tests due to a geth bug in state synchronization.


### PR DESCRIPTION
### What was wrong?

Use `blockNumber` for ``eth_getCode`` and ``eth_call``

  - For now, use the `blockNumber` from the transaction receipt to make ``eth_getCode`` and ``eth_call`` calls. Recent geth versions don't seem to be returning the latest state when called with ``latest`` as the block identifier.
  
  - Added TODOs to remove the `blockNumber` workaround after this is fixed.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="1015" alt="Screenshot 2025-05-09 at 13 12 25" src="https://github.com/user-attachments/assets/08448f89-597f-4342-a0c4-60794f6083a1" />
