### PR TITLE
refactor: emit compact JSON for outgoing JSON-RPC payloads

### DIFF
--- a/newsfragments/3496.performance.rst
+++ b/newsfragments/3496.performance.rst
@@ -1,5 +1,0 @@
-``FriendlyJsonSerde.json_encode`` now emits compact JSON
-(``separators=(",", ":")``). JSON-RPC payloads are no longer padded with
-``", "``/``": "`` between entries, shaving roughly two bytes per dict/list
-member off every outgoing request. Large payloads (``eth_getLogs``, batched
-calls) see a meaningful reduction in bandwidth and log volume.

--- a/newsfragments/3496.performance.rst
+++ b/newsfragments/3496.performance.rst
@@ -1,0 +1,5 @@
+``FriendlyJsonSerde.json_encode`` now emits compact JSON
+(``separators=(",", ":")``). JSON-RPC payloads are no longer padded with
+``", "``/``": "`` between entries, shaving roughly two bytes per dict/list
+member off every outgoing request. Large payloads (``eth_getLogs``, batched
+calls) see a meaningful reduction in bandwidth and log volume.

--- a/web3/_utils/encoding.py
+++ b/web3/_utils/encoding.py
@@ -206,7 +206,13 @@ class FriendlyJsonSerde:
         self, obj: dict[Any, Any], cls: type[json.JSONEncoder] | None = None
     ) -> str:
         try:
-            encoded = json.dumps(obj, cls=cls)
+            # Use the most compact separators. The JSON-RPC spec is
+            # whitespace-agnostic, every RPC request/response we serialize is
+            # consumed by another machine, and the default ", "/": " padding
+            # adds ~2 bytes per dict/list entry across very large payloads
+            # (e.g. eth_getLogs, batched calls). Saves bandwidth and log
+            # volume without changing semantics.
+            encoded = json.dumps(obj, cls=cls, separators=(",", ":"))
             return encoded
         except TypeError as full_exception:
             if hasattr(obj, "items"):


### PR DESCRIPTION
## Summary

\`FriendlyJsonSerde.json_encode\` left \`json.dumps\` at its default separators, which pad every entry with \`\", \"\` and \`\": \"\`. Every payload web3.py sends is consumed by another machine, so the spacing is pure overhead.

Pass \`separators=(\",\", \":\")\` to drop ~2 bytes per dict/list entry. This adds up across large payloads (\`eth_getLogs\` results, batched JSON-RPC requests, verbose websocket logs) without changing semantics.

Closes #3496 (compact-encoding portion of the issue; other suggestions there can be addressed in follow-up PRs).

## Test plan

- [x] Existing \`test_friendly_json_encode_with_web3_json_encoder\` and \`test_encode_rpc_request\` already compare via \`literal_eval\`, so spacing changes do not regress them.
- [x] Local \`python -c\` round-trip confirms compact output is still valid JSON-RPC.