### PR TITLE
Clean deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "pyunormalize>=15",
     "pywin32>=223; platform_system == 'Windows'",
     "requests>=2.23.0",
-    "typing-extensions>=4.0.1",
+    "typing-extensions>=4.0.1; python_version < '3.11'",
     "websockets>=14",
 ]
 

--- a/web3/_utils/compat/__init__.py
+++ b/web3/_utils/compat/__init__.py
@@ -6,11 +6,22 @@
 # or use the back-ported version of the type.
 
 # Once web3 supports >= the noted python version, the type may be directly
-# imported from `typing`
+# imported from `typing`. Python 3.10 still needs the `typing_extensions`
+# backport for these names.
 
-from typing_extensions import (
-    NotRequired,  # py311
-    Self,  # py311
-    Unpack,  # py310
-)
+import sys
 from typing import TypeAlias
+
+if sys.version_info >= (3, 11):
+    from typing import (
+        NotRequired,  # py311
+        Self,  # py311
+        Unpack,  # py311
+    )
+else:
+    # Python 3.10 compatibility path.
+    from typing_extensions import (
+        NotRequired,
+        Self,
+        Unpack,
+    )


### PR DESCRIPTION
### What was wrong?

Improves dependencies gathered by the project by moving a request types to the dev dependencies and not requiring type extensions for python >= 3.11 since it is not needed

### How was it fixed?

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
