### PR TITLE
``ens_encode_name`` -> ``dns_encode_name``

### DIFF
--- a/ens/async_ens.py
+++ b/ens/async_ens.py
@@ -57,7 +57,7 @@ from ens.utils import (
     address_in,
     address_to_reverse_domain,
     default,
-    ens_encode_name,
+    dns_encode_name,
     init_async_web3,
     is_empty_name,
     is_none_or_zero_address,
@@ -500,7 +500,7 @@ class AsyncENS(BaseENS):
 
             calldata = resolver.encode_abi(*contract_func_with_args)
             contract_call_result = await resolver.caller.resolve(
-                ens_encode_name(normal_name),
+                dns_encode_name(normal_name),
                 calldata,
             )
             result = self._decode_ensip10_resolve_data(

--- a/ens/ens.py
+++ b/ens/ens.py
@@ -56,7 +56,7 @@ from .utils import (
     address_in,
     address_to_reverse_domain,
     default,
-    ens_encode_name,
+    dns_encode_name,
     init_web3,
     is_empty_name,
     is_none_or_zero_address,
@@ -482,7 +482,7 @@ class ENS(BaseENS):
 
             calldata = resolver.encode_abi(*contract_func_with_args)
             contract_call_result = resolver.caller.resolve(
-                ens_encode_name(normal_name),
+                dns_encode_name(normal_name),
                 calldata,
             )
             result = self._decode_ensip10_resolve_data(

--- a/ens/utils.py
+++ b/ens/utils.py
@@ -13,6 +13,7 @@ from typing import (
     Union,
     cast,
 )
+import warnings
 
 from eth_typing import (
     Address,
@@ -132,7 +133,7 @@ def normalize_name(name: str) -> str:
     return normalize_name_ensip15(name).as_text
 
 
-def ens_encode_name(name: str) -> bytes:
+def dns_encode_name(name: str) -> HexBytes:
     r"""
     Encode a name according to DNS standards specified in section 3.1
     of RFC1035 with the following validations:
@@ -145,7 +146,7 @@ def ens_encode_name(name: str) -> bytes:
     :param str name: the dot-separated ENS name
     """
     if is_empty_name(name):
-        return b"\x00"
+        return HexBytes(b"\x00")
 
     normalized_name = normalize_name(name)
 
@@ -163,7 +164,17 @@ def ens_encode_name(name: str) -> bytes:
     dns_prepped_labels = [to_bytes(len(label)) + label for label in labels_as_bytes]
 
     # return the joined prepped labels in order and append the zero byte at the end:
-    return b"".join(dns_prepped_labels) + b"\x00"
+    return HexBytes(b"".join(dns_prepped_labels) + b"\x00")
+
+
+def ens_encode_name(name: str) -> bytes:
+    warnings.warn(
+        "``ens_encode_name`` is deprecated and will be removed in the next "
+        "major version. Use ``dns_encode_name`` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return bytes(dns_encode_name(name))
 
 
 def is_valid_name(name: str) -> bool:

--- a/newsfragments/3700.deprecation.rst
+++ b/newsfragments/3700.deprecation.rst
@@ -1,0 +1,1 @@
+Deprecate ``ens_encode_name`` in favor of ``dns_encode_name``.

--- a/newsfragments/3700.feature.rst
+++ b/newsfragments/3700.feature.rst
@@ -1,0 +1,1 @@
+Introduce ``ens.utils.dns_encode_name`` as a rename of the current ``ens_encode_name``, for consistency across other language implementations and with the ENS docs. Returns ``HexBytes`` instead of ``bytes``.

--- a/tests/ens/test_offchain_resolution.py
+++ b/tests/ens/test_offchain_resolution.py
@@ -6,7 +6,7 @@ from aiohttp import (
 import requests
 
 from ens.utils import (
-    ens_encode_name,
+    dns_encode_name,
 )
 from web3.exceptions import (
     OffchainLookup,
@@ -172,14 +172,14 @@ def test_offchain_resolver_function_call_raises_with_ccip_read_disabled(
     # should fail here with `ccip_read_enabled` flag set to False
     with pytest.raises(OffchainLookup):
         offchain_resolver.functions.resolve(
-            ens_encode_name("offchainexample.eth"),
+            dns_encode_name("offchainexample.eth"),
             ENCODED_ADDR_CALLDATA,
         ).call(ccip_read_enabled=False)
 
     # pass flag on specific call via ContractCaller is also an option
     with pytest.raises(OffchainLookup):
         offchain_resolver.caller(ccip_read_enabled=False).resolve(
-            ens_encode_name("offchainexample.eth"),
+            dns_encode_name("offchainexample.eth"),
             ENCODED_ADDR_CALLDATA,
         )
 


### PR DESCRIPTION
### What was wrong?

- For consistency with implementations across other languages, and with the ENS docs, rename ``ens_encode_name`` to ``dns_encode_name`` and deprecate the old name for removal in ``v8``.

- Closes #3700

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="645" alt="Screenshot 2025-05-19 at 14 34 07" src="https://github.com/user-attachments/assets/2ab558b3-4f26-43fc-b22b-492de8f192c8" />
