### PR TITLE
fix: treat IPv4-mapped IPv6 as IPv4 in CCIP host checks

### DIFF
--- a/newsfragments/3875.bugfix.rst
+++ b/newsfragments/3875.bugfix.rst
@@ -1,0 +1,1 @@
+CCIP Read now treats IPv4-mapped IPv6 addresses (``::ffff:127.0.0.1``) as their IPv4 equivalents when blocking private and reserved hosts.

--- a/tests/core/utilities/test_ccip_url_validation.py
+++ b/tests/core/utilities/test_ccip_url_validation.py
@@ -82,6 +82,38 @@ class TestValidateCcipUrlHost:
         with pytest.raises(Web3ValidationError, match="blocked private/reserved"):
             validate_ccip_url_host("https://example.com/api")
 
+    @pytest.mark.parametrize(
+        "mapped_ip",
+        [
+            "::ffff:127.0.0.1",
+            "::ffff:10.0.0.1",
+            "::ffff:192.168.1.1",
+            "::ffff:169.254.169.254",
+        ],
+    )
+    def test_blocked_ipv4_mapped_ipv6(self, monkeypatch, mapped_ip):
+        def _mock_getaddrinfo(host, port, *args, **kwargs):
+            return [(socket.AF_INET6, socket.SOCK_STREAM, 0, "", (mapped_ip, 0, 0, 0))]
+
+        monkeypatch.setattr("socket.getaddrinfo", _mock_getaddrinfo)
+        with pytest.raises(Web3ValidationError, match="blocked private/reserved"):
+            validate_ccip_url_host("https://example.com/api")
+
+    def test_public_ipv4_mapped_ipv6_passes(self, monkeypatch):
+        def _mock_getaddrinfo(host, port, *args, **kwargs):
+            return [
+                (
+                    socket.AF_INET6,
+                    socket.SOCK_STREAM,
+                    0,
+                    "",
+                    ("::ffff:8.8.8.8", 0, 0, 0),
+                )
+            ]
+
+        monkeypatch.setattr("socket.getaddrinfo", _mock_getaddrinfo)
+        validate_ccip_url_host("https://example.com/api")
+
     def test_unresolvable_hostname(self, monkeypatch):
         def _mock_getaddrinfo(host, port, *args, **kwargs):
             raise socket.gaierror("Name or service not known")

--- a/web3/utils/ccip_url_validation.py
+++ b/web3/utils/ccip_url_validation.py
@@ -52,9 +52,16 @@ def validate_ccip_url_scheme(url: str, allow_http: bool = False) -> None:
     )
 
 
+def _canonical_ip(ip_str: str):
+    addr = ipaddress.ip_address(ip_str)
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
+        return addr.ipv4_mapped
+    return addr
+
+
 def _check_ip_blocked(ip_str: str) -> bool:
     try:
-        addr = ipaddress.ip_address(ip_str)
+        addr = _canonical_ip(ip_str)
     except ValueError:
         return False
     return any(addr in network for network in BLOCKED_IP_NETWORKS)


### PR DESCRIPTION
## Summary
- CCIP Read (`validate_ccip_url_host`) rejects resolved addresses in RFC1918, loopback, link-local, and IPv6 ULA ranges so an OffchainLookup URL cannot send the client at private infrastructure.
- The check compared the resolved address to those networks as-is. `::ffff:127.0.0.1` (and `::ffff:10.0.0.1`, `::ffff:169.254.169.254`) is an IPv6 address, so it is not a member of the IPv4 block list and the request proceeded.
- Unwrap `IPv6Address.ipv4_mapped` before the blocklist. Public mapped addresses such as `::ffff:8.8.8.8` still pass.

Attacker: a contract that returns OffchainLookup URLs. They already choose the URL. The guard is supposed to fail closed on private/reserved IPs after DNS. Mapped IPv6 skipped that guard.

## Test plan
- [x] Added `test_blocked_ipv4_mapped_ipv6` for loopback, RFC1918, and link-local mapped forms
- [x] Added `test_public_ipv4_mapped_ipv6_passes` for `::ffff:8.8.8.8`
- [x] Revert-tested: without the unwrap, `_check_ip_blocked("::ffff:127.0.0.1")` is false
- [x] Towncrier `newsfragments/3875.bugfix.rst`
- Tip parent: `268493a`

Commit is SSH-signed.