### PR TITLE
chore: fix typos

### DIFF
--- a/newsfragments/3710.misc.rst
+++ b/newsfragments/3710.misc.rst
@@ -1,0 +1,1 @@
+Fix typo in class used for private API within ``IPCProvider``.

--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -59,7 +59,7 @@ def get_ipc_socket(ipc_path: str, timeout: float = 2.0) -> socket.socket:
         return sock
 
 
-class PersistantSocket:
+class PersistentSocket:
     sock = None
 
     def __init__(self, ipc_path: str) -> None:
@@ -157,7 +157,7 @@ class IPCProvider(JSONBaseProvider):
 
         self.timeout = timeout
         self._lock = threading.Lock()
-        self._socket = PersistantSocket(self.ipc_path)
+        self._socket = PersistentSocket(self.ipc_path)
 
     def __str__(self) -> str:
         return f"<{self.__class__.__name__} {self.ipc_path}>"


### PR DESCRIPTION
### What was wrong?

There was a typo in the class name `PersistantSocket` in web3/providers/ipc.py. The correct spelling should be `PersistentSocket` (with an 'e' instead of 'a').

### How was it fixed?

Fixed the typo by renaming the class from `PersistantSocket` to `PersistentSocket` throughout the file.

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://images.pexels.com/photos/1108099/pexels-photo-1108099.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2)