### PR TITLE
removed (almost) unreachable code

### DIFF
--- a/web3/_utils/error_formatters_utils.py
+++ b/web3/_utils/error_formatters_utils.py
@@ -150,12 +150,7 @@ def raise_contract_logic_error_on_revert(response: RPCResponse) -> RPCResponse:
     message_present = message is not None and message != ""
     data = error.get("data", MISSING_DATA)
 
-    if data is None:
-        if message_present:
-            raise ContractLogicError(message, data=data)
-        elif not message_present:
-            raise ContractLogicError("execution reverted", data=data)
-    elif isinstance(data, dict) and message_present:
+    if isinstance(data, dict) and message_present:
         raise ContractLogicError(f"execution reverted: {message}", data=data)
     elif isinstance(data, str):
         _raise_contract_error(data)


### PR DESCRIPTION
checking for None after using dict.get with an default argument is never true except if the key is present in the dict and the value is explicitly None. This check seems to be non intentional, especially as it results in an unexpected behaviour where any RPC response containing response["error"]["data"] == None is treated as an ContractLogicError, no matter what error it actually is. Simply removing this code part makes the code both more readable and more correct.