### PR TITLE
fix: EIP-7702 auth signature fields were wrong type

### DIFF
--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -569,8 +569,8 @@ async def test_async_send_set_code_transaction(async_w3, async_math_contract):
     assert get_auth["address"].lower() == async_math_contract.address.lower()
     assert get_auth["nonce"] == nonce + 1
     assert isinstance(get_auth["yParity"], int)
-    assert isinstance(get_auth["r"], HexBytes)
-    assert isinstance(get_auth["s"], HexBytes)
+    assert isinstance(get_auth["r"], int)
+    assert isinstance(get_auth["s"], int)
 
     # reset code
     reset_auth = {

--- a/tests/core/eth-module/test_transactions.py
+++ b/tests/core/eth-module/test_transactions.py
@@ -438,8 +438,8 @@ def test_send_set_code_transaction(w3, math_contract):
     assert get_auth["address"].lower() == math_contract.address.lower()
     assert get_auth["nonce"] == nonce + 1
     assert isinstance(get_auth["yParity"], int)
-    assert isinstance(get_auth["r"], HexBytes)
-    assert isinstance(get_auth["s"], HexBytes)
+    assert isinstance(get_auth["r"], int)
+    assert isinstance(get_auth["s"], int)
 
     # reset code
     reset_auth = {

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -246,8 +246,8 @@ AUTH_LIST_RESULT_FORMATTER = apply_formatter_if(
                 "address": to_checksum_address,
                 "nonce": to_integer_if_hex,
                 "yParity": to_integer_if_hex,
-                "r": to_hexbytes(32, variable_length=True),
-                "s": to_hexbytes(32, variable_length=True),
+                "r": to_integer_if_hex,
+                "s": to_integer_if_hex,
             }
         ),
     ),

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -250,7 +250,7 @@ AUTH_LIST_RESULT_FORMATTER = apply_formatter_if(
                     "yParity": to_integer_if_hex,
                     "r": to_integer_if_hex,
                     "s": to_integer_if_hex,
-                }
+                },
             )
         ),
     ),

--- a/web3/_utils/method_formatters.py
+++ b/web3/_utils/method_formatters.py
@@ -241,14 +241,17 @@ AUTH_LIST_RESULT_FORMATTER = apply_formatter_if(
     is_not_null,
     apply_formatter_to_array(
         type_aware_apply_formatters_to_dict(
-            {
-                "chainId": to_integer_if_hex,
-                "address": to_checksum_address,
-                "nonce": to_integer_if_hex,
-                "yParity": to_integer_if_hex,
-                "r": to_integer_if_hex,
-                "s": to_integer_if_hex,
-            }
+            cast(
+                Formatters,
+                {
+                    "chainId": to_integer_if_hex,
+                    "address": to_checksum_address,
+                    "nonce": to_integer_if_hex,
+                    "yParity": to_integer_if_hex,
+                    "r": to_integer_if_hex,
+                    "s": to_integer_if_hex,
+                }
+            )
         ),
     ),
 )

--- a/web3/_utils/module_testing/eth_module.py
+++ b/web3/_utils/module_testing/eth_module.py
@@ -774,8 +774,8 @@ class AsyncEthModuleTest:
         assert get_auth["address"] == async_math_contract.address
         assert get_auth["nonce"] == nonce + 1
         assert isinstance(get_auth["yParity"], int)
-        assert isinstance(get_auth["r"], HexBytes)
-        assert isinstance(get_auth["s"], HexBytes)
+        assert isinstance(get_auth["r"], int)
+        assert isinstance(get_auth["s"], int)
 
         # reset code
         reset_auth = {
@@ -3873,8 +3873,8 @@ class EthModuleTest:
         assert get_auth["address"] == math_contract.address
         assert get_auth["nonce"] == nonce + 1
         assert isinstance(get_auth["yParity"], int)
-        assert isinstance(get_auth["r"], HexBytes)
-        assert isinstance(get_auth["s"], HexBytes)
+        assert isinstance(get_auth["r"], int)
+        assert isinstance(get_auth["s"], int)
 
         # reset code
         reset_auth = {

--- a/web3/types.py
+++ b/web3/types.py
@@ -109,8 +109,8 @@ class SetCodeAuthorizationData(TypedDict):
     address: ChecksumAddress
     nonce: Nonce
     yParity: int
-    r: HexBytes
-    s: HexBytes
+    r: int
+    s: int
 
 
 # syntax b/c "from" keyword not allowed w/ class construction


### PR DESCRIPTION
Fixes #3716.

## Problem

[EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) specifies `r` and `s` in authorization tuples as **`uint256`** (integers), not `bytes32`. The current formatter converts them to `HexBytes(32)`, which is incorrect for both the formatter and the `SetCodeAuthorizationData` TypedDict.

## Changes

**`web3/_utils/method_formatters.py`**
```python
# Before
"r": to_hexbytes(32, variable_length=True),
"s": to_hexbytes(32, variable_length=True),

# After
"r": to_integer_if_hex,
"s": to_integer_if_hex,
```

**`web3/types.py`**
```python
# Before
r: HexBytes
s: HexBytes

# After
r: int
s: int
```

**`web3/_utils/module_testing/eth_module.py`**
```python
# Before
assert isinstance(get_auth["r"], HexBytes)
assert isinstance(get_auth["s"], HexBytes)

# After
assert isinstance(get_auth["r"], int)
assert isinstance(get_auth["s"], int)
```
(Same change in both sync and async test methods.)

## Testing

The existing EIP-7702 integration tests in `eth_module.py` are updated to assert `int` rather than `HexBytes`. The formatter change is covered by the existing test fixtures.
