### PR TITLE
[docs]: fix link to eth_gasPrice docs

### DIFF
--- a/docs/gas_price.rst
+++ b/docs/gas_price.rst
@@ -76,7 +76,7 @@ Available gas price strategies
 .. py:method:: rpc_gas_price_strategy(web3, transaction_params=None)
 
     Makes a call to the `JSON-RPC eth_gasPrice
-    method <https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gasprice>`_ which returns
+    method <https://ethereum.org/en/developers/docs/apis/json-rpc#eth_gasprice>`_ which returns
     the gas price configured by the connected Ethereum node.
 
 .. py:module:: web3.gas_strategies.time_based

--- a/newsfragments/3717.docs.rst
+++ b/newsfragments/3717.docs.rst
@@ -1,0 +1,1 @@
+Fix broken link to external ``eth_gasPrice`` documentation.


### PR DESCRIPTION
### What was wrong?

https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gasprice - this link is not working anymore. i tried to find new one whish will work properly in new repo https://github.com/ethereum/eth-wiki but there are no good one doc.  so i decided to change it to https://ethereum.org/en/developers/docs/apis/json-rpc#eth_gasprice 

### How was it fixed?
fixed link to https://ethereum.org/en/developers/docs/apis/json-rpc#eth_gasprice


