### PR TITLE
Allow task-based subscription processing via the subscription manager

### DIFF
--- a/newsfragments/3709.feature.rst
+++ b/newsfragments/3709.feature.rst
@@ -1,0 +1,1 @@
+Support parallelization of subscription handling via the subscription manager if processing order does not matter.

--- a/newsfragments/3709.feature.rst
+++ b/newsfragments/3709.feature.rst
@@ -1,1 +1,1 @@
-Support parallelization of subscription handling via the subscription manager if processing order does not matter.
+Support parallelization of subscription handling globally via the subscription manager ``parallelize`` flag, and on a per-subscription basis via the ``parallelize`` flag on the subscription itself.

--- a/web3/_utils/module_testing/persistent_connection_provider.py
+++ b/web3/_utils/module_testing/persistent_connection_provider.py
@@ -3,7 +3,6 @@ import asyncio
 from dataclasses import (
     dataclass,
 )
-import time
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -38,9 +37,6 @@ from web3.datastructures import (
 )
 from web3.middleware import (
     ExtraDataToPOAMiddleware,
-)
-from web3.providers.persistent.request_processor import (
-    TaskReliantQueue,
 )
 from web3.types import (
     BlockData,
@@ -918,59 +914,3 @@ class PersistentConnectionProviderTest:
 
         # cleanup
         await clean_up_task(run_forever_task)
-
-    @pytest.mark.asyncio
-    async def test_high_throughput_subscription_task_based(
-        self, async_w3: AsyncWeb3
-    ) -> None:
-        async_w3.provider._request_processor._handler_subscription_queue = (
-            TaskReliantQueue(maxsize=5_000)
-        )
-        sub_manager = async_w3.subscription_manager
-        sub_manager.task_based = True  # turn on task-based processing
-
-        class Counter:
-            val: int = 0
-
-        counter = Counter()
-
-        async def high_throughput_handler(
-            handler_context: Any,
-        ) -> None:
-            handler_context.counter.val += 1
-            if handler_context.counter.val == 5_000:
-                await handler_context.subscription.unsubscribe()
-            # if we awaited all 5_000 messages, we would sleep at least 5 seconds
-            await asyncio.sleep(5 // 5_000)
-
-        # build a meaningless subscription since we are fabricating the messages
-        sub_id = await async_w3.eth.subscribe(
-            "syncing",
-            handler=high_throughput_handler,
-            handler_context={"counter": counter},
-        )
-        async_w3.provider._request_processor.cache_request_information(
-            request_id=sub_id,
-            method=RPCEndpoint("eth_subscribe"),
-            params=[],
-            response_formatters=((), (), ()),  # type: ignore
-        )
-
-        # put 5_000 messages in the queue
-        for _ in range(5_000):
-            async_w3.provider._request_processor._handler_subscription_queue.put_nowait(
-                {
-                    "jsonrpc": "2.0",
-                    "method": "eth_subscription",
-                    "params": {"subscription": HexBytes(sub_id), "result": False},
-                }
-            )
-
-        start = time.time()
-        await sub_manager.handle_subscriptions()
-        stop = time.time()
-
-        assert counter.val == 5_000
-
-        assert sub_manager.total_handler_calls == 5_000
-        assert stop - start < 3, "subscription handling took too long!"

--- a/web3/eth/async_eth.py
+++ b/web3/eth/async_eth.py
@@ -720,19 +720,6 @@ class AsyncEth(BaseEth):
         mungers=[default_root_munger],
     )
 
-    _subscribe_with_args: Method[
-        Callable[
-            [
-                SubscriptionType,
-                Optional[Union[LogsSubscriptionArg, bool]],
-            ],
-            Awaitable[HexStr],
-        ]
-    ] = Method(
-        RPC.eth_subscribe,
-        mungers=[default_root_munger],
-    )
-
     async def subscribe(
         self,
         subscription_type: SubscriptionType,
@@ -745,6 +732,7 @@ class AsyncEth(BaseEth):
         handler: Optional[EthSubscriptionHandler] = None,
         handler_context: Optional[Dict[str, Any]] = None,
         label: Optional[str] = None,
+        parallelize: Optional[bool] = None,
     ) -> HexStr:
         if not isinstance(self.w3.provider, PersistentConnectionProvider):
             raise MethodNotSupported(
@@ -757,6 +745,7 @@ class AsyncEth(BaseEth):
             handler=handler,
             handler_context=handler_context or {},
             label=label,
+            parallelize=parallelize,
         )
         return await self.w3.subscription_manager.subscribe(sub)
 

--- a/web3/exceptions.py
+++ b/web3/exceptions.py
@@ -353,10 +353,17 @@ class PersistentConnectionClosedOK(PersistentConnectionError):
     """
 
 
-class SubscriptionProcessingFinished(Web3Exception):
+class SubscriptionProcessingFinished(PersistentConnectionError):
     """
     Raised to alert the subscription manager that the processing of subscriptions
     has finished.
+    """
+
+
+class SubscriptionHandlerTaskException(TaskNotRunning):
+    """
+    Raised to alert the subscription manager that an exception occurred in the
+    subscription processing task.
     """
 
 

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -550,13 +550,10 @@ class RequestManager:
                 else:
                     # if not an active sub, skip processing and continue
                     continue
-            except TaskNotRunning:
+            except TaskNotRunning as e:
                 await asyncio.sleep(0)
                 self._provider._handle_listener_task_exceptions()
-                self.logger.error(
-                    "Message listener background task has stopped unexpectedly. "
-                    "Stopping message stream."
-                )
+                self.logger.error("Stopping message stream: %s", e.message)
                 return
 
     async def _process_response(

--- a/web3/providers/persistent/persistent.py
+++ b/web3/providers/persistent/persistent.py
@@ -164,7 +164,7 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
         if cache_key != self._send_batch_func_cache[0]:
 
             async def send_func(
-                requests: List[Tuple[RPCEndpoint, Any]]
+                requests: List[Tuple[RPCEndpoint, Any]],
             ) -> List[RPCRequest]:
                 for mw in middleware:
                     initialized = mw(async_w3)
@@ -376,11 +376,12 @@ class PersistentConnectionProvider(AsyncJSONBaseProvider, ABC):
     ) -> None:
         # Puts a `TaskNotRunning` in appropriate queues to signal the end of the
         # listener task to any listeners relying on the queues.
+        message = "Message listener task has ended."
         self._request_processor._subscription_response_queue.put_nowait(
-            TaskNotRunning(message_listener_task)
+            TaskNotRunning(message_listener_task, message=message)
         )
         self._request_processor._handler_subscription_queue.put_nowait(
-            TaskNotRunning(message_listener_task)
+            TaskNotRunning(message_listener_task, message=message)
         )
 
     def _raise_stray_errors_from_cache(self) -> None:

--- a/web3/providers/persistent/subscription_manager.py
+++ b/web3/providers/persistent/subscription_manager.py
@@ -62,7 +62,8 @@ class SubscriptionManager:
         self.task_based = False
         self.task_timeout = 1
         self.ignore_task_exceptions = False
-        self._tasks: Set[asyncio.Task[None]] = set()
+        # TODO: can remove quotes from type hints once Python 3.8 support is dropped
+        self._tasks: Set["asyncio.Task[None]"] = set()
 
         # share the subscription container with the request processor so it can separate
         # subscriptions into different queues based on ``sub._handler`` presence
@@ -95,7 +96,8 @@ class SubscriptionManager:
                     f"labels.\n    label: {subscription._label}"
                 )
 
-    def _handler_task_callback(self, task: asyncio.Task[None]) -> None:
+    # TODO: can remove quotes from type hints once Python 3.8 support is dropped
+    def _handler_task_callback(self, task: "asyncio.Task[None]") -> None:
         """
         Callback when a handler task completes. Similar to _message_listener_callback.
         Puts handler exceptions into the queue to be raised in the main loop, else

--- a/web3/utils/subscriptions.py
+++ b/web3/utils/subscriptions.py
@@ -110,11 +110,14 @@ class EthSubscription(Generic[TSubscriptionResult]):
         handler: Optional[EthSubscriptionHandler] = None,
         handler_context: Optional[Dict[str, Any]] = None,
         label: Optional[str] = None,
+        parallelize: Optional[bool] = None,
     ) -> None:
         self._subscription_params = subscription_params
         self._handler = handler_wrapper(handler)
         self._handler_context = handler_context or {}
         self._label = label
+
+        self.parallelize = parallelize
         self.handler_call_count = 0
 
     @property
@@ -128,6 +131,7 @@ class EthSubscription(Generic[TSubscriptionResult]):
         handler: Optional[EthSubscriptionHandler] = None,
         handler_context: Optional[Dict[str, Any]] = None,
         label: Optional[str] = None,
+        parallelize: Optional[bool] = None,
     ) -> "EthSubscription[Any]":
         subscription_type = subscription_params[0]
         subscription_arg = (
@@ -135,7 +139,10 @@ class EthSubscription(Generic[TSubscriptionResult]):
         )
         if subscription_type == "newHeads":
             return NewHeadsSubscription(
-                handler=handler, handler_context=handler_context, label=label
+                handler=handler,
+                handler_context=handler_context,
+                label=label,
+                parallelize=parallelize,
             )
         elif subscription_type == "logs":
             subscription_arg = subscription_arg or {}
@@ -144,6 +151,7 @@ class EthSubscription(Generic[TSubscriptionResult]):
                 handler=handler,
                 handler_context=handler_context,
                 label=label,
+                parallelize=parallelize,
             )
         elif subscription_type == "newPendingTransactions":
             subscription_arg = subscription_arg or False
@@ -152,10 +160,14 @@ class EthSubscription(Generic[TSubscriptionResult]):
                 handler=handler,
                 handler_context=handler_context,
                 label=label,
+                parallelize=parallelize,
             )
         elif subscription_type == "syncing":
             return SyncingSubscription(
-                handler=handler, handler_context=handler_context, label=label
+                handler=handler,
+                handler_context=handler_context,
+                label=label,
+                parallelize=parallelize,
             )
         else:
             params = (
@@ -168,6 +180,7 @@ class EthSubscription(Generic[TSubscriptionResult]):
                 handler=handler,
                 handler_context=handler_context,
                 label=label,
+                parallelize=parallelize,
             )
 
     @property
@@ -206,6 +219,7 @@ class LogsSubscription(EthSubscription[LogReceipt]):
         handler: LogsSubscriptionHandler = None,
         handler_context: Optional[Dict[str, Any]] = None,
         label: Optional[str] = None,
+        parallelize: Optional[bool] = None,
     ) -> None:
         self.address = address
         self.topics = topics
@@ -222,6 +236,7 @@ class LogsSubscription(EthSubscription[LogReceipt]):
             handler=handler,
             handler_context=handler_context,
             label=label,
+            parallelize=parallelize,
         )
 
 
@@ -237,12 +252,14 @@ class NewHeadsSubscription(EthSubscription[BlockData]):
         label: Optional[str] = None,
         handler: Optional[NewHeadsSubscriptionHandler] = None,
         handler_context: Optional[Dict[str, Any]] = None,
+        parallelize: Optional[bool] = None,
     ) -> None:
         super().__init__(
             subscription_params=("newHeads",),
             handler=handler,
             handler_context=handler_context,
             label=label,
+            parallelize=parallelize,
         )
 
 
@@ -261,6 +278,7 @@ class PendingTxSubscription(EthSubscription[Union[HexBytes, TxData]]):
         label: Optional[str] = None,
         handler: Optional[PendingTxSubscriptionHandler] = None,
         handler_context: Optional[Dict[str, Any]] = None,
+        parallelize: Optional[bool] = None,
     ) -> None:
         self.full_transactions = full_transactions
         super().__init__(
@@ -268,6 +286,7 @@ class PendingTxSubscription(EthSubscription[Union[HexBytes, TxData]]):
             handler=handler,
             handler_context=handler_context,
             label=label,
+            parallelize=parallelize,
         )
 
 
@@ -283,10 +302,12 @@ class SyncingSubscription(EthSubscription[SyncProgress]):
         label: Optional[str] = None,
         handler: Optional[SyncingSubscriptionHandler] = None,
         handler_context: Optional[Dict[str, Any]] = None,
+        parallelize: Optional[bool] = None,
     ) -> None:
         super().__init__(
             subscription_params=("syncing",),
             handler=handler,
             handler_context=handler_context,
             label=label,
+            parallelize=parallelize,
         )


### PR DESCRIPTION
### What was wrong?

Closes #3672

### How was it fixed?

- For high-throughput subscriptions, where order of processing is not important, we should allow a configuration to be set to process tasks in a task-based manner - creating a task for each subscription and processing them in parallel.

- Add a ``parallelize`` flag to the subscription manager, defaulting to ``False``, but allowing this to be set to ``True`` to enable task-based, parallelized processing.

- This should be able to be controlled on a per-subscription basis as well. If sub-second blocks need to be processed in order but, say, processing some information about transactions in the mempool (`newPendingTransactions`) does not, this should be able to be accounted for as well. Adds a `parallelize` flag to subscriptions which overrides whatever the manager setting is for that particular subscription - defaults to `None` which means the manager controls the global processing state.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="687" height="425" alt="Screenshot 2025-08-01 at 13 24 31" src="https://github.com/user-attachments/assets/9b20e11c-8ae9-4de0-8bd6-562504f7e00c" />
