### PR TITLE
Add async/sync parity tests for get_block hash + invalid-identifier paths

### DIFF
--- a/newsfragments/3835.internal.rst
+++ b/newsfragments/3835.internal.rst
@@ -1,0 +1,9 @@
+Add async/sync parity tests for the previously-uncovered ``get_block``
+edge cases called out in #3835:
+
+- ``get_block(<hash>, full_transactions=True)`` is now exercised in both
+  ``AsyncEthModuleTest`` and ``EthModuleTest``. Only the number-keyed
+  variant was previously covered.
+- ``get_block(<unknown_identifier>)`` is now asserted to raise
+  ``Web3ValueError`` in both suites. The matching coverage previously
+  existed only for ``get_raw_transaction_by_block``.

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -1143,6 +1143,37 @@ class AsyncEthModuleTest:
         assert transaction["hash"] == async_block_with_txn["transactions"][0]
 
     @pytest.mark.asyncio
+    async def test_eth_get_block_by_hash_full_transactions(
+        self, async_w3: "AsyncWeb3[Any]", async_block_with_txn: BlockData
+    ) -> None:
+        # Mirror of test_eth_get_block_by_number_full_transactions but keyed
+        # by block hash. The sync suite covered the number-keyed path but
+        # neither suite previously exercised the hash-keyed variant with
+        # full_transactions=True.
+        block = await async_w3.eth.get_block(async_block_with_txn["hash"], True)
+        transaction = cast(TxData, block["transactions"][0])
+        assert transaction["hash"] == async_block_with_txn["transactions"][0]
+
+    @pytest.mark.asyncio
+    async def test_eth_get_block_invalid_identifier_raises_error(
+        self, async_w3: "AsyncWeb3[Any]"
+    ) -> None:
+        # The sync `get_raw_transaction_by_block` path had this coverage but
+        # the more commonly used `get_block` itself did not, in either suite.
+        # A typo'd block tag should fail loudly with Web3ValueError rather
+        # than silently round-tripping to the RPC.
+        unknown_identifier = "unknown"
+        with pytest.raises(
+            Web3ValueError,
+            match=(
+                "Value did not match any of the recognized block identifiers: "
+                f"{unknown_identifier}"
+            ),
+        ):
+            # type ignored because we are testing an invalid block identifier
+            await async_w3.eth.get_block(unknown_identifier)  # type: ignore
+
+    @pytest.mark.asyncio
     async def test_eth_get_raw_transaction(
         self, async_w3: "AsyncWeb3[Any]", mined_txn_hash: HexStr
     ) -> None:
@@ -4581,6 +4612,31 @@ class EthModuleTest:
         block = w3.eth.get_block(block_with_txn["number"], True)
         transaction = cast(TxData, block["transactions"][0])
         assert transaction["hash"] == block_with_txn["transactions"][0]
+
+    def test_eth_getBlockByHash_full_transactions(
+        self, w3: "Web3", block_with_txn: BlockData
+    ) -> None:
+        # Mirror of test_eth_getBlockByNumber_full_transactions keyed by
+        # block hash; previously only the number-keyed path was exercised
+        # with full_transactions=True.
+        block = w3.eth.get_block(block_with_txn["hash"], True)
+        transaction = cast(TxData, block["transactions"][0])
+        assert transaction["hash"] == block_with_txn["transactions"][0]
+
+    def test_eth_getBlock_invalid_identifier_raises_error(self, w3: "Web3") -> None:
+        # get_raw_transaction_by_block had this coverage but get_block itself
+        # did not. A typo'd block tag should fail with Web3ValueError rather
+        # than silently round-tripping to the RPC.
+        unknown_identifier = "unknown"
+        with pytest.raises(
+            Web3ValueError,
+            match=(
+                "Value did not match any of the recognized block identifiers: "
+                f"{unknown_identifier}"
+            ),
+        ):
+            # type ignored because we are testing an invalid block identifier
+            w3.eth.get_block(unknown_identifier)  # type: ignore
 
     def test_eth_getBlockReceipts_hash(
         self, w3: "Web3", empty_block: BlockData


### PR DESCRIPTION
## What was wrong?

Closes #3835.

While auditing the eth module test suite I confirmed two real gaps that the issue called out, and one item that turned out to already be covered:

1. ✅ \`get_block(<hash>, full_transactions=True)\` — **not exercised** in either \`AsyncEthModuleTest\` or \`EthModuleTest\`. Only the number-keyed variant \`get_block(<number>, full_transactions=True)\` had coverage.

2. ✅ \`get_block(<unknown_identifier>)\` — **not asserted** to raise \`Web3ValueError\` in either suite. The matching coverage previously existed only for \`get_raw_transaction_by_block\`, so a regression in block-identifier validation on the more common \`get_block\` path could land silently.

3. ➖ \`eth_getBlockByNumber\` with the \`\"pending\"\` block tag — already covered by \`test_eth_getBlockByNumber_pending\` in both suites (line 1071 async, line 4549 sync), so I left it alone.

## How was it fixed?

Pure test additions, no production code changes. Uses the existing \`async_block_with_txn\` / \`block_with_txn\` fixtures and the existing \`Web3ValueError\` import.

New tests:

- async \`test_eth_get_block_by_hash_full_transactions\`
- async \`test_eth_get_block_invalid_identifier_raises_error\`
- sync  \`test_eth_getBlockByHash_full_transactions\`
- sync  \`test_eth_getBlock_invalid_identifier_raises_error\`

## News fragment

\`newsfragments/3835.internal.rst\` added (classified as \`internal\` since this is test-only).

## Checklist

- [x] Added or updated unit tests — that's the entire PR
- [x] Added an entry to \`newsfragments/\` describing the change