### PR TITLE
fix(ens): remove abi_ens_resolver v8 backwards-compat NameNotFound catch

### DIFF
--- a/newsfragments/3580.breaking.rst
+++ b/newsfragments/3580.breaking.rst
@@ -1,1 +1,0 @@
-``abi_ens_resolver`` now lets ``NameNotFound`` propagate when an ENS name fails to resolve, instead of catching it and re-raising as ``InvalidAddress`` for non-``StaticENS`` resolvers. This aligns the sync resolver with the existing async behavior. Callers that previously caught ``InvalidAddress`` on ENS lookup failures must catch ``NameNotFound`` instead.

--- a/newsfragments/3580.breaking.rst
+++ b/newsfragments/3580.breaking.rst
@@ -1,0 +1,1 @@
+``abi_ens_resolver`` now lets ``NameNotFound`` propagate when an ENS name fails to resolve, instead of catching it and re-raising as ``InvalidAddress`` for non-``StaticENS`` resolvers. This aligns the sync resolver with the existing async behavior. Callers that previously caught ``InvalidAddress`` on ENS lookup failures must catch ``NameNotFound`` instead.

--- a/tests/core/middleware/test_name_to_address_middleware.py
+++ b/tests/core/middleware/test_name_to_address_middleware.py
@@ -7,7 +7,6 @@ from web3 import (
     Web3,
 )
 from web3.exceptions import (
-    InvalidAddress,
     NameNotFound,
 )
 from web3.middleware import (
@@ -95,7 +94,7 @@ def test_pass_name_resolver_send_transaction_dict_args(
 
 
 def test_fail_name_resolver(w3):
-    with pytest.raises(InvalidAddress, match=r".*ethereum\.eth.*"):
+    with pytest.raises(NameNotFound, match=r".*ethereum\.eth.*"):
         w3.eth.get_balance("ethereum.eth")
 
 

--- a/web3/_utils/normalizers.py
+++ b/web3/_utils/normalizers.py
@@ -46,7 +46,6 @@ from web3._utils.encoding import (
     text_if_str,
 )
 from web3._utils.ens import (
-    StaticENS,
     async_validate_name_has_address,
     is_ens_name,
     validate_name_has_address,
@@ -57,7 +56,6 @@ from web3._utils.validation import (
 )
 from web3.exceptions import (
     InvalidAddress,
-    NameNotFound,
     Web3ValueError,
 )
 
@@ -219,16 +217,7 @@ def abi_ens_resolver(
             raise InvalidAddress(
                 f"Could not look up name {val!r} because ENS is set to None"
             )
-        else:
-            try:
-                return type_str, validate_name_has_address(_ens, val)
-            except NameNotFound as e:
-                # TODO: This try/except is to keep backwards compatibility when we
-                #  removed the mainnet requirement. Remove this in web3.py v8 and allow
-                #  NameNotFound to raise.
-                if not isinstance(_ens, StaticENS):
-                    raise InvalidAddress(f"{e}")
-                raise e
+        return type_str, validate_name_has_address(_ens, val)
     else:
         return type_str, val
 


### PR DESCRIPTION
## What

Closes #3580.

`web3/_utils/normalizers.py:227` had a TODO flagging the `try/except NameNotFound` block for removal in v8:

```python
try:
    return type_str, validate_name_has_address(_ens, val)
except NameNotFound as e:
    # TODO: This try/except is to keep backwards compatibility when we
    #  removed the mainnet requirement. Remove this in web3.py v8 and allow
    #  NameNotFound to raise.
    if not isinstance(_ens, StaticENS):
        raise InvalidAddress(f"{e}")
    raise e
```

v8 has shipped (`8.0.0-beta.3`), so the backward-compat wrap can go.

## Changes

- `web3/_utils/normalizers.py`: drop the `try/except` and let `NameNotFound` propagate from `validate_name_has_address` directly. The sync resolver now matches `async_abi_ens_resolver` (line 282-304), which already has no such guard — closing a sync/async inconsistency the TODO already implied.
- `web3/_utils/normalizers.py`: remove the now-unused `StaticENS` and `NameNotFound` imports.
- `tests/core/middleware/test_name_to_address_middleware.py::test_fail_name_resolver`: switch the expectation from `InvalidAddress` to `NameNotFound`. The async counterpart at line 179 (`test_async_fail_name_resolver`) already expects `NameNotFound`, so this aligns the two paths.
- `newsfragments/3580.breaking.rst`: user-facing breaking-change note.

## Compat surface

The only callers exposed to the change are those that previously caught `InvalidAddress` on **ENS lookup failures specifically**. Two filtered grep sweeps to confirm no internal callers in the repo depend on the old shape:

- All other `pytest.raises(InvalidAddress)` sites in `tests/core/contracts/test_contract_call_interface.py` and `tests/core/utilities/test_validation.py` pass non-checksum hex addresses through `validate_address`, not ENS names through `abi_ens_resolver`, so they keep raising `InvalidAddress` as before.
- Async-side tests that exercise the same surface already expect `NameNotFound`.

## Tests

```
$ python -m pytest tests/core/middleware/test_name_to_address_middleware.py tests/core/contracts/test_contract_call_interface.py -q
423 passed, 7 xfailed in 22.60s

$ python -m pytest tests/core/ -q
13088 passed, 7 skipped, 9 xfailed in 237s
(one pre-existing macOS-only failure in tests/core/providers/test_auto_provider.py::test_get_dev_ipc_path
 unrelated to this change — Python's tempfile.gettempdir() resolves /tmp to /var/folders/... on macOS;
 Linux CI will not see this)
```

`pre-commit run --files web3/_utils/normalizers.py tests/core/middleware/test_name_to_address_middleware.py` — all hooks green (black, flake8, isort, pydocstyle, mypy, autoflake, pyupgrade, blocklint).