### PR TITLE
chore: fix dead link to Ethereum-Contract-ABI article

### DIFF
--- a/docs/web3.eth.rst
+++ b/docs/web3.eth.rst
@@ -684,7 +684,7 @@ The following methods are available on the ``web3.eth`` namespace.
       transaction
     * ``data``: ``bytes or text`` - The compiled code of a contract OR the hash
       of the invoked method signature and encoded parameters. For details see
-      `Ethereum Contract ABI <https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI>`_.
+      `Ethereum Contract ABI <https://www.quicknode.com/guides/ethereum-development/smart-contracts/what-is-an-abi>`_.
     * ``nonce``: ``integer`` - (optional) Integer of a nonce. This allows to
       overwrite your own pending transactions that use the same nonce.
 


### PR DESCRIPTION
### What was wrong?

Related to Issue #
Closes #

### How was it fixed?

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
