### PR TITLE
Fix mypy CI checks

### DIFF
--- a/newsfragments/3803.bugfix.rst
+++ b/newsfragments/3803.bugfix.rst
@@ -1,0 +1,1 @@
+Exclude type checking in Sphinx module and submodules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,10 @@ warn_return_any = false
 warn_unused_configs = true
 warn_unused_ignores = true
 
+[[tool.mypy.overrides]]
+module = "sphinx.*"
+follow_imports = "skip"
+
 [tool.pydocstyle]
 # All error codes found here:
 # http://www.pydocstyle.org/en/3.0.0/error_codes.html


### PR DESCRIPTION
### What was wrong?
mypy was type checking Sphinx and it's submodules. It was failing in Python 3.12+ because it was using a newer version of Sphinx (9.1.0) that used new `type` syntax, and our mypy was targeting Python 3.10. 


### How was it fixed?
Added an override to pyproject.toml telling mypy to skip type checking for Sphinx and its submodules. 


### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://i5.walmartimages.com/asr/4e038b26-0e05-4283-842f-fee908ca18e0.515e07ddc5c19f7764dd2f7caf657d6c.jpeg?odnHeight=768&odnWidth=768&odnBg=FFFFFF)
