### PR TITLE
Fix typo in CHECKSUM_ADDRESS_ZERO constant and minor doc update

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -3651,7 +3651,7 @@ Released January 23rd, 2019
 
 - Features
 
-  - Stablize the ``PM`` module
+  - Stabilize the ``PM`` module
     - `#1125 <https://github.com/ethereum/web3.py/pull/1125>`_
   - Implement async ``Version`` module
     - `#1166 <https://github.com/ethereum/web3.py/pull/1166>`_

--- a/web3/constants.py
+++ b/web3/constants.py
@@ -6,7 +6,7 @@ from eth_typing import (
 
 # Constants as Strings
 ADDRESS_ZERO = HexAddress(HexStr("0x0000000000000000000000000000000000000000"))
-CHECKSUM_ADDRESSS_ZERO = ChecksumAddress(ADDRESS_ZERO)
+CHECKSUM_ADDRESS_ZERO = ChecksumAddress(ADDRESS_ZERO)
 MAX_INT = HexStr("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
 HASH_ZERO = HexStr("0x0000000000000000000000000000000000000000000000000000000000000000")
 


### PR DESCRIPTION


Description:  
This pull request addresses two minor issues:
1. Fixes a typo in the constant name from CHECKSUM_ADDRESSSS_ZERO to CHECKSUM_ADDRESS_ZERO in web3/constants.py.
2. Updates the release notes in docs/release_notes.rst to correct the word "Stablize" to "Stabilize" for the PM module.

