### PR TITLE
bugfix: Raise for non-dict responses in formatting middleware

### DIFF
--- a/newsfragments/3735.bugfix.rst
+++ b/newsfragments/3735.bugfix.rst
@@ -1,0 +1,1 @@
+Raise ``BadResponseFormat`` from within ``FormattingMiddleware`` if the raw response is not a dict.

--- a/newsfragments/3735.internal.rst
+++ b/newsfragments/3735.internal.rst
@@ -1,0 +1,1 @@
+Add missing async tests for ``FormattingMiddleware`` as a sanity check.

--- a/web3/middleware/formatting.py
+++ b/web3/middleware/formatting.py
@@ -16,6 +16,7 @@ from eth_utils.toolz import (
 )
 
 from web3.exceptions import (
+    BadResponseFormat,
     Web3ValueError,
 )
 from web3.middleware.base import (
@@ -77,7 +78,12 @@ def _apply_response_formatters(
                 response, response_type, method_response_formatter(appropriate_response)
             )
 
-    if response.get("result") is not None and method in result_formatters:
+    if not isinstance(response, dict):
+        raise BadResponseFormat(
+            "Malformed response: expected a valid JSON-RPC response object, got: "
+            "`{}`".format(response)
+        )
+    elif response.get("result") is not None and method in result_formatters:
         return _format_response("result", result_formatters[method])
     elif (
         # eth_subscription responses


### PR DESCRIPTION
### What was wrong?

Closes #3734 

### How was it fixed?

- Raise early for non-dict responses within formatting middleware

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="668" height="936" alt="Screenshot 2025-07-28 at 15 45 13" src="https://github.com/user-attachments/assets/2a92ee4b-7991-4b03-9728-8d1b096a9690" />
