### PR TITLE
fix: broken import for web3

### DIFF
--- a/web3/eth/eth.py
+++ b/web3/eth/eth.py
@@ -97,7 +97,7 @@ from web3.types import (
     Wei,
     _Hash32,
 )
-from web3.utils import (
+from web3._utils import (
     handle_offchain_lookup,
 )
 


### PR DESCRIPTION
### What was wrong?

`web3.utils` is gone since v6, switched to `web3._utils` so it works again.

### How was it fixed?

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![for you](https://image.shutterstock.com/image-photo/dog-animal-pet-cat-cute-260nw-2521815587.jpg)
