### PR TITLE
fix: use explicit session for all threads when provided

### DIFF
--- a/newsfragments/3800.bugfix.rst
+++ b/newsfragments/3800.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``HTTPProvider`` to share an explicitly provided ``session`` across all threads, rather than only the creating thread.

--- a/tests/core/providers/test_http_provider.py
+++ b/tests/core/providers/test_http_provider.py
@@ -214,7 +214,7 @@ def test_no_explicit_session_creates_per_thread_sessions():
         sessions_by_thread[thread_id].append(session)
 
     # Verify thread isolation: same thread always gets the same session
-    for thread_id, sessions in sessions_by_thread.items():
+    for _, sessions in sessions_by_thread.items():
         assert all(
             s is sessions[0] for s in sessions
         ), "Same thread should always get the same session"
@@ -222,6 +222,6 @@ def test_no_explicit_session_creates_per_thread_sessions():
     # Verify different threads get different sessions (not the main thread's)
     for thread_id, sessions in sessions_by_thread.items():
         if thread_id != main_thread_id:
-            assert sessions[0] is not main_thread_session, (
-                "Different threads should have different sessions"
-            )
+            assert (
+                sessions[0] is not main_thread_session
+            ), "Different threads should have different sessions"

--- a/tests/core/providers/test_http_provider.py
+++ b/tests/core/providers/test_http_provider.py
@@ -206,12 +206,22 @@ def test_no_explicit_session_creates_per_thread_sessions():
         futures = [executor.submit(get_session_from_thread) for _ in range(3)]
         concurrent.futures.wait(futures)
 
-    # Each unique thread should have created its own session
-    unique_thread_ids = {tid for tid, _ in sessions_from_threads}
-    assert len(unique_thread_ids) == 3, "Should have 3 unique thread IDs"
-
-    # Sessions from different threads should NOT be the main thread's session
+    # Group sessions by thread ID
+    sessions_by_thread = {}
     for thread_id, session in sessions_from_threads:
+        if thread_id not in sessions_by_thread:
+            sessions_by_thread[thread_id] = []
+        sessions_by_thread[thread_id].append(session)
+
+    # Verify thread isolation: same thread always gets the same session
+    for thread_id, sessions in sessions_by_thread.items():
+        assert all(
+            s is sessions[0] for s in sessions
+        ), "Same thread should always get the same session"
+
+    # Verify different threads get different sessions (not the main thread's)
+    for thread_id, sessions in sessions_by_thread.items():
         if thread_id != main_thread_id:
-            # Different threads should have different sessions
-            assert session is not main_thread_session
+            assert sessions[0] is not main_thread_session, (
+                "Different threads should have different sessions"
+            )

--- a/tests/core/providers/test_http_provider.py
+++ b/tests/core/providers/test_http_provider.py
@@ -1,3 +1,6 @@
+import concurrent.futures
+import threading
+
 import pytest
 from unittest.mock import (
     Mock,
@@ -133,3 +136,83 @@ def test_http_empty_batch_response(mock_post):
 
     # assert that even though there was an error, we have reset the batching state
     assert not w3.provider._is_batching
+
+
+def test_user_provided_session_shared_across_threads():
+    """
+    Test that when a user provides an explicit session to HTTPProvider,
+    that same session is used by ALL threads, not just the creating thread.
+
+    This is a regression test for:
+    https://github.com/ethereum/web3.py/issues/3789
+    """
+    shared_session = Session()
+    provider = HTTPProvider(endpoint_uri=URI, session=shared_session)
+
+    sessions_from_threads = []
+    errors = []
+
+    def get_session_from_thread():
+        try:
+            # This simulates what happens internally when a request is made
+            # from a different thread - it calls cache_and_return_session
+            session = provider._request_session_manager.cache_and_return_session(URI)
+            sessions_from_threads.append(session)
+        except Exception as e:
+            errors.append(e)
+
+    # Get session from main thread
+    main_thread_session = provider._request_session_manager.cache_and_return_session(
+        URI
+    )
+
+    # Get session from multiple different threads
+    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+        futures = [executor.submit(get_session_from_thread) for _ in range(10)]
+        concurrent.futures.wait(futures)
+
+    assert not errors, f"Errors occurred: {errors}"
+    assert len(sessions_from_threads) == 10
+
+    # The main assertion: ALL sessions should be the SAME shared session
+    assert main_thread_session is shared_session
+    for session in sessions_from_threads:
+        assert session is shared_session, (
+            "Session from different thread should be the same as the "
+            "explicitly provided session"
+        )
+
+
+def test_no_explicit_session_creates_per_thread_sessions():
+    """
+    Test that when no explicit session is provided, each thread gets its own
+    session (the original thread-isolated behavior).
+    """
+    provider = HTTPProvider(endpoint_uri=URI)
+
+    sessions_from_threads = []
+
+    def get_session_from_thread():
+        session = provider._request_session_manager.cache_and_return_session(URI)
+        sessions_from_threads.append((threading.get_ident(), session))
+
+    # Get session from main thread
+    main_thread_id = threading.get_ident()
+    main_thread_session = provider._request_session_manager.cache_and_return_session(
+        URI
+    )
+
+    # Get sessions from different threads
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+        futures = [executor.submit(get_session_from_thread) for _ in range(3)]
+        concurrent.futures.wait(futures)
+
+    # Each unique thread should have created its own session
+    unique_thread_ids = {tid for tid, _ in sessions_from_threads}
+    assert len(unique_thread_ids) == 3, "Should have 3 unique thread IDs"
+
+    # Sessions from different threads should NOT be the main thread's session
+    for thread_id, session in sessions_from_threads:
+        if thread_id != main_thread_id:
+            # Different threads should have different sessions
+            assert session is not main_thread_session

--- a/tests/core/providers/test_http_provider.py
+++ b/tests/core/providers/test_http_provider.py
@@ -1,7 +1,6 @@
+import pytest
 import concurrent.futures
 import threading
-
-import pytest
 from unittest.mock import (
     Mock,
     patch,

--- a/web3/providers/rpc/rpc.py
+++ b/web3/providers/rpc/rpc.py
@@ -66,7 +66,11 @@ class HTTPProvider(JSONBaseProvider):
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
-        self._request_session_manager = HTTPSessionManager()
+        # Pass explicit session to manager so it's used for ALL requests,
+        # regardless of which thread makes them
+        self._request_session_manager = HTTPSessionManager(
+            explicit_session=session
+        )
 
         if endpoint_uri is None:
             self.endpoint_uri = (
@@ -77,11 +81,6 @@ class HTTPProvider(JSONBaseProvider):
 
         self._request_kwargs = request_kwargs or {}
         self._exception_retry_configuration = exception_retry_configuration
-
-        if session:
-            self._request_session_manager.cache_and_return_session(
-                self.endpoint_uri, session
-            )
 
     def __str__(self) -> str:
         return f"RPC connection {self.endpoint_uri}"

--- a/web3/providers/rpc/rpc.py
+++ b/web3/providers/rpc/rpc.py
@@ -68,9 +68,7 @@ class HTTPProvider(JSONBaseProvider):
         super().__init__(**kwargs)
         # Pass explicit session to manager so it's used for ALL requests,
         # regardless of which thread makes them
-        self._request_session_manager = HTTPSessionManager(
-            explicit_session=session
-        )
+        self._request_session_manager = HTTPSessionManager(explicit_session=session)
 
         if endpoint_uri is None:
             self.endpoint_uri = (


### PR DESCRIPTION
## Summary

Fixes #3789

When a `session` is explicitly provided to `HTTPProvider`, it should be used for **all** requests regardless of which thread makes them. Previously, the session was cached with a thread-specific key (`threading.get_ident()`), so other threads/greenlets would create their own sessions, defeating the purpose of providing a shared session.

## Changes

- **`HTTPSessionManager`**: Added `explicit_session` parameter. When set, `cache_and_return_session()` returns it directly, bypassing the thread-based cache.
- **`HTTPProvider`**: Pass the user's `session` to the manager constructor instead of caching it post-construction.
- **Tests**: Added regression tests verifying session sharing across threads.

## Impact

This is critical for applications using:
- **gevent** with Celery workers (common in production)
- **Threading** for concurrent requests

Without this fix, a setup with 5000 greenlets could create up to 5000 separate `requests.Session` instances, each with its own connection pool, leading to thousands of unclosed RPC connections.

## Test Plan

- [x] Added `test_user_provided_session_shared_across_threads` - verifies explicit session is used by all threads
- [x] Added `test_no_explicit_session_creates_per_thread_sessions` - verifies default behavior unchanged