### PR TITLE
Add aiohttp_evicted_sessions to HTTPSessionManager

### DIFF
--- a/tests/core/utilities/test_http_session_manager.py
+++ b/tests/core/utilities/test_http_session_manager.py
@@ -455,12 +455,14 @@ async def test_async_session_manager_cache_does_not_close_session_before_call(
     # last session remains in cache, all others evicted
     cache_data = http_session_manager.session_cache._data
     assert len(cache_data) == 1
+    assert len(http_session_manager.aiohttp_evicted_sessions) == 1
     _key, cached_session = cache_data.popitem()
     assert cached_session == all_sessions[-1]
 
     # assert all evicted sessions were closed
     await asyncio.sleep(_timeout_for_testing + 0.1)
     assert all(session.closed for session in all_sessions[:-1])
+    assert len(http_session_manager.aiohttp_evicted_sessions) == 0
 
     # -- teardown -- #
 

--- a/web3/_utils/http_session_manager.py
+++ b/web3/_utils/http_session_manager.py
@@ -51,6 +51,7 @@ class HTTPSessionManager:
         self.session_cache = SimpleCache(cache_size)
         self.session_pool = ThreadPoolExecutor(max_workers=session_pool_max_workers)
         self._explicit_session = explicit_session
+        self.aiohttp_evicted_sessions = set()
 
     @staticmethod
     def get_default_http_endpoint() -> URI:
@@ -252,6 +253,7 @@ class HTTPSessionManager:
             # just stored in the `evicted_sessions` dict. So we can kick off a future
             # task to close them and it should be safe to pop out of the lock here.
             evicted_sessions = list(evicted_items.values())
+            self.aiohttp_evicted_sessions.update(evicted_sessions)
             for evicted_session in evicted_sessions:
                 self.logger.debug(
                     "Async session cache full. Session evicted from cache: %s",
@@ -329,6 +331,7 @@ class HTTPSessionManager:
 
         for evicted_session in evicted_sessions:
             await evicted_session.close()
+            self.aiohttp_evicted_sessions.remove(evicted_session)
             self.logger.debug("Closed evicted async session: %s", evicted_session)
 
         if any(not evicted_session.closed for evicted_session in evicted_sessions):

--- a/web3/_utils/http_session_manager.py
+++ b/web3/_utils/http_session_manager.py
@@ -51,7 +51,7 @@ class HTTPSessionManager:
         self.session_cache = SimpleCache(cache_size)
         self.session_pool = ThreadPoolExecutor(max_workers=session_pool_max_workers)
         self._explicit_session = explicit_session
-        self.aiohttp_evicted_sessions = set()
+        self.aiohttp_evicted_sessions: set[ClientSession] = set()
 
     @staticmethod
     def get_default_http_endpoint() -> URI:


### PR DESCRIPTION
### What was wrong?
Still receive `Unclosed client session` messages 

```
Received interrupt signal 2, exiting...
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7fb6d9a86a20>
```
Disconnect is already implemented.
```
class ExtendedAsyncBeacon(AsyncBeacon):
    async def disconnect(self) -> None:
        """
        Close aiohttp sessions for provider.
        Got `Unclosed client session` otherwise.
        https://github.com/ethereum/web3.py/issues/3524
        """
        cache = self._request_session_manager.session_cache
        for _, session in cache.items():
            await session.close()
        cache.clear()
```
Related to Issue #
https://github.com/ethereum/web3.py/issues/3524
Closes #

### How was it fixed?
The issue is with **evicted sessions** — they cannot be force-closed from client code. They remain open for the duration of the request_timeout.

Added aiohttp_evicted_sessions to HTTPSessionManager to track currently open evicted sessions.

Disconnect should now look like this:
```
async def disconnect(self) -> None:
    """
    Close aiohttp sessions for provider.
    Got `Unclosed client session` otherwise.
    https://github.com/ethereum/web3.py/issues/3524
    """
    cache = self._request_session_manager.session_cache
    for _, session in cache.items():
        await session.close()
    evicted_sessions = self._request_session_manager.aiohttp_evicted_sessions
    for session in evicted_sessions:
        await session.close()
    cache.clear()
``` 
### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://upload.wikimedia.org/wikipedia/commons/thumb/a/a1/Emppumenossa.jpg/330px-Emppumenossa.jpg)
