### PR TITLE
docs: add Moccasin to frameworks and tooling

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -65,6 +65,7 @@ Frameworks and Tooling
 
 - `Ape <https://www.apeworx.io/>`__ - The Ethereum development framework for Python Developers, Data Scientists, and Security Professionals
 - `Titanoboa <https://github.com/vyperlang/titanoboa>`__ - A Vyper interpreter and testing framework
+- `Moccasin <https://github.com/Cyfrin/moccasin>`__ - A fast, Pythonic smart contract development and testing framework built by Cyfrin
 - `Wake <https://github.com/Ackee-Blockchain/wake>`__ - A Python-based development and testing framework for Solidity
 - `Brownie <https://github.com/eth-brownie/brownie>`__ - [No longer actively maintained] A Python-based development and testing framework for smart contracts targeting EVM
 


### PR DESCRIPTION
The documentation doesn't currently mention Cyfrin Moccasin as a Python-based smart contract development and testing framework. Moccasin is a modern Pythonic framework that integrates well with web3.py for developers who prefer Python tooling.

How was it fixed?
Added Moccasin to frameworks and tooling with a brief description and link to the documentation.

