### PR TITLE
chore: Clarify log wording

### DIFF
--- a/web3/providers/persistent/request_processor.py
+++ b/web3/providers/persistent/request_processor.py
@@ -334,8 +334,7 @@ class RequestProcessor:
                 if self._subscription_queue_synced_with_ws_stream:
                     self._subscription_queue_synced_with_ws_stream = False
                 self._provider.logger.info(
-                    "Subscription response queue has %s subscriptions. "
-                    "Processing as FIFO.",
+                    "Subscription response queue size is %s. Processing as FIFO.",
                     qsize,
                 )
 


### PR DESCRIPTION
## Description

`qsize` reflects the length of _subscription_response_queue (number of pending responses/messages), not the number of active subscriptions. The previous wording “has %s subscriptions” was misleading.