### PR TITLE
Fix Windows compatibility in test_package.py script

### DIFF
--- a/scripts/release/test_package.py
+++ b/scripts/release/test_package.py
@@ -21,9 +21,7 @@ def create_venv(parent_path: Path) -> Path:
     venv_path = parent_path / "package-smoke-test"
     venv.create(venv_path, with_pip=True)
     pip_exe = get_pip_exe(venv_path)
-    subprocess.run(
-        [pip_exe, "install", "-U", "pip", "setuptools"], check=True
-    )
+    subprocess.run([pip_exe, "install", "-U", "pip", "setuptools"], check=True)
     return venv_path
 
 
@@ -41,10 +39,7 @@ def find_wheel(project_path: Path) -> Path:
 
 def install_wheel(venv_path: Path, wheel_path: Path) -> None:
     pip_exe = get_pip_exe(venv_path)
-    subprocess.run(
-        [pip_exe, "install", f"{wheel_path}"],
-        check=True,
-    )
+    subprocess.run([pip_exe, "install", f"{wheel_path}"], check=True)
 
 
 def test_install_local_wheel() -> None:

--- a/scripts/release/test_package.py
+++ b/scripts/release/test_package.py
@@ -2,17 +2,27 @@ from pathlib import (
     Path,
 )
 import subprocess
+import sys
 from tempfile import (
     TemporaryDirectory,
 )
 import venv
 
 
+def get_pip_exe(venv_path: Path) -> Path:
+    """Get the path to pip executable for the given virtual environment."""
+    if sys.platform == "win32":
+        return venv_path / "Scripts" / "pip.exe"
+    else:
+        return venv_path / "bin" / "pip"
+
+
 def create_venv(parent_path: Path) -> Path:
     venv_path = parent_path / "package-smoke-test"
     venv.create(venv_path, with_pip=True)
+    pip_exe = get_pip_exe(venv_path)
     subprocess.run(
-        [venv_path / "bin" / "pip", "install", "-U", "pip", "setuptools"], check=True
+        [pip_exe, "install", "-U", "pip", "setuptools"], check=True
     )
     return venv_path
 
@@ -21,7 +31,7 @@ def find_wheel(project_path: Path) -> Path:
     wheels = list(project_path.glob("dist/*.whl"))
 
     if len(wheels) != 1:
-        raise Exception(
+        raise ValueError(
             f"Expected one wheel. Instead found: {wheels} "
             f"in project {project_path.absolute()}"
         )
@@ -30,8 +40,9 @@ def find_wheel(project_path: Path) -> Path:
 
 
 def install_wheel(venv_path: Path, wheel_path: Path) -> None:
+    pip_exe = get_pip_exe(venv_path)
     subprocess.run(
-        [venv_path / "bin" / "pip", "install", f"{wheel_path}"],
+        [pip_exe, "install", f"{wheel_path}"],
         check=True,
     )
 
@@ -42,7 +53,10 @@ def test_install_local_wheel() -> None:
         wheel_path = find_wheel(Path("."))
         install_wheel(venv_path, wheel_path)
         print("Installed", wheel_path.absolute(), "to", venv_path)
-        print(f"Activate with `source {venv_path}/bin/activate`")
+        if sys.platform == "win32":
+            print(f"Activate with `{venv_path}\\Scripts\\activate`")
+        else:
+            print(f"Activate with `source {venv_path}/bin/activate`")
         input("Press enter when the test has completed. The directory will be deleted.")
 
 


### PR DESCRIPTION
### What was wrong?

The `test_package.py` script had hardcoded Unix-style paths (`bin/pip`) that would fail on Windows systems. Additionally, the activation command message only showed Unix instructions, making it confusing for Windows users. The code also had duplication of the pip path logic between `create_venv()` and `install_wheel()` functions, and used a generic `Exception` type instead of a more specific exception.

Related to Issue # (leave blank if none)

Closes # (leave blank if none)

### How was it fixed?

- Introduced a `get_pip_exe()` helper function to centralize platform-specific pip executable path detection (Windows: `Scripts/pip.exe`, Unix: `bin/pip`)
- Updated both `create_venv()` and `install_wheel()` to use the new helper function, eliminating code duplication
- Added platform-specific activation command instructions (Windows: `Scripts\activate`, Unix: `source bin/activate`)
- Changed generic `Exception` to `ValueError` for better error handling when multiple or no wheels are found

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes (N/A - internal test script)
- [x] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md) (N/A - internal test script change)

#### Cute Animal Picture

![Cute Python](https://images.unsplash.com/photo-1559827260-dc66d52bef19?w=400)