### PR TITLE
fix: change r and s types from HexBytes to int in SetCodeAuthoriz…

### DIFF
--- a/web3/types.py
+++ b/web3/types.py
@@ -111,8 +111,8 @@ class SetCodeAuthorizationData(TypedDict):
     address: ChecksumAddress
     nonce: Nonce
     yParity: int
-    r: HexBytes
-    s: HexBytes
+    r: int
+    s: int
 
 
 # syntax b/c "from" keyword not allowed w/ class construction


### PR DESCRIPTION
Fixes #3716

r and s fields in SetCodeAuthorizationData were incorrectly typed as HexBytes. Changed to int as per the EIP-7702 specification.

### What was wrong?
r and s signature fields were typed as HexBytes instead of int.

### How was it fixed?
Changed both r and s field types from HexBytes to int in SetCodeAuthorizationData TypedDict.