### PR TITLE
test(eth): cover accessList formatter on type 1, 2 and 4 transactions

### DIFF
--- a/newsfragments/3707.internal.rst
+++ b/newsfragments/3707.internal.rst
@@ -1,0 +1,1 @@
+Add transaction-formatter regression tests for EIP-2930 (type 1) and EIP-1559 (type 2) payloads carrying an ``accessList``, plus an EIP-7702 (type 4) payload carrying both an ``authorizationList`` and an ``accessList`` together, exercising both ``eth_sendTransaction`` and ``eth_sendRawTransaction`` paths.

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -88,6 +88,8 @@ from web3.middleware import (
 )
 from web3.types import (
     ENS,
+    AccessList,
+    AccessListEntry,
     BlockData,
     FilterParams,
     Nonce,
@@ -696,6 +698,98 @@ class AsyncEthModuleTest:
         assert txn_hash == HexBytes(signed.hash)
 
     @pytest.mark.asyncio
+    async def test_async_eth_send_raw_transaction_type_1_access_list(
+        self, async_w3: "AsyncWeb3[Any]", keyfile_account_pkey: HexStr
+    ) -> None:
+        # Locks the eth_sendRawTransaction formatter on an EIP-2930 (type 1)
+        # payload — `gasPrice` + `accessList` with no max-fee fields. Surfaces
+        # any regression in the access-list field encoding on the raw path.
+        keyfile_account = async_w3.eth.account.from_key(keyfile_account_pkey)
+        access_list = AccessList(
+            [
+                AccessListEntry(
+                    address=HexStr("0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae"),
+                    storageKeys=[
+                        HexStr(
+                            "0x0000000000000000000000000000000000000000000000"
+                            "000000000000000003"
+                        ),
+                        HexStr(
+                            "0x0000000000000000000000000000000000000000000000"
+                            "000000000000000007"
+                        ),
+                    ],
+                ),
+            ]
+        )
+        txn = {
+            "chainId": 131277322940537,
+            "from": keyfile_account.address,
+            "to": keyfile_account.address,
+            "value": Wei(0),
+            "gas": 30000,
+            "nonce": await async_w3.eth.get_transaction_count(
+                keyfile_account.address, "pending"
+            ),
+            "gasPrice": 10**9,
+            "accessList": access_list,
+        }
+        signed = keyfile_account.sign_transaction(txn)
+        txn_hash = await async_w3.eth.send_raw_transaction(signed.raw_transaction)
+        assert txn_hash == HexBytes(signed.hash)
+
+        fetched = await async_w3.eth.get_transaction(txn_hash)
+        assert fetched["type"] == 1
+        assert len(fetched["accessList"]) == 1
+        assert is_same_address(
+            fetched["accessList"][0]["address"], access_list[0]["address"]
+        )
+        assert fetched["accessList"][0]["storageKeys"] == access_list[0]["storageKeys"]
+
+    @pytest.mark.asyncio
+    async def test_async_eth_send_transaction_type_2_access_list(
+        self,
+        async_w3: "AsyncWeb3[Any]",
+        async_keyfile_account_address_dual_type: ChecksumAddress,
+    ) -> None:
+        # Locks the eth_sendTransaction formatter on an EIP-1559 (type 2)
+        # payload that carries an `accessList`. Both fields go through
+        # separate formatter branches, so the combination is worth pinning.
+        access_list = AccessList(
+            [
+                AccessListEntry(
+                    address=HexStr("0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae"),
+                    storageKeys=[
+                        HexStr(
+                            "0x0000000000000000000000000000000000000000000000"
+                            "000000000000000003"
+                        ),
+                    ],
+                ),
+            ]
+        )
+        txn_params: TxParams = {
+            "from": async_keyfile_account_address_dual_type,
+            "to": async_keyfile_account_address_dual_type,
+            "value": Wei(1),
+            "gas": 30000,
+            "maxFeePerGas": async_w3.to_wei(3, "gwei"),
+            "maxPriorityFeePerGas": async_w3.to_wei(1, "gwei"),
+            "accessList": access_list,
+        }
+
+        txn_hash = await async_w3.eth.send_transaction(txn_params)
+        txn = await async_w3.eth.get_transaction(txn_hash)
+
+        assert txn["type"] == 2
+        assert is_same_address(txn["from"], cast(ChecksumAddress, txn_params["from"]))
+        assert len(txn["accessList"]) == 1
+        assert is_same_address(
+            txn["accessList"][0]["address"], access_list[0]["address"]
+        )
+        assert txn["accessList"][0]["storageKeys"] == access_list[0]["storageKeys"]
+
+    @pytest.mark.asyncio
     async def test_async_sign_and_send_raw_middleware(
         self, async_w3: "AsyncWeb3[Any]", keyfile_account_pkey: HexStr
     ) -> None:
@@ -799,6 +893,70 @@ class AsyncEthModuleTest:
 
         reset_code = await async_w3.eth.get_code(keyfile_account.address)
         assert reset_code == HexBytes("0x")
+
+    @pytest.mark.asyncio
+    async def test_async_set_code_transaction_with_access_list(
+        self,
+        async_w3: "AsyncWeb3[Any]",
+        keyfile_account_pkey: HexStr,
+        async_math_contract: "AsyncContract",
+    ) -> None:
+        # Type-4 (EIP-7702) carries authorizationList + (optionally) accessList
+        # in the same payload. Confirm both formatters cooperate on the raw
+        # signing path so future changes to either don't silently drop a field.
+        keyfile_account = async_w3.eth.account.from_key(keyfile_account_pkey)
+
+        chain_id = await async_w3.eth.chain_id
+        nonce = await async_w3.eth.get_transaction_count(keyfile_account.address)
+
+        auth = {
+            "chainId": chain_id,
+            "address": async_math_contract.address,
+            "nonce": nonce + 1,
+        }
+        signed_auth = keyfile_account.sign_authorization(auth)
+
+        math_counter = await async_math_contract.functions.counter().call()
+        data = async_math_contract.encode_abi("incrementCounter", [math_counter + 1337])
+        access_list = AccessList(
+            [
+                AccessListEntry(
+                    address=HexStr(async_math_contract.address),
+                    storageKeys=[
+                        HexStr(
+                            "0x0000000000000000000000000000000000000000000000"
+                            "000000000000000000"
+                        ),
+                    ],
+                ),
+            ]
+        )
+        txn: TxParams = {
+            "chainId": chain_id,
+            "to": keyfile_account.address,
+            "value": Wei(0),
+            "gas": 200_000,
+            "nonce": nonce,
+            "maxPriorityFeePerGas": Wei(10**9),
+            "maxFeePerGas": Wei(10**9),
+            "data": data,
+            "authorizationList": [signed_auth],
+            "accessList": access_list,
+        }
+
+        signed = keyfile_account.sign_transaction(txn)
+        tx_hash = await async_w3.eth.send_raw_transaction(signed.raw_transaction)
+        get_tx = await async_w3.eth.get_transaction(tx_hash)
+        await async_w3.eth.wait_for_transaction_receipt(tx_hash)
+
+        # Both type-4 markers must survive the round-trip
+        assert get_tx["type"] == 4
+        assert len(get_tx["authorizationList"]) == 1
+        assert len(get_tx["accessList"]) == 1
+        assert is_same_address(
+            get_tx["accessList"][0]["address"], access_list[0]["address"]
+        )
+        assert get_tx["accessList"][0]["storageKeys"] == access_list[0]["storageKeys"]
 
     @pytest.mark.asyncio
     async def test_GasPriceStrategyMiddleware(
@@ -3849,6 +4007,92 @@ class EthModuleTest:
         txn_hash = w3.eth.send_raw_transaction(signed.raw_transaction)
         assert txn_hash == HexBytes(signed.hash)
 
+    def test_eth_send_raw_transaction_type_1_access_list(
+        self, w3: "Web3", keyfile_account_pkey: HexStr
+    ) -> None:
+        # Locks the eth_sendRawTransaction formatter on an EIP-2930 (type 1)
+        # payload — `gasPrice` + `accessList` with no max-fee fields.
+        keyfile_account = w3.eth.account.from_key(keyfile_account_pkey)
+        access_list = AccessList(
+            [
+                AccessListEntry(
+                    address=HexStr("0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae"),
+                    storageKeys=[
+                        HexStr(
+                            "0x0000000000000000000000000000000000000000000000"
+                            "000000000000000003"
+                        ),
+                        HexStr(
+                            "0x0000000000000000000000000000000000000000000000"
+                            "000000000000000007"
+                        ),
+                    ],
+                ),
+            ]
+        )
+        txn = {
+            "chainId": 131277322940537,
+            "from": keyfile_account.address,
+            "to": keyfile_account.address,
+            "value": Wei(0),
+            "gas": 30000,
+            "nonce": w3.eth.get_transaction_count(keyfile_account.address, "pending"),
+            "gasPrice": 10**9,
+            "accessList": access_list,
+        }
+        signed = keyfile_account.sign_transaction(txn)
+        txn_hash = w3.eth.send_raw_transaction(signed.raw_transaction)
+        assert txn_hash == HexBytes(signed.hash)
+
+        fetched = w3.eth.get_transaction(txn_hash)
+        assert fetched["type"] == 1
+        assert len(fetched["accessList"]) == 1
+        assert is_same_address(
+            fetched["accessList"][0]["address"], access_list[0]["address"]
+        )
+        assert fetched["accessList"][0]["storageKeys"] == access_list[0]["storageKeys"]
+
+    def test_eth_send_transaction_type_2_access_list(
+        self,
+        w3: "Web3",
+        keyfile_account_address_dual_type: ChecksumAddress,
+    ) -> None:
+        # Locks the eth_sendTransaction formatter on an EIP-1559 (type 2)
+        # payload that carries an `accessList`.
+        access_list = AccessList(
+            [
+                AccessListEntry(
+                    address=HexStr("0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae"),
+                    storageKeys=[
+                        HexStr(
+                            "0x0000000000000000000000000000000000000000000000"
+                            "000000000000000003"
+                        ),
+                    ],
+                ),
+            ]
+        )
+        txn_params: TxParams = {
+            "from": keyfile_account_address_dual_type,
+            "to": keyfile_account_address_dual_type,
+            "value": Wei(1),
+            "gas": 30000,
+            "maxFeePerGas": w3.to_wei(3, "gwei"),
+            "maxPriorityFeePerGas": w3.to_wei(1, "gwei"),
+            "accessList": access_list,
+        }
+
+        txn_hash = w3.eth.send_transaction(txn_params)
+        txn = w3.eth.get_transaction(txn_hash)
+
+        assert txn["type"] == 2
+        assert is_same_address(txn["from"], cast(ChecksumAddress, txn_params["from"]))
+        assert len(txn["accessList"]) == 1
+        assert is_same_address(
+            txn["accessList"][0]["address"], access_list[0]["address"]
+        )
+        assert txn["accessList"][0]["storageKeys"] == access_list[0]["storageKeys"]
+
     def test_sign_and_send_raw_middleware(
         self, w3: "Web3", keyfile_account_pkey: HexStr
     ) -> None:
@@ -3944,6 +4188,68 @@ class EthModuleTest:
 
         reset_code = w3.eth.get_code(keyfile_account.address)
         assert reset_code == HexBytes("0x")
+
+    def test_set_code_transaction_with_access_list(
+        self,
+        w3: "Web3",
+        keyfile_account_pkey: HexStr,
+        math_contract: "Contract",
+    ) -> None:
+        # Type-4 (EIP-7702) carries authorizationList + (optionally) accessList
+        # in the same payload. Confirm both formatters cooperate on the raw
+        # signing path so future changes to either don't silently drop a field.
+        keyfile_account = w3.eth.account.from_key(keyfile_account_pkey)
+
+        chain_id = w3.eth.chain_id
+        nonce = w3.eth.get_transaction_count(keyfile_account.address)
+
+        auth = {
+            "chainId": chain_id,
+            "address": math_contract.address,
+            "nonce": nonce + 1,
+        }
+        signed_auth = keyfile_account.sign_authorization(auth)
+
+        math_counter = math_contract.functions.counter().call()
+        data = math_contract.encode_abi("incrementCounter", [math_counter + 1337])
+        access_list = AccessList(
+            [
+                AccessListEntry(
+                    address=HexStr(math_contract.address),
+                    storageKeys=[
+                        HexStr(
+                            "0x0000000000000000000000000000000000000000000000"
+                            "000000000000000000"
+                        ),
+                    ],
+                ),
+            ]
+        )
+        txn: TxParams = {
+            "chainId": chain_id,
+            "to": keyfile_account.address,
+            "value": Wei(0),
+            "gas": 200_000,
+            "nonce": nonce,
+            "maxPriorityFeePerGas": Wei(10**9),
+            "maxFeePerGas": Wei(10**9),
+            "data": data,
+            "authorizationList": [signed_auth],
+            "accessList": access_list,
+        }
+
+        signed = keyfile_account.sign_transaction(txn)
+        tx_hash = w3.eth.send_raw_transaction(signed.raw_transaction)
+        get_tx = w3.eth.get_transaction(tx_hash)
+        w3.eth.wait_for_transaction_receipt(tx_hash)
+
+        assert get_tx["type"] == 4
+        assert len(get_tx["authorizationList"]) == 1
+        assert len(get_tx["accessList"]) == 1
+        assert is_same_address(
+            get_tx["accessList"][0]["address"], access_list[0]["address"]
+        )
+        assert get_tx["accessList"][0]["storageKeys"] == access_list[0]["storageKeys"]
 
     def test_eth_call(self, w3: "Web3", math_contract: "Contract") -> None:
         txn_params = math_contract._prepare_transaction(


### PR DESCRIPTION
## What

Closes #3707.

Issue #3707 flags that the transaction-param formatters lack direct tests for several `accessList` combinations the wire format actually allows. Add three focused cases (with async + sync mirrors) that exercise the `eth_sendTransaction` and `eth_sendRawTransaction` paths together.

| New test | Tx type | Path | Pins |
|----------|---------|------|------|
| `test_(async_)eth_send_raw_transaction_type_1_access_list` | EIP-2930 (type 1) | `eth_sendRawTransaction` | `gasPrice` + `accessList`, no max-fee fields; the round-tripped tx reports `type == 1` and preserves the access-list entries |
| `test_(async_)eth_send_transaction_type_2_access_list` | EIP-1559 (type 2) | `eth_sendTransaction` | `maxFeePerGas` + `maxPriorityFeePerGas` + `accessList` go through separate formatter branches; the combination is the regression case |
| `test_(async_)set_code_transaction_with_access_list` | EIP-7702 (type 4) | `eth_sendRawTransaction` | `authorizationList` + `accessList` survive together on the raw signing path; the existing set-code test only exercises `authorizationList` |

## Why these three

The existing coverage at `web3/_utils/module_testing/eth_module.py`:

- `test_eth_create_access_list` exercises the `eth_createAccessList` RPC and then feeds the result into `eth_sendTransaction` (type 2 by default), but doesn't drive `eth_sendRawTransaction` and doesn't lock the tx type explicitly.
- `test_(async_)sign_authorization_send_raw_and_send_set_code_transactions` exercises `authorizationList` on both raw + send paths, but never with `accessList` attached — so a regression in the type-4 formatter that drops `accessList` would not be caught.

The three additions close exactly the gaps the issue points at without changing production code.

## No production changes

Pure test additions:

- `web3/_utils/module_testing/eth_module.py` — 6 new methods (3 async, 3 sync mirrors).
- `web3/_utils/module_testing/eth_module.py` — import `AccessList` + `AccessListEntry` from `web3.types` for typed literals (satisfies `TxParams.accessList` declared as `AccessList`, and resolves a `Sequence[str]` inference issue mypy raised on the dict-literal form).
- `newsfragments/3707.internal.rst`.

## Tests

```
$ python -m pytest tests/integration/test_ethereum_tester.py::TestEthereumTesterEthModule \
       -k "access_list or set_code" -v
test_eth_send_transaction_type_2_access_list[<lambda>] PASSED
test_eth_send_transaction_type_2_access_list[identity] PASSED
test_eth_send_raw_transaction_type_1_access_list      PASSED
test_set_code_transaction_with_access_list            PASSED
test_eth_create_access_list[<lambda>]                 PASSED  (existing)
test_eth_create_access_list[identity]                 PASSED  (existing)
test_sign_authorization_send_raw_and_send_set_code_transactions PASSED  (existing)
7 passed
```

Async mirrors are not exercised against `EthereumTesterProvider` (no async tester runner exists for the eth module today — the async eth-module suite runs against the geth integration), but the implementations are direct ports of the passing sync cases with `await` added; the geth CI pipeline will exercise them.

```
$ pre-commit run --files web3/_utils/module_testing/eth_module.py
all hooks green (black, flake8, isort, pydocstyle, mypy, autoflake, pyupgrade, blocklint)
```

## Open question for the maintainers

Issue #3707 also wonders aloud about blob (type 3) transaction coverage. The current `eth-tester` backends don't appear to validate type-3 round trips end-to-end the way they do for the other types, so I've left that out of scope here. Happy to add it as a follow-up if a tester path is available, or punt to the geth integration suite.