### PR TITLE
bugfix: Fix batching for AutoProvider

### DIFF
--- a/newsfragments/3712.bugfix.rst
+++ b/newsfragments/3712.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``AutoProvider`` batching setup by adding a proxy batch request.

--- a/tests/integration/go_ethereum/test_goethereum_http.py
+++ b/tests/integration/go_ethereum/test_goethereum_http.py
@@ -7,6 +7,7 @@ import pytest_asyncio
 
 from web3 import (
     AsyncWeb3,
+    AutoProvider,
     Web3,
 )
 from web3._utils.module_testing.go_ethereum_admin_module import (
@@ -102,8 +103,17 @@ class TestGoEthereumDebugModuleTest(GoEthereumDebugModuleTest):
 
 class TestGoEthereumEthModuleTest(GoEthereumEthModuleTest):
     def test_auto_provider_batching(self, auto_w3: "Web3") -> None:
-        # test that batch_requests doesn't error out when using the auto provider
-        auto_w3.batch_requests()
+        with auto_w3.batch_requests() as batch:
+            assert isinstance(auto_w3.provider, AutoProvider)
+            assert auto_w3.provider._is_batching
+            assert auto_w3.provider._batching_context is not None
+            batch.add(auto_w3.eth.get_block("latest"))
+            batch.add(auto_w3.eth.get_block("earliest"))
+            batch.add(auto_w3.eth.get_block("pending"))
+            results = batch.execute()
+
+        assert not auto_w3.provider._is_batching
+        assert len(results) == 3
 
 
 class TestGoEthereumNetModuleTest(GoEthereumNetModuleTest):

--- a/web3/manager.py
+++ b/web3/manager.py
@@ -254,9 +254,9 @@ class RequestManager:
         """
         Context manager for making batch requests
         """
-        if isinstance(self.provider, AutoProvider):
-            self.provider = self.provider._get_active_provider(use_cache=True)
-        if not isinstance(self.provider, (AsyncJSONBaseProvider, JSONBaseProvider)):
+        if not isinstance(
+            self.provider, (AsyncJSONBaseProvider, JSONBaseProvider, AutoProvider)
+        ):
             raise Web3TypeError("Batch requests are not supported by this provider.")
         return RequestBatcher(self.w3)
 


### PR DESCRIPTION
### What was wrong?

Closes #3711

### How was it fixed?

- We can't set the provider, we must let `AutoProvider` decide when it makes proxy calls using the "active" provider.

- For the reason above, we need to implement a proxy batch request so that it can instead pull the active provider and make the batch request using it.

- Make sure current tests fail with the old implementation and pass with the new one.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="547" alt="Screenshot 2025-05-29 at 09 30 31" src="https://github.com/user-attachments/assets/f686bb51-6bbc-4c16-b6d9-6d0e4b24ff8a" />
