### PR TITLE
feat: cache Method.method_selector_fn

### DIFF
--- a/newsfragments/3696.performance.rst
+++ b/newsfragments/3696.performance.rst
@@ -1,0 +1,1 @@
+optimize Method.method_selector_function

--- a/web3/method.py
+++ b/web3/method.py
@@ -182,12 +182,13 @@ class Method(Generic[TFunc]):
     @property
     def method_selector_fn(
         self,
-    ) -> Callable[..., RPCEndpoint]:
+    ) -> Callable[[], RPCEndpoint]:
         """Gets the method selector from the config."""
-        if callable(self.json_rpc_method):
-            return self.json_rpc_method
-        elif isinstance(self.json_rpc_method, (str,)):
-            return lambda *_: self.json_rpc_method
+        method = self.json_rpc_method
+        if callable(method):
+            return method
+        elif isinstance(method, str):
+            return lambda: method
         raise Web3ValueError(
             "``json_rpc_method`` config invalid.  May be a string or function"
         )


### PR DESCRIPTION
### What was wrong?

Since it is accessed each time a method is called, I decorated Method.method_selector_fn with functools.cached_property.

I also fixed the type hint for it's return value.

This PR is ready for review.


Related to Issue #
Closes #

### How was it fixed?

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes  (not applicable)
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://github.com/user-attachments/assets/770b7aa1-c1dc-4a4a-98f0-4659d03c5f0a)

