### PR TITLE
feat: cache error and null result formatters

### DIFF
--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -1262,6 +1262,7 @@ def get_result_formatters(
 
 _error_formatters: CachedFormatters = {}
 
+
 def get_error_formatters(method_name: RPCEndpoint) -> Callable[[RPCResponse], Any]:
     #  Note error formatters work on the full response dict
     try:
@@ -1274,6 +1275,7 @@ def get_error_formatters(method_name: RPCEndpoint) -> Callable[[RPCResponse], An
 
 
 _null_result_formatters: CachedFormatters = {}
+
 
 def get_null_result_formatters(
     method_name: RPCEndpoint,


### PR DESCRIPTION
### What was wrong?

When using the default formatters, we can cache the callable for re-use instead of rebuilding it every time it is used.

Related to Issue #
Closes #

### How was it fixed?

A simple dict-based cache

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
