### PR TITLE
Fix: logs subscription topics

### DIFF
--- a/newsfragments/3748.bugfix.rst
+++ b/newsfragments/3748.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``topics`` type for ``LogsSubscription`` to reflect AND / OR nested list conditions on log filters.

--- a/newsfragments/3748.feature.rst
+++ b/newsfragments/3748.feature.rst
@@ -1,0 +1,1 @@
+Add the ``TopicFilter`` type to better describe the cases for filtering logs by topics.

--- a/tests/integration/go_ethereum/conftest.py
+++ b/tests/integration/go_ethereum/conftest.py
@@ -175,12 +175,14 @@ def start_geth_process_and_yield_port(
         bufsize=1,
     )
 
-    port = wait_for_port(proc)
-    yield port
-
-    kill_proc_gracefully(proc)
-    output, errors = proc.communicate(timeout=5)
-    print("Geth Process Exited:\n" f"stdout: {output}\n\n" f"stderr: {errors}\n\n")
+    try:
+        port = wait_for_port(proc)
+        yield port
+    finally:
+        # Ensure cleanup happens even if test fails
+        kill_proc_gracefully(proc)
+        output, errors = proc.communicate(timeout=5)
+        print("Geth Process Exited:\n" f"stdout: {output}\n\n" f"stderr: {errors}\n\n")
 
 
 @pytest.fixture

--- a/web3/types.py
+++ b/web3/types.py
@@ -62,6 +62,19 @@ ABIElementIdentifier = Union[str, Type[FallbackFn], Type[ReceiveFn]]
 
 # bytes, hexbytes, or hexstr representing a 32 byte hash
 _Hash32 = Union[Hash32, HexBytes, HexStr]
+
+# --- ``TopicFilter`` type for event log filtering with AND/OR patterns --- #
+# - ``None``: wildcard, matches any value at this position
+# - ``_Hash32``: single topic that must match exactly
+# - ``Sequence[Union[None, _Hash32]]``: OR condition, at least one must match
+# - ``Sequence[Sequence[...]]``: nested OR conditions
+TopicFilter = Union[
+    None,
+    _Hash32,
+    Sequence[Union[None, _Hash32]],
+    Sequence["TopicFilter"],
+]
+
 EnodeURI = NewType("EnodeURI", str)
 ENS = NewType("ENS", str)
 Nonce = NewType("Nonce", int)
@@ -345,7 +358,7 @@ class FilterParams(TypedDict, total=False):
     blockHash: HexBytes
     fromBlock: BlockIdentifier
     toBlock: BlockIdentifier
-    topics: Sequence[Optional[Union[_Hash32, Sequence[_Hash32]]]]
+    topics: Sequence[TopicFilter]
 
 
 class FeeHistory(TypedDict):
@@ -667,4 +680,4 @@ class LogsSubscriptionArg(TypedDict, total=False):
         ENS,
         Sequence[Union[Address, ChecksumAddress, ENS]],
     ]
-    topics: Sequence[Union[HexStr, Sequence[HexStr]]]
+    topics: Sequence[TopicFilter]

--- a/web3/utils/subscriptions.py
+++ b/web3/utils/subscriptions.py
@@ -30,6 +30,7 @@ from web3.types import (
     FilterParams,
     LogReceipt,
     SyncProgress,
+    TopicFilter,
     TxData,
 )
 
@@ -215,7 +216,7 @@ class LogsSubscription(EthSubscription[LogReceipt]):
         address: Optional[
             Union[Address, ChecksumAddress, List[Address], List[ChecksumAddress]]
         ] = None,
-        topics: Optional[List[HexStr]] = None,
+        topics: Optional[Sequence[TopicFilter]] = None,
         handler: LogsSubscriptionHandler = None,
         handler_context: Optional[Dict[str, Any]] = None,
         label: Optional[str] = None,


### PR DESCRIPTION
### What was wrong?

Closes #3747

### How was it fixed?

- We were lacking the appropriate type for topic filtering, where AND / OR conditions can be set by providing inner lists with topic elements to `topics`. The typing is fixed here for topic filter conditions, and also relaxed for topic elements.

### Todo:

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="526" height="726" alt="Screenshot 2025-09-01 at 13 21 21" src="https://github.com/user-attachments/assets/01db9a34-ad77-46b1-ac5a-dcdfd6eb708e" />
