### PR TITLE
thread safety: context vars for batching context

### DIFF
--- a/newsfragments/3705.bugfix.rst
+++ b/newsfragments/3705.bugfix.rst
@@ -1,0 +1,4 @@
+Thread safety for batching and better consistency with ``PersistentConnectionProvider`` implementations:
+
+  - Make request batching threadsafe by using ``contextvars.ContextVar`` rather than a global flag for setting the batching state.
+  - Deterministically match responses with request ids for ``PersistentConnectionProvider`` batch requests.

--- a/newsfragments/3705.internal.rst
+++ b/newsfragments/3705.internal.rst
@@ -1,0 +1,1 @@
+Fix issues and start running the core tests with `pytest-xdist`, effectively reducing the CI test times by ~75-80%.

--- a/tests/core/caching-utils/test_request_caching.py
+++ b/tests/core/caching-utils/test_request_caching.py
@@ -204,7 +204,7 @@ def test_all_providers_do_not_cache_by_default_and_can_set_caching_properties(pr
     "threshold",
     (RequestCacheValidationThreshold.FINALIZED, RequestCacheValidationThreshold.SAFE),
 )
-@pytest.mark.parametrize("endpoint", BLOCKNUM_IN_PARAMS | BLOCK_IN_RESULT)
+@pytest.mark.parametrize("endpoint", sorted(BLOCKNUM_IN_PARAMS | BLOCK_IN_RESULT))
 @pytest.mark.parametrize(
     "blocknum,should_cache",
     (
@@ -254,7 +254,7 @@ def test_blocknum_validation_against_validation_threshold_when_caching_mainnet(
     "threshold",
     (RequestCacheValidationThreshold.FINALIZED, RequestCacheValidationThreshold.SAFE),
 )
-@pytest.mark.parametrize("endpoint", BLOCKNUM_IN_PARAMS)
+@pytest.mark.parametrize("endpoint", sorted(BLOCKNUM_IN_PARAMS))
 @pytest.mark.parametrize(
     "block_id,blocknum,should_cache",
     (
@@ -297,7 +297,7 @@ def test_block_id_param_caching_mainnet(
     "threshold",
     (RequestCacheValidationThreshold.FINALIZED, RequestCacheValidationThreshold.SAFE),
 )
-@pytest.mark.parametrize("endpoint", BLOCKHASH_IN_PARAMS)
+@pytest.mark.parametrize("endpoint", sorted(BLOCKHASH_IN_PARAMS))
 @pytest.mark.parametrize(
     "blocknum,should_cache",
     (
@@ -360,7 +360,7 @@ def test_request_caching_validation_threshold_defaults(
 
 
 @pytest.mark.parametrize(
-    "endpoint", BLOCKNUM_IN_PARAMS | BLOCK_IN_RESULT | BLOCKHASH_IN_PARAMS
+    "endpoint", sorted(BLOCKNUM_IN_PARAMS | BLOCK_IN_RESULT | BLOCKHASH_IN_PARAMS)
 )
 @pytest.mark.parametrize(
     "time_from_threshold,should_cache",
@@ -436,7 +436,7 @@ def test_sync_validation_against_validation_threshold_time_based(
     ),
 )
 @pytest.mark.parametrize(
-    "endpoint", BLOCKNUM_IN_PARAMS | BLOCK_IN_RESULT | BLOCKHASH_IN_PARAMS
+    "endpoint", sorted(BLOCKNUM_IN_PARAMS | BLOCK_IN_RESULT | BLOCKHASH_IN_PARAMS)
 )
 def test_validation_against_validation_threshold_time_based_configured(
     time_from_threshold, should_cache, chain_id, endpoint, sync_provider, request_mocker
@@ -642,7 +642,7 @@ async def test_async_request_caching_does_not_share_state_between_providers(
     "threshold",
     (RequestCacheValidationThreshold.FINALIZED, RequestCacheValidationThreshold.SAFE),
 )
-@pytest.mark.parametrize("endpoint", BLOCKNUM_IN_PARAMS | BLOCK_IN_RESULT)
+@pytest.mark.parametrize("endpoint", sorted(BLOCKNUM_IN_PARAMS | BLOCK_IN_RESULT))
 @pytest.mark.parametrize(
     "blocknum,should_cache",
     (
@@ -689,7 +689,7 @@ async def test_async_blocknum_validation_against_validation_threshold_mainnet(
     "threshold",
     (RequestCacheValidationThreshold.FINALIZED, RequestCacheValidationThreshold.SAFE),
 )
-@pytest.mark.parametrize("endpoint", BLOCKNUM_IN_PARAMS)
+@pytest.mark.parametrize("endpoint", sorted(BLOCKNUM_IN_PARAMS))
 @pytest.mark.parametrize(
     "block_id,blocknum,should_cache",
     (
@@ -735,7 +735,7 @@ async def test_async_block_id_param_caching_mainnet(
     "threshold",
     (RequestCacheValidationThreshold.FINALIZED, RequestCacheValidationThreshold.SAFE),
 )
-@pytest.mark.parametrize("endpoint", BLOCKHASH_IN_PARAMS)
+@pytest.mark.parametrize("endpoint", sorted(BLOCKHASH_IN_PARAMS))
 @pytest.mark.parametrize(
     "blocknum,should_cache",
     (
@@ -794,7 +794,7 @@ async def test_async_request_caching_validation_threshold_defaults(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "endpoint", BLOCKNUM_IN_PARAMS | BLOCK_IN_RESULT | BLOCKHASH_IN_PARAMS
+    "endpoint", sorted(BLOCKNUM_IN_PARAMS | BLOCK_IN_RESULT | BLOCKHASH_IN_PARAMS)
 )
 @pytest.mark.parametrize(
     "time_from_threshold,should_cache",
@@ -856,7 +856,7 @@ async def test_async_validation_against_validation_threshold_time_based(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "endpoint", BLOCKNUM_IN_PARAMS | BLOCK_IN_RESULT | BLOCKHASH_IN_PARAMS
+    "endpoint", sorted(BLOCKNUM_IN_PARAMS | BLOCK_IN_RESULT | BLOCKHASH_IN_PARAMS)
 )
 @pytest.mark.parametrize("blocknum", ("0x0", "0x1", "0x2", "0x3", "0x4", "0x5"))
 async def test_async_request_caching_with_validation_threshold_set_to_none(
@@ -901,7 +901,7 @@ async def test_async_request_caching_with_validation_threshold_set_to_none(
     ),
 )
 @pytest.mark.parametrize(
-    "endpoint", BLOCKNUM_IN_PARAMS | BLOCK_IN_RESULT | BLOCKHASH_IN_PARAMS
+    "endpoint", sorted(BLOCKNUM_IN_PARAMS | BLOCK_IN_RESULT | BLOCKHASH_IN_PARAMS)
 )
 async def test_async_validation_against_validation_threshold_time_based_configured(
     time_from_threshold,

--- a/tests/core/contracts/test_contract_init.py
+++ b/tests/core/contracts/test_contract_init.py
@@ -85,7 +85,7 @@ def test_init_multiple_contracts_performance(w3, emitter_contract_data):
             abi=emitter_contract_data["abi"], bytecode=emitter_contract_data["bytecode"]
         )
     # assert initializing 500 contracts is within a conservative / reasonable time
-    assert (time.time() - start_time) < 1.75
+    assert (time.time() - start_time) < 3
 
 
 # -- async -- #
@@ -98,4 +98,4 @@ def test_async_init_multiple_contracts_performance(async_w3, emitter_contract_da
             abi=emitter_contract_data["abi"], bytecode=emitter_contract_data["bytecode"]
         )
     # assert initializing 500 contracts is within a conservative / reasonable time
-    assert (time.time() - start_time) < 1.75
+    assert (time.time() - start_time) < 3

--- a/tests/core/middleware/test_eth_tester_middleware.py
+++ b/tests/core/middleware/test_eth_tester_middleware.py
@@ -18,7 +18,7 @@ SAMPLE_ADDRESS_LIST = [
 SAMPLE_ADDRESS = "0x0000000000000000000000000000000000000004"
 
 
-@pytest.mark.parametrize("block_number", {0, "0x0", "earliest"})
+@pytest.mark.parametrize("block_number", (0, "0x0", "earliest"))
 def test_get_transaction_count_formatters(w3, block_number):
     tx_counts = w3.eth.get_transaction_count(w3.eth.accounts[-1], block_number)
     assert tx_counts == 0

--- a/tests/core/providers/test_async_http_provider.py
+++ b/tests/core/providers/test_async_http_provider.py
@@ -12,9 +12,6 @@ from web3 import (
     AsyncWeb3,
     __version__ as web3py_version,
 )
-from web3._utils.batching import (
-    is_batching_context,
-)
 from web3.eth import (
     AsyncEth,
 )
@@ -131,4 +128,4 @@ async def test_async_http_empty_batch_response(mock_async_post):
         with pytest.raises(Web3RPCError, match="empty batch"):
             await batch.async_execute()
 
-    assert not is_batching_context()
+    assert not async_w3.provider._is_batching

--- a/tests/core/providers/test_async_http_provider.py
+++ b/tests/core/providers/test_async_http_provider.py
@@ -12,6 +12,9 @@ from web3 import (
     AsyncWeb3,
     __version__ as web3py_version,
 )
+from web3._utils.batching import (
+    is_batching_context,
+)
 from web3.eth import (
     AsyncEth,
 )
@@ -128,23 +131,4 @@ async def test_async_http_empty_batch_response(mock_async_post):
         with pytest.raises(Web3RPCError, match="empty batch"):
             await batch.async_execute()
 
-    # assert that even though there was an error, we have reset the batching state
-    assert not async_w3.provider._is_batching
-
-
-@patch(
-    "web3._utils.http_session_manager.HTTPSessionManager.async_make_post_request",
-    new_callable=AsyncMock,
-)
-@pytest.mark.asyncio
-async def test_async_provider_is_batching_when_make_batch_request(mock_post):
-    def assert_is_batching_and_return_response(*_args, **_kwargs) -> bytes:
-        assert provider._is_batching
-        return b'{"jsonrpc":"2.0","id":1,"result":["0x1"]}'
-
-    mock_post.side_effect = assert_is_batching_and_return_response
-    provider = AsyncHTTPProvider()
-
-    assert not provider._is_batching
-    await provider.make_batch_request([("eth_blockNumber", [])])
-    assert not provider._is_batching
+    assert not is_batching_context()

--- a/tests/core/providers/test_async_ipc_provider.py
+++ b/tests/core/providers/test_async_ipc_provider.py
@@ -20,9 +20,6 @@ from websockets import (
 from web3 import (
     AsyncWeb3,
 )
-from web3._utils.batching import (
-    is_batching_context,
-)
 from web3.datastructures import (
     AttributeDict,
 )
@@ -388,8 +385,8 @@ async def test_persistent_connection_provider_empty_batch_response(
                 )
             )
             async with async_w3.batch_requests() as batch:
-                assert is_batching_context()
+                assert async_w3.provider._is_batching
                 await batch.async_execute()
 
         # assert that even though there was an error, we have reset the batching state
-        assert not is_batching_context()
+        assert not async_w3.provider._is_batching

--- a/tests/core/providers/test_http_provider.py
+++ b/tests/core/providers/test_http_provider.py
@@ -15,9 +15,6 @@ from web3 import (
     Web3,
     __version__ as web3py_version,
 )
-from web3._utils.batching import (
-    is_batching_context,
-)
 from web3.eth import (
     Eth,
 )
@@ -130,9 +127,9 @@ def test_http_empty_batch_response(mock_post):
     )
     w3 = Web3(HTTPProvider())
     with w3.batch_requests() as batch:
-        assert is_batching_context()
+        assert w3.provider._is_batching
         with pytest.raises(Web3RPCError, match="empty batch"):
             batch.execute()
 
     # assert that even though there was an error, we have reset the batching state
-    assert not is_batching_context()
+    assert not w3.provider._is_batching

--- a/tests/core/providers/test_http_provider.py
+++ b/tests/core/providers/test_http_provider.py
@@ -15,6 +15,9 @@ from web3 import (
     Web3,
     __version__ as web3py_version,
 )
+from web3._utils.batching import (
+    is_batching_context,
+)
 from web3.eth import (
     Eth,
 )
@@ -127,26 +130,9 @@ def test_http_empty_batch_response(mock_post):
     )
     w3 = Web3(HTTPProvider())
     with w3.batch_requests() as batch:
+        assert is_batching_context()
         with pytest.raises(Web3RPCError, match="empty batch"):
             batch.execute()
 
     # assert that even though there was an error, we have reset the batching state
-    assert not w3.provider._is_batching
-
-
-@patch(
-    "web3._utils.http_session_manager.HTTPSessionManager.make_post_request",
-    new_callable=Mock,
-)
-def test_sync_provider_is_batching_when_make_batch_request(mock_post):
-    def assert_is_batching_and_return_response(*_args, **_kwargs) -> bytes:
-        assert provider._is_batching
-        return b'{"jsonrpc":"2.0","id":1,"result":["0x1"]}'
-
-    provider = HTTPProvider()
-    assert not provider._is_batching
-
-    mock_post.side_effect = assert_is_batching_and_return_response
-
-    provider.make_batch_request([("eth_blockNumber", [])])
-    assert not provider._is_batching
+    assert not is_batching_context()

--- a/tests/core/providers/test_ipc_provider.py
+++ b/tests/core/providers/test_ipc_provider.py
@@ -199,18 +199,3 @@ def test_ipc_provider_write_messages_end_with_new_line_delimiter(jsonrpc_ipc_pip
 
     request_data = b'{"jsonrpc": "2.0", "method": "method", "params": [], "id": 0}'
     provider._socket.sock.sendall.assert_called_with(request_data + b"\n")
-
-
-def test_ipc_provider_is_batching_when_make_batch_request(jsonrpc_ipc_pipe_path):
-    def assert_is_batching_and_return_response(*_args, **_kwargs) -> bytes:
-        assert provider._is_batching
-        return [{"id": 0, "jsonrpc": "2.0", "result": {}}]
-
-    provider = IPCProvider(pathlib.Path(jsonrpc_ipc_pipe_path), timeout=3)
-    provider._make_request = Mock()
-    provider._make_request.side_effect = assert_is_batching_and_return_response
-
-    assert not provider._is_batching
-
-    provider.make_batch_request([("eth_blockNumber", [])])
-    assert not provider._is_batching

--- a/tests/core/providers/test_websocket_provider.py
+++ b/tests/core/providers/test_websocket_provider.py
@@ -18,9 +18,6 @@ from websockets import (
 from web3 import (
     AsyncWeb3,
 )
-from web3._utils.batching import (
-    is_batching_context,
-)
 from web3._utils.caching import (
     RequestInformation,
     generate_cache_key,
@@ -479,7 +476,7 @@ async def test_persistent_connection_provider_empty_batch_response():
         with pytest.raises(Web3RPCError, match="empty batch"):
             async with AsyncWeb3(WebSocketProvider("ws://mocked")) as async_w3:
                 async with async_w3.batch_requests() as batch:
-                    assert is_batching_context()
+                    assert async_w3.provider._is_batching
                     async_w3.provider._ws.recv = AsyncMock()
                     async_w3.provider._ws.recv.return_value = (
                         b'{"jsonrpc": "2.0","id":null,"error": {"code": -32600, '
@@ -489,7 +486,7 @@ async def test_persistent_connection_provider_empty_batch_response():
 
         # assert that even though there was an error, we have reset the batching
         # state
-        assert not is_batching_context()
+        assert not async_w3.provider._is_batching
 
 
 @pytest.mark.parametrize(

--- a/tests/core/providers/test_websocket_provider.py
+++ b/tests/core/providers/test_websocket_provider.py
@@ -18,6 +18,9 @@ from websockets import (
 from web3 import (
     AsyncWeb3,
 )
+from web3._utils.batching import (
+    is_batching_context,
+)
 from web3._utils.caching import (
     RequestInformation,
     generate_cache_key,
@@ -473,19 +476,20 @@ async def test_persistent_connection_provider_empty_batch_response():
         "web3.providers.persistent.websocket.connect",
         new=lambda *_1, **_2: _mocked_ws_conn(),
     ):
-        async with AsyncWeb3(WebSocketProvider("ws://mocked")) as async_w3:
-            async_w3.provider._ws.recv = AsyncMock()
-            async_w3.provider._ws.recv.return_value = (
-                b'{"jsonrpc": "2.0","id":null,"error": {"code": -32600, "message": '
-                b'"empty batch"}}\n'
-            )
-            async with async_w3.batch_requests() as batch:
-                with pytest.raises(Web3RPCError, match="empty batch"):
+        with pytest.raises(Web3RPCError, match="empty batch"):
+            async with AsyncWeb3(WebSocketProvider("ws://mocked")) as async_w3:
+                async with async_w3.batch_requests() as batch:
+                    assert is_batching_context()
+                    async_w3.provider._ws.recv = AsyncMock()
+                    async_w3.provider._ws.recv.return_value = (
+                        b'{"jsonrpc": "2.0","id":null,"error": {"code": -32600, '
+                        b'"message": "empty batch"}}\n'
+                    )
                     await batch.async_execute()
 
-            # assert that even though there was an error, we have reset the batching
-            # state
-            assert not async_w3.provider._is_batching
+        # assert that even though there was an error, we have reset the batching
+        # state
+        assert not is_batching_context()
 
 
 @pytest.mark.parametrize(
@@ -564,21 +568,3 @@ async def test_raise_stray_errors_from_cache_handles_list_response_without_error
 
     # assert no errors raised
     provider._raise_stray_errors_from_cache()
-
-
-@pytest.mark.asyncio
-async def test_websocket_provider_is_batching_when_make_batch_request():
-    def assert_is_batching_and_return_response(*_args, **_kwargs) -> bytes:
-        assert provider._is_batching
-        return b'{"jsonrpc":"2.0","id":1,"result":["0x1"]}'
-
-    provider = WebSocketProvider("ws://mocked")
-    _mock_ws(provider)
-    provider._get_response_for_request_id = AsyncMock()
-    provider._get_response_for_request_id.side_effect = (
-        assert_is_batching_and_return_response
-    )
-
-    assert not provider._is_batching
-    await provider.make_batch_request([("eth_blockNumber", [])])
-    assert not provider._is_batching

--- a/tests/core/utilities/test_http_session_manager.py
+++ b/tests/core/utilities/test_http_session_manager.py
@@ -87,7 +87,7 @@ def _simulate_call(http_session_manager, uri):
     return _session
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def http_session_manager():
     return HTTPSessionManager()
 
@@ -485,7 +485,7 @@ async def test_session_manager_async_unique_cache_keys_created_per_thread_with_s
         event_loop = asyncio.new_event_loop()
         unique_session = event_loop.run_until_complete(
             http_session_manager.async_cache_and_return_session(
-                endpoint_uri, request_timeout=ClientTimeout(0.01)
+                endpoint_uri, request_timeout=ClientTimeout(0.1)
             )
         )
         event_loop.close()
@@ -500,6 +500,7 @@ async def test_session_manager_async_unique_cache_keys_created_per_thread_with_s
             daemon=True,
         )
         thread.start()
+        time.sleep(0.01)
         threads.append(thread)
 
     [thread.join() for thread in threads]

--- a/tests/integration/go_ethereum/test_goethereum_legacy_ws.py
+++ b/tests/integration/go_ethereum/test_goethereum_legacy_ws.py
@@ -55,11 +55,12 @@ def w3(start_geth_process_and_yield_port):
     return _w3
 
 
+@pytest.mark.skip("LegacyWebSocketProvider does not support concurrent requests")
 class TestGoEthereumWeb3ModuleTest(GoEthereumWeb3ModuleTest):
     def test_batch_requests_concurrently_with_regular_requests(
         self, w3: "Web3"
     ) -> None:
-        pytest.skip("LegacyWebSocketProvider does not support concurrent requests")
+        pass
 
 
 class TestGoEthereumAdminModuleTest(GoEthereumAdminModuleTest):

--- a/tests/integration/go_ethereum/test_goethereum_legacy_ws.py
+++ b/tests/integration/go_ethereum/test_goethereum_legacy_ws.py
@@ -56,7 +56,10 @@ def w3(start_geth_process_and_yield_port):
 
 
 class TestGoEthereumWeb3ModuleTest(GoEthereumWeb3ModuleTest):
-    pass
+    def test_batch_requests_concurrently_with_regular_requests(
+        self, w3: "Web3"
+    ) -> None:
+        pytest.skip("LegacyWebSocketProvider does not support concurrent requests")
 
 
 class TestGoEthereumAdminModuleTest(GoEthereumAdminModuleTest):

--- a/tests/integration/test_ethereum_tester.py
+++ b/tests/integration/test_ethereum_tester.py
@@ -269,6 +269,12 @@ class TestEthereumTesterWeb3Module(Web3ModuleTest):
         Web3ModuleTest.test_batch_requests_clear, Web3TypeError
     )
 
+    @pytest.mark.skip("EthereumTesterProvider does not support batch requests")
+    def test_batch_requests_concurrently_with_regular_requests(self, w3):
+        # batching is not supported by ``EthereumTesterProvider`` and the exception
+        # is triggered in a different thread so not caught by it. Skip it here instead.
+        pass
+
 
 class TestEthereumTesterEthModule(EthModuleTest):
     test_eth_sign = not_implemented(EthModuleTest.test_eth_sign, MethodUnavailable)

--- a/tox.ini
+++ b/tox.ini
@@ -20,8 +20,8 @@ allowlist_externals=make,pre-commit
 install_command=python -m pip install {opts} {packages}
 usedevelop=True
 commands=
-    core: pytest {posargs:tests/core -m "not asyncio"}
-    core_async: pytest {posargs:tests/core -m asyncio}
+    core: pytest {posargs:tests/core -m "not asyncio" -n auto --maxprocesses=15}
+    core_async: pytest {posargs:tests/core -m asyncio -n auto --maxprocesses=15}
     ens: pytest {posargs:tests/ens --ignore=tests/ens/normalization/test_normalize_name_ensip15.py -n auto --maxprocesses=15}
     ensip15: pytest {posargs:tests/ens/normalization/test_normalize_name_ensip15.py -q -n auto --maxprocesses=15}
     integration-goethereum-ipc: pytest {posargs:tests/integration/go_ethereum/test_goethereum_ipc.py -k "not Async" -n auto --maxprocesses=15}

--- a/web3/_utils/http_session_manager.py
+++ b/web3/_utils/http_session_manager.py
@@ -178,7 +178,7 @@ class HTTPSessionManager:
         request_timeout: Optional[ClientTimeout] = None,
     ) -> ClientSession:
         # cache key should have a unique thread identifier
-        cache_key = generate_cache_key(f"{threading.get_ident()}:{endpoint_uri}")
+        cache_key = generate_cache_key(f"{id(asyncio.get_event_loop())}:{endpoint_uri}")
 
         evicted_items = None
         async with async_lock(self.session_pool, self._lock):

--- a/web3/_utils/module_testing/web3_module.py
+++ b/web3/_utils/module_testing/web3_module.py
@@ -22,6 +22,9 @@ from web3 import (
     AsyncWeb3,
     Web3,
 )
+from web3._utils.batching import (
+    is_batching_context,
+)
 from web3._utils.ens import (
     ens_addresses,
 )
@@ -336,7 +339,7 @@ class Web3ModuleTest:
 
             # assert proper batch cleanup after execution
             assert batch._requests_info == []
-            assert not batch._provider._is_batching
+            assert not is_batching_context()
 
             # assert batch cannot be added to after execution
             with pytest.raises(
@@ -395,7 +398,7 @@ class Web3ModuleTest:
 
         # assert proper batch cleanup after execution
         assert batch._requests_info == []
-        assert not batch._provider._is_batching
+        assert not is_batching_context()
 
         # assert batch cannot be added to after execution
         with pytest.raises(
@@ -551,7 +554,7 @@ class AsyncWeb3ModuleTest(Web3ModuleTest):
 
             # assert proper batch cleanup after execution
             assert batch._async_requests_info == []
-            assert not batch._provider._is_batching
+            assert not is_batching_context()
 
             # assert batch cannot be added to after execution
             with pytest.raises(
@@ -614,7 +617,7 @@ class AsyncWeb3ModuleTest(Web3ModuleTest):
 
         # assert proper batch cleanup after execution
         assert batch._async_requests_info == []
-        assert not batch._provider._is_batching
+        assert not is_batching_context()
 
         # assert batch cannot be added to after execution
         with pytest.raises(

--- a/web3/_utils/module_testing/web3_module.py
+++ b/web3/_utils/module_testing/web3_module.py
@@ -1,4 +1,7 @@
 import pytest
+import asyncio
+import threading
+import time
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -44,6 +47,9 @@ if TYPE_CHECKING:
     from web3.contract import (  # noqa: F401
         AsyncContract,
     )
+
+
+SOME_BLOCK_KEYS = {"number", "hash", "parentHash", "stateRoot", "transactions"}
 
 
 class Web3ModuleTest:
@@ -516,6 +522,43 @@ class Web3ModuleTest:
                 batch.add(w3.eth.sign(Address(b"\x00" * 20)))
                 batch.execute()
 
+    def test_batch_requests_concurrently_with_regular_requests(
+        self, w3: "Web3"
+    ) -> None:
+        num_requests = 40
+        responses = []
+        batch_response = []
+
+        def make_regular_requests() -> None:
+            for _ in range(num_requests):
+                responses.append(w3.eth.get_block(0))
+                time.sleep(0.01)
+
+        def make_batch_request() -> None:
+            with w3.batch_requests() as batch:
+                for _ in range(num_requests):
+                    batch.add(w3.eth.get_block(0))
+                    time.sleep(0.01)
+                batch_response.extend(batch.execute())
+
+        # split into threads
+        regular_thread = threading.Thread(target=make_regular_requests)
+        batch_thread = threading.Thread(target=make_batch_request)
+
+        regular_thread.start()
+        batch_thread.start()
+
+        # wait for threads to finish
+        regular_thread.join()
+        batch_thread.join()
+        assert not regular_thread.is_alive()
+        assert not batch_thread.is_alive()
+
+        assert len(responses) == num_requests
+        assert len(batch_response) == num_requests
+        assert all(SOME_BLOCK_KEYS.issubset(response.keys()) for response in responses)
+        assert set(responses) == set(batch_response)
+
 
 # -- async -- #
 
@@ -737,3 +780,33 @@ class AsyncWeb3ModuleTest(Web3ModuleTest):
             with pytest.raises(MethodNotSupported, match="eth_sign"):
                 batch.add(async_w3.eth.sign(Address(b"\x00" * 20)))
                 await batch.async_execute()
+
+    @pytest.mark.asyncio
+    async def test_batch_requests_concurrently_with_regular_requests(  # type: ignore[override]  # noqa: E501
+        self, async_w3: AsyncWeb3  # type: ignore[override]
+    ) -> None:
+        num_requests = 40
+        responses = []
+        batch_response = []
+
+        async def make_regular_requests() -> None:
+            for _ in range(num_requests):
+                responses.append(await async_w3.eth.get_block(0))
+                await asyncio.sleep(0.01)
+
+        async def make_batch_request() -> None:
+            async with async_w3.batch_requests() as batch:
+                for _ in range(num_requests):
+                    batch.add(async_w3.eth.get_block(0))
+                    await asyncio.sleep(0.01)
+                batch_response.extend(await batch.async_execute())
+
+        await asyncio.gather(
+            make_regular_requests(),
+            make_batch_request(),
+        )
+
+        assert len(responses) == num_requests
+        assert len(batch_response) == num_requests
+        assert all(SOME_BLOCK_KEYS.issubset(response.keys()) for response in responses)
+        assert set(responses) == set(batch_response)

--- a/web3/contract/utils.py
+++ b/web3/contract/utils.py
@@ -43,6 +43,9 @@ from web3._utils.abi import (
 from web3._utils.async_transactions import (
     async_fill_transaction_defaults,
 )
+from web3._utils.batching import (
+    is_batching_context,
+)
 from web3._utils.compat import (
     TypeAlias,
 )
@@ -175,8 +178,8 @@ def call_contract_function(
     if abi_callable["type"] == "function":
         output_types = get_abi_output_types(abi_callable)
 
-    provider = w3.provider
-    if hasattr(provider, "_is_batching") and provider._is_batching:
+    w3.provider
+    if is_batching_context():
         BatchingReturnData: TypeAlias = Tuple[Tuple[RPCEndpoint, Any], Tuple[Any, ...]]
         request_information = tuple(cast(BatchingReturnData, return_data))
         method_and_params = request_information[0]
@@ -474,7 +477,7 @@ async def async_call_contract_function(
     if fn_abi["type"] == "function":
         output_types = get_abi_output_types(fn_abi)
 
-    if async_w3.provider._is_batching:
+    if is_batching_context():
         contract_call_return_data_formatter = format_contract_call_return_data_curried(
             async_w3,
             decode_tuples,

--- a/web3/contract/utils.py
+++ b/web3/contract/utils.py
@@ -46,9 +46,6 @@ from web3._utils.async_transactions import (
 from web3._utils.batching import (
     BatchRequestInformation,
 )
-from web3._utils.compat import (
-    TypeAlias,
-)
 from web3._utils.contracts import (
     prepare_transaction,
 )
@@ -65,7 +62,6 @@ from web3.exceptions import (
 from web3.types import (
     ABIElementIdentifier,
     BlockIdentifier,
-    RPCEndpoint,
     StateOverride,
     TContractEvent,
     TContractFn,
@@ -485,8 +481,7 @@ async def async_call_contract_function(
             output_types,
         )
 
-        BatchingReturnData: TypeAlias = Tuple[Tuple[RPCEndpoint, Any], Tuple[Any, ...]]
-        request_information = tuple(cast(BatchingReturnData, return_data))
+        request_information = tuple(cast(BatchRequestInformation, return_data))
         method_and_params = request_information[0]
 
         # append return data formatter to result formatters
@@ -502,8 +497,6 @@ async def async_call_contract_function(
             current_response_formatters[2],  # null result formatters
         )
         return (method_and_params, response_formatters)
-
-        return return_data
 
     try:
         output_data = async_w3.codec.decode(output_types, return_data)

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -261,7 +261,7 @@ class RequestManager:
         return RequestBatcher(self.w3)
 
     def _make_batch_request(
-        self, requests_info: List[Tuple[Tuple["RPCEndpoint", Any], Sequence[Any]]]
+        self, requests_info: List[Tuple[Tuple["RPCEndpoint", Any], Tuple[Any, ...]]]
     ) -> List[RPCResponse]:
         """
         Make a batch request using the provider
@@ -291,7 +291,7 @@ class RequestManager:
     async def _async_make_batch_request(
         self,
         requests_info: List[
-            Coroutine[Any, Any, Tuple[Tuple["RPCEndpoint", Any], Sequence[Any]]]
+            Coroutine[Any, Any, Tuple[Tuple["RPCEndpoint", Any], Tuple[Any]]]
         ],
     ) -> List[RPCResponse]:
         """
@@ -315,13 +315,6 @@ class RequestManager:
         if isinstance(response, list):
             # expected format
             response = cast(List[RPCResponse], response)
-            if isinstance(self.provider, PersistentConnectionProvider):
-                # call _process_response for each response in the batch
-                return [
-                    cast(RPCResponse, await self._process_response(resp))
-                    for resp in response
-                ]
-
             formatted_responses = [
                 self._format_batched_response(info, resp)
                 for info, resp in zip(unpacked_requests_info, response)
@@ -330,6 +323,86 @@ class RequestManager:
         else:
             # expect a single response with an error
             raise_error_for_batch_response(response, self.logger)
+
+    async def _async_send_batch(
+        self, requests: List[Tuple["RPCEndpoint", Any]]
+    ) -> List[RPCRequest]:
+        """
+        Send a batch request via socket.
+        """
+        if not isinstance(self._provider, PersistentConnectionProvider):
+            raise Web3TypeError(
+                "Only providers that maintain an open, persistent connection "
+                "can send batch requests."
+            )
+        send_func = await self._provider.send_batch_func(
+            cast("AsyncWeb3", self.w3),
+            cast("MiddlewareOnion", self.middleware_onion),
+        )
+        self.logger.debug(
+            "Sending batch request to open socket connection: %s",
+            self._provider.get_endpoint_uri_or_ipc_path(),
+        )
+        return await send_func(requests)
+
+    async def _async_recv_batch(self, requests: List[RPCRequest]) -> List[RPCResponse]:
+        """
+        Receive a batch request via socket.
+        """
+        if not isinstance(self._provider, PersistentConnectionProvider):
+            raise Web3TypeError(
+                "Only providers that maintain an open, persistent connection "
+                "can receive batch requests."
+            )
+        recv_func = await self._provider.recv_batch_func(
+            cast("AsyncWeb3", self.w3),
+            cast("MiddlewareOnion", self.middleware_onion),
+        )
+        self.logger.debug(
+            "Receiving batch request from open socket connection: %s",
+            self._provider.get_endpoint_uri_or_ipc_path(),
+        )
+        return await recv_func(requests)
+
+    async def _async_make_socket_batch_request(
+        self,
+        requests_info: List[
+            Coroutine[Any, Any, Tuple[Tuple["RPCEndpoint", Any], Tuple[Any, ...]]]
+        ],
+    ) -> List[RPCResponse]:
+        """
+        Send and receive a batch request via a socket.
+        """
+        if not isinstance(self._provider, PersistentConnectionProvider):
+            raise Web3TypeError(
+                "Only providers that maintain an open, persistent connection "
+                "can send and receive batch requests."
+            )
+
+        unpacked_requests_info = await asyncio.gather(*requests_info)
+        reqs = [req for req, _ in unpacked_requests_info]
+        response_formatters = [resp_f for _, resp_f in unpacked_requests_info]
+
+        requests = await self._async_send_batch(reqs)
+
+        for i, request in enumerate(requests):
+            self._provider._request_processor.cache_request_information(
+                request["id"],
+                request["method"],
+                request["params"],
+                response_formatters=response_formatters[i],
+            )
+
+        responses = await self._async_recv_batch(requests)
+        if isinstance(responses, list):
+            # expected format
+            return [
+                cast(RPCResponse, await self._process_response(resp))
+                for resp in responses
+            ]
+        else:
+            # expect a single response with an error
+            raise_error_for_batch_response(responses, self.logger)
 
     def _format_batched_response(
         self,

--- a/web3/method.py
+++ b/web3/method.py
@@ -23,7 +23,6 @@ from eth_utils.toolz import (
 
 from web3._utils.batching import (
     RPC_METHODS_UNSUPPORTED_DURING_BATCH,
-    is_batching_context,
 )
 from web3._utils.method_formatters import (
     get_error_formatters,
@@ -166,7 +165,7 @@ class Method(Generic[TFunc]):
                 "usually attached to a web3 instance."
             )
 
-        if is_batching_context():
+        if module.w3.provider._is_batching:
             if self.json_rpc_method in RPC_METHODS_UNSUPPORTED_DURING_BATCH:
                 raise MethodNotSupported(
                     f"Method `{self.json_rpc_method}` is not supported within a batch "

--- a/web3/method.py
+++ b/web3/method.py
@@ -23,6 +23,7 @@ from eth_utils.toolz import (
 
 from web3._utils.batching import (
     RPC_METHODS_UNSUPPORTED_DURING_BATCH,
+    is_batching_context,
 )
 from web3._utils.method_formatters import (
     get_error_formatters,
@@ -165,8 +166,7 @@ class Method(Generic[TFunc]):
                 "usually attached to a web3 instance."
             )
 
-        provider = module.w3.provider
-        if hasattr(provider, "_is_batching") and provider._is_batching:
+        if is_batching_context():
             if self.json_rpc_method in RPC_METHODS_UNSUPPORTED_DURING_BATCH:
                 raise MethodNotSupported(
                     f"Method `{self.json_rpc_method}` is not supported within a batch "

--- a/web3/providers/async_base.py
+++ b/web3/providers/async_base.py
@@ -94,7 +94,6 @@ class AsyncBaseProvider:
         self.cache_allowed_requests = cache_allowed_requests
         self.cacheable_requests = cacheable_requests or CACHEABLE_REQUESTS
         self.request_cache_validation_threshold = request_cache_validation_threshold
-        self._is_batching: bool = False
         self._batch_request_func_cache: Tuple[
             Tuple[Middleware, ...],
             Callable[..., Coroutine[Any, Any, Union[List[RPCResponse], RPCResponse]]],

--- a/web3/providers/base.py
+++ b/web3/providers/base.py
@@ -120,7 +120,6 @@ class JSONBaseProvider(BaseProvider):
         super().__init__(**kwargs)
         self.request_counter = itertools.count()
 
-        self._is_batching: bool = False
         self._batch_request_func_cache: Tuple[
             Tuple[Middleware, ...], Callable[..., Union[List[RPCResponse], RPCResponse]]
         ] = (None, None)

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -30,7 +30,6 @@ from web3.types import (
 )
 
 from .._utils.batching import (
-    batching_context,
     sort_batch_response_by_response_ids,
 )
 from .._utils.caching import (
@@ -202,7 +201,6 @@ class IPCProvider(JSONBaseProvider):
         request = self.encode_rpc_request(method, params)
         return self._make_request(request)
 
-    @batching_context
     def make_batch_request(
         self, requests: List[Tuple[RPCEndpoint, Any]]
     ) -> List[RPCResponse]:

--- a/web3/providers/legacy_websocket.py
+++ b/web3/providers/legacy_websocket.py
@@ -27,7 +27,6 @@ from websockets.legacy.client import (
 )
 
 from web3._utils.batching import (
-    batching_context,
     sort_batch_response_by_response_ids,
 )
 from web3._utils.caching import (
@@ -144,7 +143,6 @@ class LegacyWebSocketProvider(JSONBaseProvider):
         )
         return future.result()
 
-    @batching_context
     def make_batch_request(
         self, requests: List[Tuple[RPCEndpoint, Any]]
     ) -> List[RPCResponse]:

--- a/web3/providers/persistent/persistent.py
+++ b/web3/providers/persistent/persistent.py
@@ -24,7 +24,7 @@ from websockets import (
 
 from web3._utils.batching import (
     BATCH_REQUEST_ID,
-    async_batching_context,
+    is_batching_context,
     sort_batch_response_by_response_ids,
 )
 from web3._utils.caching import (
@@ -237,14 +237,12 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
         rpc_request = await self.send_request(method, params)
         return await self.recv_for_request(rpc_request)
 
-    @async_batching_context
     async def make_batch_request(
         self, requests: List[Tuple[RPCEndpoint, Any]]
     ) -> List[RPCResponse]:
         request_data = self.encode_batch_rpc_request(requests)
         await self.socket_send(request_data)
 
-        # breakpoint()
         response = cast(
             List[RPCResponse],
             await self._get_response_for_request_id(BATCH_REQUEST_ID),
@@ -319,7 +317,7 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
         Check the request response cache for any errors not tied to current requests
         and raise them if found.
         """
-        if not self._is_batching:
+        if not is_batching_context():
             for (
                 response
             ) in self._request_processor._request_response_cache._data.values():

--- a/web3/providers/persistent/request_processor.py
+++ b/web3/providers/persistent/request_processor.py
@@ -19,7 +19,6 @@ from eth_utils.toolz import (
 
 from web3._utils.batching import (
     BATCH_REQUEST_ID,
-    is_batching_context,
 )
 from web3._utils.caching import (
     RequestInformation,
@@ -136,13 +135,10 @@ class RequestProcessor:
                 return None
 
         if request_id is None:
-            if not is_batching_context():
+            if not self._provider._is_batching:
                 raise Web3ValueError(
                     "Request id must be provided when not batching requests."
                 )
-            # the _batch_request_counter is set when entering the context manager
-            request_id = self._provider._batch_request_counter
-            self._provider._batch_request_counter += 1
 
         cache_key = generate_cache_key(request_id)
         request_info = RequestInformation(
@@ -298,7 +294,7 @@ class RequestProcessor:
         return isinstance(raw_response, list) or (
             isinstance(raw_response, dict)
             and raw_response.get("id") is None
-            and is_batching_context()
+            and self._provider._is_batching
         )
 
     async def cache_raw_response(

--- a/web3/providers/persistent/request_processor.py
+++ b/web3/providers/persistent/request_processor.py
@@ -19,6 +19,7 @@ from eth_utils.toolz import (
 
 from web3._utils.batching import (
     BATCH_REQUEST_ID,
+    is_batching_context,
 )
 from web3._utils.caching import (
     RequestInformation,
@@ -135,7 +136,7 @@ class RequestProcessor:
                 return None
 
         if request_id is None:
-            if not self._provider._is_batching:
+            if not is_batching_context():
                 raise Web3ValueError(
                     "Request id must be provided when not batching requests."
                 )
@@ -297,7 +298,7 @@ class RequestProcessor:
         return isinstance(raw_response, list) or (
             isinstance(raw_response, dict)
             and raw_response.get("id") is None
-            and self._provider._is_batching
+            and is_batching_context()
         )
 
     async def cache_raw_response(

--- a/web3/providers/persistent/request_processor.py
+++ b/web3/providers/persistent/request_processor.py
@@ -13,10 +13,6 @@ from typing import (
     Union,
 )
 
-from eth_utils.toolz import (
-    compose,
-)
-
 from web3._utils.batching import (
     BATCH_REQUEST_ID,
 )
@@ -227,34 +223,6 @@ class RequestProcessor:
                 self.pop_cached_request_information(subscribe_cache_key)
 
         return request_info
-
-    def append_result_formatter_for_request(
-        self, request_id: int, result_formatter: Callable[..., Any]
-    ) -> None:
-        cache_key = generate_cache_key(request_id)
-        cached_request_info_for_id: RequestInformation = (
-            self._request_information_cache.get_cache_entry(cache_key)
-        )
-        if cached_request_info_for_id is not None:
-            (
-                current_result_formatters,
-                error_formatters,
-                null_result_formatters,
-            ) = cached_request_info_for_id.response_formatters
-            cached_request_info_for_id.response_formatters = (
-                compose(
-                    result_formatter,
-                    current_result_formatters,
-                ),
-                error_formatters,
-                null_result_formatters,
-            )
-        else:
-            self._provider.logger.debug(
-                "No cached request info for response id `%s`. Cannot "
-                "append response formatter for response.",
-                request_id,
-            )
 
     def append_middleware_response_processor(
         self,

--- a/web3/providers/rpc/async_rpc.py
+++ b/web3/providers/rpc/async_rpc.py
@@ -36,7 +36,6 @@ from web3.types import (
 )
 
 from ..._utils.batching import (
-    async_batching_context,
     sort_batch_response_by_response_ids,
 )
 from ..._utils.caching import (
@@ -169,7 +168,6 @@ class AsyncHTTPProvider(AsyncJSONBaseProvider):
         )
         return response
 
-    @async_batching_context
     async def make_batch_request(
         self, batch_requests: List[Tuple[RPCEndpoint, Any]]
     ) -> Union[List[RPCResponse], RPCResponse]:

--- a/web3/providers/rpc/rpc.py
+++ b/web3/providers/rpc/rpc.py
@@ -34,7 +34,6 @@ from web3.types import (
 )
 
 from ..._utils.batching import (
-    batching_context,
     sort_batch_response_by_response_ids,
 )
 from ..._utils.caching import (
@@ -177,7 +176,6 @@ class HTTPProvider(JSONBaseProvider):
         )
         return response
 
-    @batching_context
     def make_batch_request(
         self, batch_requests: List[Tuple[RPCEndpoint, Any]]
     ) -> Union[List[RPCResponse], RPCResponse]:


### PR DESCRIPTION
### What was wrong?

Closes #3613

### How was it fixed?

- [bugfix](https://github.com/ethereum/web3.py/pull/3705/commits/2e3559741feba1e305c8ab99ce809de35603900a) Use `ContextVar` rather than global flag to toggle batching context. This should better isolate the batching context to its own thread-safe context.
- Add test for concurrent execution of many requests at the same time as a batch request
- [bugfix](https://github.com/ethereum/web3.py/pull/3705/commits/30f76faa5a0c99c53c96178f48bbd44c0b0f88ff): Found an issue with `PersistentConnectionProvider` batching requests where we hadn't yet separated the send and receive functions to deterministically match responses with their requests by `id`. Fixed that in this PR as well.[](https://github.com/ethereum/web3.py/pull/3705/commits/30f76faa5a0c99c53c96178f48bbd44c0b0f88ff)
- [bugfix](https://github.com/ethereum/web3.py/pull/3705/commits/9cf645dd5cf341810cc8af6b1ec0e8c8dd12ad62): threading id means nothing for async, use loop id
- [test fix](https://github.com/ethereum/web3.py/pull/3705/commits/1542d9df4ac5cf2f0978c05f4d203558705a4245): gather sessions deterministically to check order

---
🎉 🎉  Bonus 🎉 🎉 

I was able to switch our core tests to run via `pytest-xdist` insanely fast by sorting any `set` parametrized params or using `tuple`s / `list`s instead, where appropriate. I am kind of shocked we hadn't gone this route before but this is a pretty significant update.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="968" alt="Screenshot 2025-05-20 at 18 59 53" src="https://github.com/user-attachments/assets/73fadf20-7731-4391-9ca9-1489a6b868ab" />
