### PR TITLE
Fix TypedDict field names to use camelCase for JSON-RPC consistency

### DIFF
--- a/newsfragments/3801.bugfix.rst
+++ b/newsfragments/3801.bugfix.rst
@@ -1,0 +1,1 @@
+Fix TypedDict field names to use camelCase (``validatorIndex``, ``yParity``) matching JSON-RPC conventions and formatter outputs.

--- a/web3/types.py
+++ b/web3/types.py
@@ -152,7 +152,7 @@ class SetCodeAuthorizationParams(TypedDict):
     chainId: int
     address: Address | ChecksumAddress | str
     nonce: Nonce
-    y_parity: int
+    yParity: int
     r: int
     s: int
 
@@ -189,7 +189,7 @@ TxParams = TypedDict(
 
 class WithdrawalData(TypedDict):
     index: int
-    validator_index: int
+    validatorIndex: int
     address: ChecksumAddress
     amount: Gwei
 


### PR DESCRIPTION
What was wrong?

  Two TypedDict definitions in web3/types.py used snake_case field names:

  - WithdrawalData.validator_index
  - SetCodeAuthorizationParams.y_parity

  However, the formatters in method_formatters.py return camelCase (validatorIndex, yParity), which is the JSON-RPC convention used throughout web3.py.

  This mismatch caused incorrect type hints for users relying on these types for IDE autocompletion.

  How was it fixed?

  Updated field names to match the actual formatter output:

  - WithdrawalData.validator_index -> validatorIndex
  - SetCodeAuthorizationParams.y_parity -> yParity

  Verification:
  - Confirmed WITHDRAWAL_RESULT_FORMATTERS uses validatorIndex
  - Confirmed AUTH_LIST_REQUEST_FORMATTER uses yParity
  - No breaking changes - aligns types with actual behavior

  Todo:

  - Clean up commit history
  - Add or update documentation related to these changes
  - Add entry to the https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md

  Cute Animal Picture

  https://upload.wikimedia.org/wikipedia/commons/thumb/4/43/07._Camel_Profile%2C_near_Silverton%2C_NSW%2C_07.07.2007.jpg/1280px-07._Camel_Profile%2C_near_Silverton%2C_NSW%2C_07.07.2007.jpg