### PR TITLE
Fixed spelling of PersistantSocket to PersistentSocket in web3/providers/ipc.py

### DIFF
--- a/web3/providers/ipc.py
+++ b/web3/providers/ipc.py
@@ -59,7 +59,7 @@ def get_ipc_socket(ipc_path: str, timeout: float = 2.0) -> socket.socket:
         return sock
 
 
-class PersistantSocket:
+class PersistentSocket:
     sock = None
 
     def __init__(self, ipc_path: str) -> None:
@@ -157,7 +157,7 @@ class IPCProvider(JSONBaseProvider):
 
         self.timeout = timeout
         self._lock = threading.Lock()
-        self._socket = PersistantSocket(self.ipc_path)
+        self._socket = PersistentSocket(self.ipc_path)
 
     def __str__(self) -> str:
         return f"<{self.__class__.__name__} {self.ipc_path}>"


### PR DESCRIPTION
### What was wrong?

The word "Persistant" was misspelled - it should be "Persistent"

### How was it fixed?

changed Persistant ----> Persistent

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
